### PR TITLE
学習辞書に追加する機能の修正（複数回タップ対応）

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,6 +4,14 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2024-12-25T22:05:40.497654Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="PhysicalDevice" identifier="serial=29171FDH300GKH" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
@@ -1191,49 +1191,6 @@ class KanaKanjiEngine {
         )
     }
 
-    suspend fun nBestPath(
-        input: String, n: Int
-    ): List<Candidate> {
-        val graph = graphBuilder.constructGraph(
-            input,
-            systemYomiTrie,
-            systemTangoTrie,
-            systemTokenArray,
-            systemRank0ArrayLBSYomi,
-            systemRank1ArrayLBSYomi,
-            systemRank1ArrayIsLeaf,
-            systemRank0ArrayTokenArrayBitvector,
-            systemRank1ArrayTokenArrayBitvector,
-            rank0ArrayLBSTango = systemRank0ArrayLBSTango,
-            rank1ArrayLBSTango = systemRank1ArrayLBSTango,
-            LBSBooleanArray = systemYomiLBSBooleanArray,
-            LBSBooleanArrayPreprocess = systemYomiLBSPreprocess,
-        )
-        val result = findPath.backwardAStar(graph, input.length, connectionIds, n)
-        result.apply {
-            if (!this.map { it.string }.contains(input)) {
-                add(
-                    Candidate(
-                        string = input,
-                        type = (3).toByte(),
-                        length = (input.length).toUByte(),
-                        score = (input.length) * 2000
-                    )
-                )
-            }
-            if (!this.map { it.string }.contains(input.hiraToKata())) {
-                add(
-                    Candidate(
-                        string = input.hiraToKata(),
-                        type = (3).toByte(),
-                        length = (input.length).toUByte(),
-                        score = (input.length) * 2000
-                    )
-                )
-            }
-        }
-        return result
-    }
 
     private fun nBestPathForLongest(
         input: String, n: Int

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -33,9 +33,9 @@ class SuggestionAdapter : RecyclerView.Adapter<SuggestionAdapter.SuggestionViewH
         }
     }
 
-    private var onItemClickListener: ((Candidate, Int) -> Unit)? = null
+    private var onItemClickListener: ((Candidate) -> Unit)? = null
 
-    fun setOnItemClickListener(onItemClick: (Candidate, Int) -> Unit) {
+    fun setOnItemClickListener(onItemClick: (Candidate) -> Unit) {
         this.onItemClickListener = onItemClick
     }
 
@@ -111,7 +111,7 @@ class SuggestionAdapter : RecyclerView.Adapter<SuggestionAdapter.SuggestionViewH
         }
         holder.itemView.isPressed = position == highlightedPosition
         holder.itemView.setOnClickListener {
-            onItemClickListener?.invoke(suggestion, position)
+            onItemClickListener?.invoke(suggestion)
         }
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
@@ -23,10 +23,10 @@ import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.KanaKanjiEngine
 import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionAdapter
 import com.kazumaproject.markdownhelperkeyboard.ime_service.models.PressedKeyStatus
-import com.kazumaproject.markdownhelperkeyboard.learning.adapter.LearnDataOutputAdapter
 import com.kazumaproject.markdownhelperkeyboard.learning.adapter.LearnDictionaryAdapter
 import com.kazumaproject.markdownhelperkeyboard.learning.database.LearnDao
 import com.kazumaproject.markdownhelperkeyboard.learning.database.LearnDatabase
+import com.kazumaproject.markdownhelperkeyboard.learning.multiple.LearnMultiple
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
 import com.kazumaproject.preprocessLBSIntoBooleanArray
 import com.kazumaproject.toBooleanArray
@@ -68,6 +68,10 @@ object AppModule {
     @Singleton
     @Provides
     fun providesLearnDictionaryAdapter(): LearnDictionaryAdapter = LearnDictionaryAdapter()
+
+    @Singleton
+    @Provides
+    fun providesLearnMultiple(): LearnMultiple = LearnMultiple()
 
     @MainDispatcher
     @Singleton
@@ -1045,6 +1049,5 @@ object AppModule {
     @Provides
     @SymbolList
     fun provideSymbolList(kanaKanjiEngine: KanaKanjiEngine) = kanaKanjiEngine.getSymbolCandidates()
-
 
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/learning/multiple/LearnMultiple.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/learning/multiple/LearnMultiple.kt
@@ -1,0 +1,46 @@
+package com.kazumaproject.markdownhelperkeyboard.learning.multiple
+
+class LearnMultiple {
+    private var isEnabled: Boolean = false
+    private var input: String? = null
+    private var stringBuilder: StringBuilder = StringBuilder()
+
+    fun enabled(): Boolean {
+        return isEnabled
+    }
+
+    fun setInput(inputFromIME: String): Boolean {
+        input = inputFromIME
+        return true
+    }
+
+    fun getInput(): String {
+        return input ?: ""
+    }
+
+    fun setWordToStringBuilder(word: String) {
+        stringBuilder.append(word)
+    }
+
+    fun getInputAndStringBuilder(): Pair<String, String> {
+        return Pair(input ?: "", stringBuilder.toString())
+    }
+
+    fun start() {
+        isEnabled = true
+    }
+
+    fun stop() {
+        clearInput()
+        clearStringBuilder()
+        isEnabled = false
+    }
+
+    private fun clearInput() {
+        input = null
+    }
+
+    private fun clearStringBuilder() {
+        stringBuilder.clear()
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/learning/multiple/LearnMultipleTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/learning/multiple/LearnMultipleTest.kt
@@ -1,0 +1,29 @@
+package com.kazumaproject.markdownhelperkeyboard.learning.multiple
+
+import org.junit.Before
+import org.junit.Test
+
+class LearnMultipleTest {
+
+    private lateinit var learnMultiple: LearnMultiple
+
+    @Before
+    fun setUp() {
+        learnMultiple = LearnMultiple()
+    }
+
+    @Test
+    fun `LearnMultiple の使用方法`() {
+        val yomi = "じろう"
+        learnMultiple.apply {
+            start()
+            setInput(yomi)
+            setWordToStringBuilder("二")
+            setWordToStringBuilder("郎")
+        }
+        println("${learnMultiple.getInputAndStringBuilder()} ${learnMultiple.enabled()}")
+        learnMultiple.stop()
+
+        println("${learnMultiple.getInputAndStringBuilder()} ${learnMultiple.enabled()}")
+    }
+}


### PR DESCRIPTION
#20 

## 概要
`Candidate` を複数回タップ、もしくは `Enter Key` が複数回押された場合、学習辞書に保存する。

i.e.)
よみ: じろう

単語：
"二" => "郎"

ユーザーは`二`をタップ、またはエンターキーで変換を確定後 `郎` をタップ、またはエンターキーで変換を確定

### 辞書には以下のように保存される。
よみ：じろう

単語： 二郎