### PR TITLE
学習辞書の Fragment に ProgressBar を設置する

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 35
-        versionCode 196
+        versionCode 197
         versionName "1.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1703,7 +1703,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
         suggestionClickNum += 1
         suggestionClickNum = suggestionClickNum.coerceAtMost(suggestions.size + 1)
         mainView.suggestionRecyclerView.apply {
-            smoothScrollToPosition((suggestionClickNum - 1).coerceAtLeast(0))
+            smoothScrollToPosition((suggestionClickNum - 1 + 2).coerceAtLeast(0).coerceAtMost(suggestions.size -1))
             suggestionAdapter.updateHighlightPosition((suggestionClickNum - 1).coerceAtLeast(0))
         }
         setConvertLetterInJapaneseFromButton(suggestions, true, mainView, insertString)

--- a/app/src/main/res/layout/fragment_learn_dictionary.xml
+++ b/app/src/main/res/layout/fragment_learn_dictionary.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_marginBottom="?attr/actionBarSize"
@@ -27,6 +26,17 @@
         android:layout_height="match_parent"
         android:paddingTop="80dp"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintTop_toBottomOf="parent"/>
+        app:layout_constraintTop_toBottomOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/progress_bar_learn_dictionary_fragment"
+        android:indeterminateTint="@color/enter_key_bg"
+        android:layout_width="128dp"
+        android:layout_height="128dp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
#23 
#24 

LearnDictionary Fragment 内に ProgressBar を置いて学習辞書のデータを削除する際に表示する

変換候補を見やすくする。
Candidate RecyclerView を変換ボタンがタップして次の変換候補をハイライトする際に RecyclerView をスクロールする。
