### PR TITLE
フリックのみモードのサポート

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -23,6 +23,7 @@ object AppPreference {
     private val KEYBOARD_HEIGHT = Pair("keyboard_height_preference", 280)
     private val KEYBOARD_WIDTH = Pair("keyboard_width_preference", 100)
     private val KEYBOARD_POSITION = Pair("keyboard_position_preference", true)
+    private val FLICK_INPUT_ONLY = Pair("flick_input_only_preference", false)
 
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -129,5 +130,11 @@ object AppPreference {
         get() = preferences.getBoolean(KEYBOARD_POSITION.first, KEYBOARD_POSITION.second)
         set(value) = preferences.edit {
             it.putBoolean(KEYBOARD_POSITION.first, value ?: true)
+        }
+
+    var flick_input_only_preference: Boolean?
+        get() = preferences.getBoolean(FLICK_INPUT_ONLY.first, FLICK_INPUT_ONLY.second)
+        set(value) = preferences.edit {
+            it.putBoolean(FLICK_INPUT_ONLY.first, value ?: false)
         }
 }

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -7,6 +7,12 @@
             android:key="keyboard_screen_preference"
             android:summary="キーボードのサイズの設定を変更できます"
             android:title="サイズの設定" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="flick_input_only_preference"
+            android:summary="フリック入力のみを使用し、ケータイ打ちを無効にする"
+            android:title="フリックのみ" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="操作">


### PR DESCRIPTION
フリックのみのモードを有効にする新しい設定を導入しました。
このモードが有効な場合、ユーザーは"あ"を2回押下すると、"ああ"と入力することが可能になります。
