### PR TITLE
署名付きの APK を GitHub Actions で作成する

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -61,7 +61,7 @@ jobs:
             touch local.properties
           fi
           echo "# --- SigningConfig for CI ---" >> local.properties
-          echo "KEYSTORE_FILE=my-release-key.jks"     >> local.properties
+          echo "KEYSTORE_FILE=../my-release-key.jks"     >> local.properties
           echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> local.properties
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}"   >> local.properties
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> local.properties

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -67,12 +67,6 @@ jobs:
       - name: Build Signed Release APK
         run: ./gradlew clean assembleRelease
 
-      # 追加：ファイル名をリリース名に合わせて変更する
-      - name: Rename APK for Release
-        run: |
-          mv app/build/outputs/apk/release/app-release-unsigned.apk \
-             app/build/outputs/apk/release/app-release.apk
-
       # ↓（あらためて）どのファイルがあるか確認しておく
       - name: List APK directory
         run: ls -R app/build/outputs/apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,70 +1,70 @@
 name: Android Release CI
 
+# 例: v1.0.0 のタグを push したときに実行
 on:
   push:
     tags:
-      - 'v*' # Triggers only on version tags like v1.0.0, v2.1.3, etc.
+      - 'v*'
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        api-level: [24]
-        target: [android-35]
-        build-tools: [35.0.0]
-
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
+      # 1. ソースコードをチェックアウト
+      - name: Checkout code
+        uses: actions/checkout@v3
 
-    - name: Set up JDK 17
-      uses: actions/setup-java@v3
-      with:
-        java-version: '17'
-        distribution: 'temurin'
+      # 2. JDK 17 をセットアップ（Android Studio バンドル JDK が不要な場合）
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
 
-    - name: Download Android SDK
-      uses: android-actions/setup-android@v2
-      with:
-        api-level: ${{ matrix.api-level }}
-        target: ${{ matrix.target }}
-        build-tools: ${{ matrix.build-tools }}
+      # 3. Android SDK をセットアップ
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v2
+        with:
+          api-level: 35
+          build-tools: '35.0.0'
+          target: 'android-35'
 
-    - name: Cache Gradle
-      uses: actions/cache@v4
-      with:
-        path: |
-          ~/.gradle/caches
-          ~/.gradle/wrapper
-        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-        restore-keys: |
-          ${{ runner.os }}-gradle-
+      # 4. Gradle キャッシュ
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-    - name: Build Debug APK
-      run: ./gradlew assembleDebug
+      # 5. JKS を Secrets から復号してファイルに保存
+      - name: Decode JKS from Base64
+        run: |
+          echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > my-release-key.jks
+        # my-release-key.jks はワークスペース直下に作成される（必要に応じてパスは変えてください）。
 
-    - name: Create Release
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }} # Use the tag name
-        release_name: Release ${{ github.ref }}
-        draft: false
-        prerelease: false
-        body: |
-          This release includes:
-          - The latest APK build for Android.
+      # 6. gradle.properties を更新して、署名情報を設定
+      #    （既存の gradle.properties に末尾追記するイメージ）
+      - name: Add signing info to gradle.properties
+        run: |
+          echo "" >> gradle.properties
+          echo "# --- SigningConfig for CI ---" >> gradle.properties
+          echo "KEYSTORE_FILE=my-release-key.jks" >> gradle.properties
+          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> gradle.properties
+          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> gradle.properties
+          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> gradle.properties
 
-    - name: Upload APK to Release
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: app/build/outputs/apk/debug/app-debug.apk
-        asset_name: app-debug.apk
-        asset_content_type: application/vnd.android.package-archive
+      # 7. 署名付きリリースAPK をビルド
+      - name: Build Signed Release APK
+        run: ./gradlew clean assembleRelease
+
+      # 8. (オプション) 作成された APK をアーティファクトとしてアップロードする
+      - name: Upload APK as Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: release-apk
+          path: app/build/outputs/apk/release/app-release.apk

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -53,24 +53,22 @@ jobs:
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > my-release-key.jks
 
-      # 6. gradle.properties に署名情報を追記
-      - name: Add signing info to gradle.properties
+      # 6. local.properties に署名情報を追記
+      - name: Add signing info to local.properties
         run: |
-          echo "" >> gradle.properties
-          echo "# --- SigningConfig for CI ---" >> gradle.properties
-          echo "KEYSTORE_FILE=my-release-key.jks" >> gradle.properties
-          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> gradle.properties
-          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> gradle.properties
-          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> gradle.properties
+          # local.properties が存在しなければ新規作成
+          if [ ! -f local.properties ]; then
+            touch local.properties
+          fi
+          echo "# --- SigningConfig for CI ---" >> local.properties
+          echo "KEYSTORE_FILE=my-release-key.jks"     >> local.properties
+          echo "KEYSTORE_PASSWORD=${{ secrets.KEYSTORE_PASSWORD }}" >> local.properties
+          echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}"   >> local.properties
+          echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> local.properties
 
       # 7. リリース APK をビルド
       - name: Build Signed Release APK
-        run: |
-          ./gradlew clean assembleRelease \
-            -Pandroid.injected.signing.store.file=app/my-release-key.jks \
-            -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} \
-            -Pandroid.injected.signing.key.alias=${{ secrets.KEY_ALIAS }} \
-            -Pandroid.injected.signing.key.password=${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew clean assembleRelease
 
       # ↓（あらためて）どのファイルがあるか確認しておく
       - name: List APK directory

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -65,7 +65,12 @@ jobs:
 
       # 7. リリース APK をビルド
       - name: Build Signed Release APK
-        run: ./gradlew clean assembleRelease
+        run: |
+          ./gradlew clean assembleRelease \
+            -Pandroid.injected.signing.store.file=app/my-release-key.jks \
+            -Pandroid.injected.signing.store.password=${{ secrets.KEYSTORE_PASSWORD }} \
+            -Pandroid.injected.signing.key.alias=${{ secrets.KEY_ALIAS }} \
+            -Pandroid.injected.signing.key.password=${{ secrets.KEY_PASSWORD }}
 
       # ↓（あらためて）どのファイルがあるか確認しておく
       - name: List APK directory

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,34 +1,41 @@
 name: Android Release CI
 
-# 例: v1.0.0 のタグを push したときに実行
 on:
   push:
     tags:
-      - 'v*'
+      - 'v*'  # v1.0.0 のようにタグをプッシュしたときに実行
 
 jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        # 必要に応じて matrix を使って複数 API Level / ビルドツールを並列に回せますが、
+        # 今回は単一のセットで大丈夫なら省略しても OK です。
+        api-level: [ 35 ]
+        build-tools: [ '35.0.0' ]
+        target: [ 'android-35' ]
+
     steps:
-      # 1. ソースコードをチェックアウト
+      # 1. コードチェックアウト
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # 2. JDK 17 をセットアップ（Android Studio バンドル JDK が不要な場合）
+      # 2. JDK 17 セットアップ
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # 3. Android SDK をセットアップ
+      # 3. Android SDK セットアップ
       - name: Set up Android SDK
         uses: android-actions/setup-android@v2
         with:
-          api-level: 35
-          build-tools: '35.0.0'
-          target: 'android-35'
+          api-level: ${{ matrix.api-level }}
+          build-tools: ${{ matrix.build-tools }}
+          target: ${{ matrix.target }}
 
       # 4. Gradle キャッシュ
       - name: Cache Gradle
@@ -41,14 +48,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 5. JKS を Secrets から復号してファイルに保存
+      # 5. JKS を Secrets から復号して my-release-key.jks に出力
       - name: Decode JKS from Base64
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > my-release-key.jks
-        # my-release-key.jks はワークスペース直下に作成される（必要に応じてパスは変えてください）。
 
-      # 6. gradle.properties を更新して、署名情報を設定
-      #    （既存の gradle.properties に末尾追記するイメージ）
+      # 6. gradle.properties に署名情報を追記
       - name: Add signing info to gradle.properties
         run: |
           echo "" >> gradle.properties
@@ -58,13 +63,33 @@ jobs:
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> gradle.properties
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> gradle.properties
 
-      # 7. 署名付きリリースAPK をビルド
+      # 7. リリース APK をビルド（assembleRelease）
       - name: Build Signed Release APK
         run: ./gradlew clean assembleRelease
 
-      # 8. (オプション) 作成された APK をアーティファクトとしてアップロードする
-      - name: Upload APK as Artifact
-        uses: actions/upload-artifact@v3
+      # 8. GitHub リリースを作成（または取得）する
+      - name: Create GitHub Release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          name: release-apk
-          path: app/build/outputs/apk/release/app-release.apk
+          # github.ref が "refs/tags/v1.0.0" のように入るので、tag_name にそのまま渡す
+          tag_name: ${{ github.ref }}
+          release_name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          body: |
+            • このリリースには署名済みのAPKが含まれます。
+            • バージョン: ${{ github.ref_name }}
+      # ──────────────────────────────────────────────────────────────────────────────
+      # 9. 上記で作成したリリースに APK をアップロードする
+      - name: Upload APK to Release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: app/build/outputs/apk/release/app-release.apk
+          asset_name: app-release.apk
+          asset_content_type: application/vnd.android.package-archive

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -63,18 +63,27 @@ jobs:
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}" >> gradle.properties
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> gradle.properties
 
-      # 7. リリース APK をビルド（assembleRelease）
+      # 7. リリース APK をビルド
       - name: Build Signed Release APK
         run: ./gradlew clean assembleRelease
 
-      # 8. GitHub リリースを作成（または取得）する
+      # 追加：ファイル名をリリース名に合わせて変更する
+      - name: Rename APK for Release
+        run: |
+          mv app/build/outputs/apk/release/app-release-unsigned.apk \
+             app/build/outputs/apk/release/app-release.apk
+
+      # ↓（あらためて）どのファイルがあるか確認しておく
+      - name: List APK directory
+        run: ls -R app/build/outputs/apk
+
+      # 8. リリース作成
       - name: Create GitHub Release
         id: create_release
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # github.ref が "refs/tags/v1.0.0" のように入るので、tag_name にそのまま渡す
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref_name }}
           draft: false
@@ -82,8 +91,8 @@ jobs:
           body: |
             • このリリースには署名済みのAPKが含まれます。
             • バージョン: ${{ github.ref_name }}
-      # ──────────────────────────────────────────────────────────────────────────────
-      # 9. 上記で作成したリリースに APK をアップロードする
+
+      # 9. リネーム後のファイルをアップロード
       - name: Upload APK to Release
         uses: actions/upload-release-asset@v1
         env:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -41,6 +41,7 @@ android {
 
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -9,6 +9,21 @@ android {
     namespace 'com.kazumaproject.markdownhelperkeyboard'
     compileSdk 36
 
+    def localProperties = new Properties()
+    def localPropertiesFile = rootProject.file("local.properties")
+    if (localPropertiesFile.exists()) {
+        localProperties.load(new FileInputStream(localPropertiesFile))
+    }
+
+    signingConfigs {
+        release {
+            storeFile file(localProperties['KEYSTORE_FILE'])
+            storePassword localProperties['KEYSTORE_PASSWORD']
+            keyAlias localProperties['KEY_ALIAS']
+            keyPassword localProperties['KEY_PASSWORD']
+        }
+    }
+
     defaultConfig {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,20 +23,9 @@ android {
         }
     }
 
-    signingConfigs {
-        release {
-            storeFile file(KEYSTORE_FILE)
-            storePassword KEYSTORE_PASSWORD
-            keyAlias KEY_ALIAS
-            keyPassword KEY_PASSWORD
-            v1SigningEnabled true
-            v2SigningEnabled true
-        }
-    }
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,20 @@ android {
         }
     }
 
+    signingConfigs {
+        release {
+            storeFile file(KEYSTORE_FILE)
+            storePassword KEYSTORE_PASSWORD
+            keyAlias KEY_ALIAS
+            keyPassword KEY_PASSWORD
+            v1SigningEnabled true
+            v2SigningEnabled true
+        }
+    }
+
     buildTypes {
         release {
+            signingConfig signingConfigs.release
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'

--- a/core/src/main/java/com/kazumaproject/core/domain/extensions/AppCompatButton.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/extensions/AppCompatButton.kt
@@ -10,9 +10,9 @@ import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatImageButton
 import com.kazumaproject.core.ui.appcompatbutton.CustomLineHeightSpan
 
-const val KEY_JAPANESE_SIZE = 17f
-const val KEY_ENGLISH_SIZE = 14f
-const val KEY_NUMBER_SIZE = 18f
+const val KEY_JAPANESE_SIZE = 16f
+const val KEY_ENGLISH_SIZE = 12f
+const val KEY_NUMBER_SIZE = 16f
 
 const val KEY_TABLET_SIZE = 18f
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,3 +23,7 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
+KEYSTORE_FILE=dammy
+KEYSTORE_PASSWORD=dammy
+KEY_ALIAS=dammy
+KEY_PASSWORD=dammy

--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,3 @@ kotlin.code.style=official
 android.nonTransitiveRClass=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonFinalResIds=false
-KEYSTORE_FILE=dammy
-KEYSTORE_PASSWORD=dammy
-KEY_ALIAS=dammy
-KEY_PASSWORD=dammy


### PR DESCRIPTION
## Issue
#53 

## 概要
GitHub Actions の CI で `app-debug.apk` を配布していたので署名付きの `app-release.apk` に修正する