### PR TITLE
全角の濁点付きの小文字を削除した時のバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 356
+        versionCode 357
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -2916,7 +2916,17 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                         val beforeChar = getLastCharacterAsString(currentInputConnection)
                         if (beforeChar.isNotEmpty()) {
                             deletedBuffer.append(beforeChar)
-                            if (beforeChar == "ゥ゙") {
+                            if (
+                                beforeChar == "ァ゙" ||
+                                beforeChar == "ィ゙" ||
+                                beforeChar == "ゥ゙" ||
+                                beforeChar == "ェ゙" ||
+                                beforeChar == "ォ゙" ||
+                                beforeChar == "ッ゙" ||
+                                beforeChar == "ャ゙" ||
+                                beforeChar == "ュ゙" ||
+                                beforeChar == "ョ゙"
+                            ) {
                                 deleteSurroundingTextInCodePoints(2, 0)
                                 continue
                             }
@@ -3073,7 +3083,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                             setUndoPreviewText(deletedBuffer.toString())
                         }
                         Timber.d("beforeChar: $beforeChar")
-                        if (beforeChar == "ゥ゙") {
+                        if (beforeChar == "ァ゙" ||
+                            beforeChar == "ィ゙" ||
+                            beforeChar == "ゥ゙" ||
+                            beforeChar == "ェ゙" ||
+                            beforeChar == "ォ゙" ||
+                            beforeChar == "ッ゙" ||
+                            beforeChar == "ャ゙" ||
+                            beforeChar == "ュ゙" ||
+                            beforeChar == "ョ゙"
+                        ) {
                             deleteSurroundingTextInCodePoints(2, 0)
                             return
                         }


### PR DESCRIPTION
## 概要
ァ゙",ィ゙",ゥ゙",ェ゙",ォ゙",ッ゙",ャ゙",ュ゙",ョ゙"

上記の文字を元に戻そうとすると " が一文字として認識されるバグの修正