### PR TITLE
スミレ入力キーボード β の修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 373
+        versionCode 374
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1497,8 +1497,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     KeyAction.ShowEmojiKeyboard -> {}
                     KeyAction.Space -> {}
                     KeyAction.SwitchToNextIme -> {}
-                    KeyAction.ToggleCase -> {}
-                    KeyAction.ToggleDakuten -> {}
+                    KeyAction.ToggleCase -> {
+                        dakutenSmallActionForSumire(mainView)
+                    }
+
+                    KeyAction.ToggleDakuten -> {
+                        dakutenSmallActionForSumire(mainView)
+                    }
                 }
             }
 
@@ -1666,30 +1671,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     KeyAction.SelectLeft -> {}
                     KeyAction.SelectRight -> {}
                     KeyAction.ShowEmojiKeyboard -> {}
-                    KeyAction.ToggleCase -> {}
+                    KeyAction.ToggleCase -> {
+                        dakutenSmallActionForSumire(mainView)
+                    }
+
                     KeyAction.ToggleDakuten -> {
-                        val insertString = inputString.value
-                        mainLayoutBinding?.let { mainView ->
-                            mainView.keyboardView.let {
-                                Timber.d("onAction: $action ${it.currentInputMode.value}")
-                                val sb = StringBuilder()
-                                when (it.currentInputMode.value) {
-                                    InputMode.ModeJapanese -> {
-                                        dakutenSmallLetter(
-                                            sb, insertString, GestureType.Tap
-                                        )
-                                    }
-
-                                    InputMode.ModeEnglish -> {
-                                        smallBigLetterConversionEnglish(sb, insertString)
-                                    }
-
-                                    InputMode.ModeNumber -> {
-
-                                    }
-                                }
-                            }
-                        }
+                        dakutenSmallActionForSumire(mainView)
                     }
                 }
             }
@@ -1703,6 +1690,46 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
             clearDeletedBufferWithoutResetLayout()
             suggestionAdapter?.setUndoEnabled(false)
             setClipboardText()
+        }
+    }
+
+    private fun dakutenSmallActionForSumire(mainView: MainLayoutBinding) {
+        val insertString = inputString.value
+        val sb = StringBuilder()
+        mainView.keyboardView.let {
+            when (it.currentInputMode.value) {
+                InputMode.ModeJapanese -> {
+                    dakutenSmallLetter(
+                        sb, insertString, GestureType.Tap
+                    )
+                }
+
+                InputMode.ModeEnglish -> {
+                    smallConversionEnglish(sb, insertString)
+                }
+
+                InputMode.ModeNumber -> {
+
+                }
+            }
+        }
+    }
+
+    private fun smallConversionEnglish(
+        sb: StringBuilder, insertString: String,
+    ) {
+        _dakutenPressed.value = true
+        englishSpaceKeyPressed.set(false)
+
+        if (insertString.isNotEmpty()) {
+            val insertPosition = insertString.last()
+            insertPosition.let { c ->
+                if (!c.isHiragana()) {
+                    c.getDakutenSmallChar()?.let { dakutenChar ->
+                        setStringBuilderForConvertStringInHiragana(dakutenChar, sb, insertString)
+                    }
+                }
+            }
         }
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1310,7 +1310,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                 }
             }
 
-            // ▼▼▼ 変更 ▼▼▼ onSpecialKey と onSpecialKeyLongPress は onAction と onActionLongPress になります
             override fun onActionLongPress(action: KeyAction) {
                 // 特殊キーが長押しされた場合
                 // 例: Deleteの長押しで文章を大きく削除する、などの実装が可能
@@ -1485,7 +1484,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     }
 
                     KeyAction.NewLine -> {}
-                    KeyAction.Paste -> {}
+                    KeyAction.Paste -> {
+                        pasteAction()
+                    }
+
                     KeyAction.SelectAll -> {
                         selectAllText()
                     }
@@ -1654,7 +1656,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     }
 
                     KeyAction.Paste -> {
-
+                        pasteAction()
                     }
 
                     KeyAction.SelectAll -> {
@@ -1692,6 +1694,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                 }
             }
         })
+    }
+
+    private fun pasteAction() {
+        val allClipboardText = clipboardUtil.getFirstClipboardTextOrNull() ?: ""
+        if (allClipboardText.isNotEmpty()) {
+            commitText(allClipboardText, 1)
+            clearDeletedBufferWithoutResetLayout()
+            suggestionAdapter?.setUndoEnabled(false)
+            setClipboardText()
+        }
     }
 
     private var currentKeyboardOrder = 0
@@ -2434,9 +2446,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     position = position
                 )
             }
-            adapter.setOnItemLongClickListener { candidate, _ ->
-                /** Candidate Long Click **/
-            }
             adapter.setOnItemHelperIconClickListener { helperIcon ->
                 when (helperIcon) {
                     SuggestionAdapter.HelperIcon.UNDO -> {
@@ -2461,13 +2470,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     }
 
                     SuggestionAdapter.HelperIcon.PASTE -> {
-                        val allClipboardText = clipboardUtil.getFirstClipboardTextOrNull() ?: ""
-                        if (allClipboardText.isNotEmpty()) {
-                            commitText(allClipboardText, 1)
-                            clearDeletedBufferWithoutResetLayout()
-                            suggestionAdapter?.setUndoEnabled(false)
-                            setClipboardText()
-                        }
+                        pasteAction()
                     }
                 }
             }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1959,7 +1959,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     if (mainView.customLayoutDefault.isVisible) {
                         setSumireKeyboardDakutenKey()
                         setSumireKeyboardEnterKey(1)
-                        setSumireKeyboardSpaceKey(1)
+                        when (mainView.keyboardView.currentInputMode.value) {
+                            InputMode.ModeJapanese -> {
+                                setSumireKeyboardSpaceKey(1)
+                            }
+
+                            else -> {}
+                        }
                     }
                 }
                 when (currentFlag) {

--- a/core/consumer-rules.pro
+++ b/core/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.kazumaproject.core.** { *; }
+-keep interface com.kazumaproject.core.** { *; }

--- a/custom_keyboard/consumer-rules.pro
+++ b/custom_keyboard/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.kazumaproject.custom_keyboard.** { *; }
+-keep interface com.kazumaproject.custom_keyboard.** { *; }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
@@ -81,7 +81,10 @@ enum class KeyType {
     CIRCULAR_FLICK,
 
     /** 十字フリックキー */
-    CROSS_FLICK
+    CROSS_FLICK,
+
+    /** 動的タップとフリックを両立するハイブリッドキー */
+    DYNAMIC_FLICK
 }
 
 

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
@@ -82,9 +82,6 @@ enum class KeyType {
 
     /** 十字フリックキー */
     CROSS_FLICK,
-
-    /** 動的タップとフリックを両立するハイブリッドキー */
-    DYNAMIC_FLICK
 }
 
 

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -54,14 +54,9 @@ object KeyboardDefaultLayouts {
         )
     )
 
-    // ▼▼▼ Define states for the Space/Convert key ▼▼▼
+    // ▼▼▼ NEW: Define states for the Space/Convert key ▼▼▼
     private val spaceConvertStates = listOf(
         FlickAction.Action(KeyAction.Space, "空白"), FlickAction.Action(KeyAction.Convert, "変換")
-    )
-
-    private val spaceFlickOnlyMap = mapOf(
-        FlickDirection.UP_LEFT to FlickAction.Action(KeyAction.Space),
-        // TAP is NOT defined here, because it will be handled dynamically
     )
 
     /**
@@ -163,17 +158,17 @@ object KeyboardDefaultLayouts {
                 drawableResId = com.kazumaproject.core.R.drawable.backspace_24px,
                 isSpecialKey = true
             ),
+            // ▼▼▼ MODIFIED: Space key is now dynamic ▼▼▼
             KeyData(
                 label = spaceConvertStates[0].label ?: "",
                 row = 1,
                 column = 4,
-                isFlickable = true,
+                isFlickable = false,
                 action = spaceConvertStates[0].action,
                 rowSpan = 1,
                 isSpecialKey = true,
                 keyId = "space_convert_key",
-                dynamicStates = spaceConvertStates,
-                keyType = KeyType.DYNAMIC_FLICK
+                dynamicStates = spaceConvertStates
             ),
             KeyData(
                 label = enterKeyStates[0].label ?: "",
@@ -362,7 +357,6 @@ object KeyboardDefaultLayouts {
         val wa_small = mapOf(
             FlickDirection.TAP to FlickAction.Input("ゎ"),
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("ゎ"),
-            FlickDirection.UP_LEFT to FlickAction.Input("-"),
             FlickDirection.UP_RIGHT to FlickAction.Input("~"),
             FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〜"),
             FlickDirection.DOWN to FlickAction.Input("大")
@@ -391,7 +385,6 @@ object KeyboardDefaultLayouts {
         val flickMaps: Map<String, List<Map<FlickDirection, FlickAction>>> = mapOf(
             "PasteActionKey" to listOf(pasteActionMap),
             "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "space_convert_key" to listOf(spaceFlickOnlyMap),
             "あ" to listOf(a, small_a),
             "か" to listOf(ka, ga),
             "さ" to listOf(sa, za),
@@ -460,8 +453,7 @@ object KeyboardDefaultLayouts {
             KeyData("PQRS", 2, 1, true),
             KeyData("TUV", 2, 2, true),
             KeyData("WXYZ", 2, 3, true),
-            // a/AキーはflickMapsを持たないアクションキー
-            KeyData("a/A", 3, 1, false, action = KeyAction.ToggleDakuten),
+            KeyData("a/A", 3, 1, false, action = KeyAction.ToggleCase),
             KeyData("' \" ( )", 3, 2, true),
             KeyData(". , ? !", 3, 3, true),
             KeyData(
@@ -478,13 +470,12 @@ object KeyboardDefaultLayouts {
                 label = spaceConvertStates[0].label ?: "",
                 row = 1,
                 column = 4,
-                isFlickable = true,
+                isFlickable = false,
                 action = spaceConvertStates[0].action,
                 rowSpan = 1,
                 isSpecialKey = true,
                 keyId = "space_convert_key",
-                dynamicStates = spaceConvertStates,
-                keyType = KeyType.DYNAMIC_FLICK
+                dynamicStates = spaceConvertStates
             ),
             KeyData(
                 label = enterKeyStates[0].label ?: "",
@@ -714,7 +705,6 @@ object KeyboardDefaultLayouts {
         val flickMaps: Map<String, List<Map<FlickDirection, FlickAction>>> = mapOf(
             "PasteActionKey" to listOf(pasteActionMap),
             "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "space_convert_key" to listOf(spaceFlickOnlyMap),
             "@#/_" to listOf(symbols1, basicMathOperators, advancedMathSymbols),
             "' \" ( )" to listOf(symbols2, programmingSymbols),
             ". , ? !" to listOf(symbols3),
@@ -805,13 +795,12 @@ object KeyboardDefaultLayouts {
                 label = spaceConvertStates[0].label ?: "",
                 row = 1,
                 column = 4,
-                isFlickable = true,
+                isFlickable = false,
                 action = spaceConvertStates[0].action,
                 rowSpan = 1,
                 isSpecialKey = true,
                 keyId = "space_convert_key",
-                dynamicStates = spaceConvertStates,
-                keyType = KeyType.DYNAMIC_FLICK
+                dynamicStates = spaceConvertStates
             ),
             KeyData(
                 label = enterKeyStates[0].label ?: "",
@@ -856,7 +845,7 @@ object KeyboardDefaultLayouts {
             // Added for consistency
             "PasteActionKey" to listOf(pasteActionMap),
             "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "space_convert_key" to listOf(spaceFlickOnlyMap),
+
             "1" to listOf(
                 mapOf(
                     FlickDirection.TAP to FlickAction.Input("1"),

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -54,9 +54,14 @@ object KeyboardDefaultLayouts {
         )
     )
 
-    // ▼▼▼ NEW: Define states for the Space/Convert key ▼▼▼
+    // ▼▼▼ Define states for the Space/Convert key ▼▼▼
     private val spaceConvertStates = listOf(
         FlickAction.Action(KeyAction.Space, "空白"), FlickAction.Action(KeyAction.Convert, "変換")
+    )
+
+    private val spaceFlickOnlyMap = mapOf(
+        FlickDirection.UP_LEFT to FlickAction.Action(KeyAction.Space),
+        // TAP is NOT defined here, because it will be handled dynamically
     )
 
     /**
@@ -158,17 +163,17 @@ object KeyboardDefaultLayouts {
                 drawableResId = com.kazumaproject.core.R.drawable.backspace_24px,
                 isSpecialKey = true
             ),
-            // ▼▼▼ MODIFIED: Space key is now dynamic ▼▼▼
             KeyData(
                 label = spaceConvertStates[0].label ?: "",
                 row = 1,
                 column = 4,
-                isFlickable = false,
+                isFlickable = true,
                 action = spaceConvertStates[0].action,
                 rowSpan = 1,
                 isSpecialKey = true,
                 keyId = "space_convert_key",
-                dynamicStates = spaceConvertStates
+                dynamicStates = spaceConvertStates,
+                keyType = KeyType.DYNAMIC_FLICK
             ),
             KeyData(
                 label = enterKeyStates[0].label ?: "",
@@ -386,6 +391,7 @@ object KeyboardDefaultLayouts {
         val flickMaps: Map<String, List<Map<FlickDirection, FlickAction>>> = mapOf(
             "PasteActionKey" to listOf(pasteActionMap),
             "CursorMoveLeft" to listOf(cursorMoveActionMap),
+            "space_convert_key" to listOf(spaceFlickOnlyMap),
             "あ" to listOf(a, small_a),
             "か" to listOf(ka, ga),
             "さ" to listOf(sa, za),
@@ -472,12 +478,13 @@ object KeyboardDefaultLayouts {
                 label = spaceConvertStates[0].label ?: "",
                 row = 1,
                 column = 4,
-                isFlickable = false,
+                isFlickable = true,
                 action = spaceConvertStates[0].action,
                 rowSpan = 1,
                 isSpecialKey = true,
                 keyId = "space_convert_key",
-                dynamicStates = spaceConvertStates
+                dynamicStates = spaceConvertStates,
+                keyType = KeyType.DYNAMIC_FLICK
             ),
             KeyData(
                 label = enterKeyStates[0].label ?: "",
@@ -707,6 +714,7 @@ object KeyboardDefaultLayouts {
         val flickMaps: Map<String, List<Map<FlickDirection, FlickAction>>> = mapOf(
             "PasteActionKey" to listOf(pasteActionMap),
             "CursorMoveLeft" to listOf(cursorMoveActionMap),
+            "space_convert_key" to listOf(spaceFlickOnlyMap),
             "@#/_" to listOf(symbols1, basicMathOperators, advancedMathSymbols),
             "' \" ( )" to listOf(symbols2, programmingSymbols),
             ". , ? !" to listOf(symbols3),
@@ -797,12 +805,13 @@ object KeyboardDefaultLayouts {
                 label = spaceConvertStates[0].label ?: "",
                 row = 1,
                 column = 4,
-                isFlickable = false,
+                isFlickable = true,
                 action = spaceConvertStates[0].action,
                 rowSpan = 1,
                 isSpecialKey = true,
                 keyId = "space_convert_key",
-                dynamicStates = spaceConvertStates
+                dynamicStates = spaceConvertStates,
+                keyType = KeyType.DYNAMIC_FLICK
             ),
             KeyData(
                 label = enterKeyStates[0].label ?: "",
@@ -847,7 +856,7 @@ object KeyboardDefaultLayouts {
             // Added for consistency
             "PasteActionKey" to listOf(pasteActionMap),
             "CursorMoveLeft" to listOf(cursorMoveActionMap),
-
+            "space_convert_key" to listOf(spaceFlickOnlyMap),
             "1" to listOf(
                 mapOf(
                     FlickDirection.TAP to FlickAction.Input("1"),

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -351,15 +351,15 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT to FlickAction.Input("を"),
             FlickDirection.UP to FlickAction.Input("ん"),
             FlickDirection.UP_RIGHT to FlickAction.Input("ー"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〜"),
             FlickDirection.DOWN to FlickAction.Input("小")
         )
 
         val wa_small = mapOf(
             FlickDirection.TAP to FlickAction.Input("ゎ"),
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("ゎ"),
-            FlickDirection.UP to FlickAction.Input("-"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("~"),
+            FlickDirection.UP_LEFT to FlickAction.Input("-"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("~"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〜"),
             FlickDirection.DOWN to FlickAction.Input("大")
 
         )
@@ -369,7 +369,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT to FlickAction.Input("。"),
             FlickDirection.UP to FlickAction.Input("？"),
             FlickDirection.UP_RIGHT to FlickAction.Input("！"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("…"),
             FlickDirection.DOWN to FlickAction.Input("")
         )
 
@@ -523,6 +523,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("a"),
             FlickDirection.UP_LEFT to FlickAction.Input("b"),
             FlickDirection.UP to FlickAction.Input("c"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("2"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val defLower = mapOf(
@@ -530,6 +531,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("d"),
             FlickDirection.UP_LEFT to FlickAction.Input("e"),
             FlickDirection.UP to FlickAction.Input("f"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("3"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val ghiLower = mapOf(
@@ -537,6 +539,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("g"),
             FlickDirection.UP_LEFT to FlickAction.Input("h"),
             FlickDirection.UP to FlickAction.Input("i"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("4"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val jklLower = mapOf(
@@ -544,6 +547,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("j"),
             FlickDirection.UP_LEFT to FlickAction.Input("k"),
             FlickDirection.UP to FlickAction.Input("l"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("5"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val mnoLower = mapOf(
@@ -551,6 +555,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("m"),
             FlickDirection.UP_LEFT to FlickAction.Input("n"),
             FlickDirection.UP to FlickAction.Input("o"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("6"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val pqrsLower = mapOf(
@@ -559,6 +564,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT to FlickAction.Input("q"),
             FlickDirection.UP to FlickAction.Input("r"),
             FlickDirection.UP_RIGHT to FlickAction.Input("s"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("7"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val tuvLower = mapOf(
@@ -566,6 +572,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT_FAR to FlickAction.Input("t"),
             FlickDirection.UP_LEFT to FlickAction.Input("u"),
             FlickDirection.UP to FlickAction.Input("v"),
+            FlickDirection.UP_RIGHT to FlickAction.Input("8"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
         val wxyzLower = mapOf(
@@ -574,6 +581,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT to FlickAction.Input("x"),
             FlickDirection.UP to FlickAction.Input("y"),
             FlickDirection.UP_RIGHT to FlickAction.Input("z"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("9"),
             FlickDirection.DOWN to FlickAction.Input("a/A")
         )
 
@@ -644,6 +652,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT to FlickAction.Input("#"),
             FlickDirection.UP to FlickAction.Input("/"),
             FlickDirection.UP_RIGHT to FlickAction.Input("_"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("1"),
             FlickDirection.DOWN to FlickAction.Input("")
         )
         val symbols2 = mapOf(
@@ -652,6 +661,7 @@ object KeyboardDefaultLayouts {
             FlickDirection.UP_LEFT to FlickAction.Input("\""),
             FlickDirection.UP to FlickAction.Input("("),
             FlickDirection.UP_RIGHT to FlickAction.Input(")"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("0"),
             FlickDirection.DOWN to FlickAction.Input("")
         )
         val symbols3 = mapOf(

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -2,6 +2,7 @@ package com.kazumaproject.custom_keyboard.view
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.PointF
 import android.util.AttributeSet
 import android.util.TypedValue
 import android.view.MotionEvent
@@ -21,15 +22,17 @@ import com.kazumaproject.custom_keyboard.data.FlickPopupColorTheme
 import com.kazumaproject.custom_keyboard.data.KeyAction
 import com.kazumaproject.custom_keyboard.data.KeyType
 import com.kazumaproject.custom_keyboard.data.KeyboardLayout
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlin.math.atan2
+import kotlin.math.sqrt
 
 class FlickKeyboardView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0
 ) : GridLayout(context, attrs, defStyleAttr) {
 
-    /**
-     * ▼▼▼ 修正 ▼▼▼
-     * 十字フリックのロングプレス後の指離しイベントを処理するメソッドを追加
-     */
     interface OnKeyboardActionListener {
         fun onKey(text: String)
         fun onAction(action: KeyAction)
@@ -39,27 +42,31 @@ class FlickKeyboardView @JvmOverloads constructor(
         fun onFlickActionLongPress(action: KeyAction)
         fun onFlickActionUpAfterLongPress(action: KeyAction)
     }
-    // ▲▲▲ 修正 ▲▲▲
 
     private var listener: OnKeyboardActionListener? = null
     private val flickControllers = mutableListOf<FlickInputController>()
     private val crossFlickControllers = mutableListOf<CrossFlickInputController>()
 
+    // ▼▼▼ 新設 ▼▼▼ ハイブリッドキーのCoroutinesスコープ
+    private val hybridKeyScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+
     fun setOnKeyboardActionListener(listener: OnKeyboardActionListener) {
         this.listener = listener
     }
 
-    @SuppressLint("ClickableViewAccessibility")
+    @SuppressLint("ClickableViewAccessibility", "Recycle")
     fun setKeyboard(layout: KeyboardLayout) {
         this.removeAllViews()
         flickControllers.forEach { it.cancel() }
         flickControllers.clear()
         crossFlickControllers.forEach { it.cancel() }
         crossFlickControllers.clear()
+        // ▼▼▼ 新設 ▼▼▼ スコープをキャンセル
+        hybridKeyScope.coroutineContext[Job]?.cancel()
+
 
         this.columnCount = layout.columnCount
         this.rowCount = layout.rowCount
-
         this.isFocusable = false
 
         layout.keys.forEach { keyData ->
@@ -98,6 +105,7 @@ class FlickKeyboardView @JvmOverloads constructor(
             }
             keyView.layoutParams = params
 
+            // ▼▼▼ 修正 ▼▼▼ キーのタイプに応じてイベントハンドラを割り振る
             when (keyData.keyType) {
                 KeyType.CIRCULAR_FLICK -> {
                     val flickKeyMapsList = layout.flickKeyMaps[keyData.label]
@@ -129,7 +137,8 @@ class FlickKeyboardView @JvmOverloads constructor(
                             setPopupColors(dynamicColorTheme)
                             this.listener = object : FlickInputController.FlickListener {
                                 override fun onStateChanged(
-                                    view: View, newMap: Map<FlickDirection, String>
+                                    view: View,
+                                    newMap: Map<FlickDirection, String>
                                 ) {
                                 }
 
@@ -168,13 +177,11 @@ class FlickKeyboardView @JvmOverloads constructor(
                 }
 
                 KeyType.CROSS_FLICK -> {
-                    val flickActionMap = layout.flickKeyMaps[keyData.label]?.firstOrNull()
+                    // ▼▼▼ 修正 ▼▼▼ keyIdを優先してflickMapを検索する
+                    val mapKey = keyData.keyId ?: keyData.label
+                    val flickActionMap = layout.flickKeyMaps[mapKey]?.firstOrNull()
                     if (flickActionMap != null) {
                         val controller = CrossFlickInputController(context).apply {
-                            /**
-                             * ▼▼▼ 修正 ▼▼▼
-                             * 新しい onFlickUpAfterLongPress メソッドを実装
-                             */
                             this.listener = object : CrossFlickInputController.CrossFlickListener {
                                 override fun onFlick(flickAction: FlickAction) {
                                     when (flickAction) {
@@ -189,37 +196,88 @@ class FlickKeyboardView @JvmOverloads constructor(
                                 }
 
                                 override fun onFlickLongPress(flickAction: FlickAction) {
-                                    when (flickAction) {
-                                        is FlickAction.Action -> {
-                                            this@FlickKeyboardView.listener?.onFlickActionLongPress(
-                                                flickAction.action
-                                            )
-                                        }
-
-                                        is FlickAction.Input -> {
-                                            // 必要であれば、文字入力のロングプレスに対する処理をここに記述
-                                        }
+                                    if (flickAction is FlickAction.Action) {
+                                        this@FlickKeyboardView.listener?.onFlickActionLongPress(
+                                            flickAction.action
+                                        )
                                     }
                                 }
 
                                 override fun onFlickUpAfterLongPress(flickAction: FlickAction) {
-                                    when (flickAction) {
-                                        is FlickAction.Action -> {
-                                            this@FlickKeyboardView.listener?.onFlickActionUpAfterLongPress(
-                                                flickAction.action
-                                            )
-                                        }
-
-                                        is FlickAction.Input -> {
-                                            // 必要であれば、文字入力のロングプレス後の指離しに対する処理をここに記述
-                                        }
+                                    if (flickAction is FlickAction.Action) {
+                                        this@FlickKeyboardView.listener?.onFlickActionUpAfterLongPress(
+                                            flickAction.action
+                                        )
                                     }
                                 }
                             }
-                            // ▲▲▲ 修正 ▲▲▲
                             attach(keyView, flickActionMap)
                         }
                         crossFlickControllers.add(controller)
+                    }
+                }
+
+                // ▼▼▼ 新設 ▼▼▼ DYNAMIC_FLICKキーの処理
+                KeyType.DYNAMIC_FLICK -> {
+                    val mapKey = keyData.keyId ?: keyData.label
+                    val flickMap = layout.flickKeyMaps[mapKey]?.firstOrNull() ?: emptyMap()
+
+                    var isFlick = false
+                    val initialTouchPoint = PointF(0f, 0f)
+                    val flickThreshold = 80f
+
+                    keyView.setOnTouchListener { _, event ->
+                        when (event.action) {
+                            MotionEvent.ACTION_DOWN -> {
+                                isFlick = false
+                                initialTouchPoint.set(event.rawX, event.rawY)
+                                // ここでポップアップ表示を開始しても良い
+                                true
+                            }
+
+                            MotionEvent.ACTION_MOVE -> {
+                                val dx = event.rawX - initialTouchPoint.x
+                                val dy = event.rawY - initialTouchPoint.y
+                                if (!isFlick && sqrt(dx * dx + dy * dy) > flickThreshold) {
+                                    isFlick = true
+                                    // フリックが検出されたことを示す（例：振動、ポップアップ表示）
+                                }
+                                true
+                            }
+
+                            MotionEvent.ACTION_UP -> {
+                                if (isFlick) {
+                                    // フリック操作の場合
+                                    val dx = event.rawX - initialTouchPoint.x
+                                    val dy = event.rawY - initialTouchPoint.y
+                                    val angle = atan2(dy.toDouble(), dx.toDouble()) * 180 / Math.PI
+                                    val direction = when {
+                                        angle > -135 && angle <= -45 -> FlickDirection.UP
+                                        angle > -45 && angle <= 45 -> FlickDirection.UP_RIGHT
+                                        angle > 45 && angle <= 135 -> FlickDirection.DOWN
+                                        else -> FlickDirection.UP_LEFT
+                                    }
+
+                                    // 暫定的な方向マッピング。より詳細なフリック方向が必要な場合は要調整
+                                    val targetDirection = when (direction) {
+                                        FlickDirection.UP_LEFT -> FlickDirection.UP_LEFT
+                                        FlickDirection.UP_RIGHT -> FlickDirection.UP_RIGHT
+                                        else -> direction
+                                    }
+
+                                    val action = flickMap[targetDirection]
+                                    if (action is FlickAction.Action) {
+                                        listener?.onAction(action.action)
+                                    }
+                                } else {
+                                    // タップ操作の場合：keyDataの現在のactionを使用
+                                    keyData.action?.let { listener?.onAction(it) }
+                                }
+                                true
+                            }
+
+                            else -> false
+                        }
                     }
                 }
 
@@ -227,22 +285,23 @@ class FlickKeyboardView @JvmOverloads constructor(
                     keyData.action?.let { action ->
                         var isLongPressTriggered = false
                         keyView.setOnClickListener {
-                            this@FlickKeyboardView.listener?.onAction(
-                                action
-                            )
+                            if (!isLongPressTriggered) {
+                                this@FlickKeyboardView.listener?.onAction(action)
+                            }
+                            isLongPressTriggered = false // Reset after click
                         }
                         keyView.setOnLongClickListener {
                             isLongPressTriggered = true
                             this@FlickKeyboardView.listener?.onActionLongPress(action)
                             true
                         }
-                        keyView.setOnTouchListener { _, event ->
-                            if (event.action == MotionEvent.ACTION_UP || event.action == MotionEvent.ACTION_CANCEL) {
-                                if (isLongPressTriggered) {
-                                    this@FlickKeyboardView.listener?.onActionUpAfterLongPress(action)
-                                    isLongPressTriggered = false
-                                }
+                        keyView.setOnTouchListener { v, event ->
+                            if (event.action == MotionEvent.ACTION_UP && isLongPressTriggered) {
+                                this@FlickKeyboardView.listener?.onActionUpAfterLongPress(action)
+                                isLongPressTriggered = false
                             }
+                            // Return false to allow OnClickListener to be called
+                            v.onTouchEvent(event)
                             false
                         }
                     }
@@ -256,6 +315,7 @@ class FlickKeyboardView @JvmOverloads constructor(
         super.onDetachedFromWindow()
         flickControllers.forEach { it.cancel() }
         crossFlickControllers.forEach { it.cancel() }
+        hybridKeyScope.coroutineContext[Job]?.cancel()
     }
 
     private fun Context.getColorFromAttr(@AttrRes attrRes: Int): Int {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -11,7 +11,6 @@ import android.widget.GridLayout
 import androidx.annotation.AttrRes
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
-import androidx.core.view.setMargins
 import com.kazumaproject.core.domain.extensions.isDarkThemeOn
 import com.kazumaproject.custom_keyboard.controller.CrossFlickInputController
 import com.kazumaproject.custom_keyboard.controller.FlickInputController
@@ -92,9 +91,9 @@ class FlickKeyboardView @JvmOverloads constructor(
                 width = 0
                 height = 0
                 if (keyData.isSpecialKey) {
-                    setMargins(6, 7, 6, 5)
+                    setMargins(6, 12, 6, 6)
                 } else {
-                    setMargins(7)
+                    setMargins(6, 9, 6, 9)
                 }
             }
             keyView.layoutParams = params

--- a/qwerty_keyboard/consumer-rules.pro
+++ b/qwerty_keyboard/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.kazumaproject.qwerty_keyboard.** { *; }
+-keep interface com.kazumaproject.qwerty_keyboard.** { *; }

--- a/symbol_keyboard/consumer-rules.pro
+++ b/symbol_keyboard/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.kazumaproject.symbol_keyboard.** { *; }
+-keep interface com.kazumaproject.symbol_keyboard.** { *; }

--- a/tabletkey/consumer-rules.pro
+++ b/tabletkey/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.kazumaproject.tabletkey.** { *; }
+-keep interface com.kazumaproject.tabletkey.** { *; }

--- a/tenkey/consumer-rules.pro
+++ b/tenkey/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.kazumaproject.tenkey.** { *; }
+-keep interface com.kazumaproject.tenkey.** { *; }


### PR DESCRIPTION
## 概要
- 日本語、英語、数字キーボードのキーマップを修正
- 英語キーで PreEditText がない状態で a/A を押すとキーボードが切り替わるバグの修正 