### PR TITLE
ユーザー辞書のフォーマットを txt に変更

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 389
+        versionCode 390
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 388
+        versionCode 389
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,5 +20,4 @@
 # com.kazumaproject.core.domain.extensions.hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
--keepnames class com.kazumaproject.markdownhelperkeyboard.database.** { *; }
--keepnames class com.kazumaproject.markdownhelperkeyboard.user_dictionary.database.** { *; }
+-keep class com.kazumaproject.markdownhelperkeyboard.user_dictionary.database.UserWord { *; }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
@@ -53,7 +53,7 @@ object AppModule {
         .addMigrations(
             MIGRATION_1_2,
             MIGRATION_2_3,
-            MIGRATION_3_4
+            MIGRATION_3_4,
         )
         .build()
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/UserDictionaryRepository.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/UserDictionaryRepository.kt
@@ -31,8 +31,7 @@ class UserDictionaryRepository @Inject constructor(
     }
 
     suspend fun insertAll(words: List<UserWord>) {
-        // インポート機能のために複数の単語を一度に登録する
-        words.forEach { userWordDao.insert(it) }
+        userWordDao.insertAll(words)
     }
 
     suspend fun update(userWord: UserWord) {
@@ -42,4 +41,9 @@ class UserDictionaryRepository @Inject constructor(
     suspend fun delete(id: Int) {
         userWordDao.delete(id)
     }
+
+    suspend fun deleteAll() {
+        userWordDao.deleteAll()
+    }
+
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/user_dictionary/UserDictionaryViewModel.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/user_dictionary/UserDictionaryViewModel.kt
@@ -52,6 +52,10 @@ class UserDictionaryViewModel @Inject constructor(
         repository.delete(id)
     }
 
+    fun deleteAll() = viewModelScope.launch {
+        repository.deleteAll()
+    }
+
     /**
      * readingの前方一致で単語を検索する
      * @param prefix 検索したい読みの文字列

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/user_dictionary/database/UserWordDao.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/user_dictionary/database/UserWordDao.kt
@@ -28,9 +28,15 @@ interface UserWordDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insert(userWord: UserWord)
 
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insertAll(words: List<UserWord>)
+
     @Update
     suspend fun update(userWord: UserWord)
 
     @Query("DELETE FROM user_word WHERE id = :id")
     suspend fun delete(id: Int)
+
+    @Query("DELETE FROM user_word")
+    suspend fun deleteAll()
 }

--- a/app/src/main/res/menu/user_dictionary_menu.xml
+++ b/app/src/main/res/menu/user_dictionary_menu.xml
@@ -4,14 +4,20 @@
 
     <item
         android:id="@+id/action_import"
-        android:icon="@drawable/upload_file_24px"
+        android:icon="@drawable/download_24px"
         android:title="インポート"
         app:showAsAction="ifRoom" />
 
     <item
         android:id="@+id/action_export"
-        android:icon="@drawable/download_24px"
+        android:icon="@drawable/upload_file_24px"
         android:title="エクスポート"
         app:showAsAction="ifRoom" />
+
+    <item
+        android:id="@+id/action_delete_all"
+        android:icon="@android:drawable/ic_menu_delete"
+        android:title="すべて削除"
+        app:showAsAction="never" />
 
 </menu>


### PR DESCRIPTION
## 概要
前回の実装では export したテキストを暗号化していたがアプリを再インストールするとキーを失ってユーザー辞書を復元できなかった。なのでシンプルに txt で export, import できるように修正した