### PR TITLE
Android 13の環境でキーボードを閉じられない への対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 393
+        versionCode 394
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -723,6 +723,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                             romajiConverter.clear()
                             return true
                         }
+
+                        KeyEvent.KEYCODE_BACK -> {
+                            requestHideSelf(0)
+                        }
                     }
 
                     event?.let { e ->


### PR DESCRIPTION
## Issue
#112 

## 概要
一部の特定のデバイスや Android の API バージョンにおいて、戻るボタンを押すと KeyEvent.KEYCODE_BACK が検知される現象が確認されました。

本来 KeyEvent は物理キーに対応するものと考えられていましたが、Android のバージョンや端末によっては、システムナビゲーション（ソフトキー）でも KEYCODE_BACK が検知されるケースがあるようです。

この現象に気づくきっかけをくださった @hanubeki さんに感謝いたします。

そこで今回の対応として、KEYCODE_BACK が検知された場合には、キーボードを閉じる処理を追加しました。これにより、該当デバイスでも意図通りにキーボードが閉じるようになります。