### PR TITLE
Android 13等の一部の環境にて一部アプリにて戻るのナビゲーションが効かなくなる への対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -28,7 +28,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 394
+        versionCode 395
         versionName "1.0.3"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -725,7 +725,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                         }
 
                         KeyEvent.KEYCODE_BACK -> {
-                            requestHideSelf(0)
+                            return super.onKeyDown(keyCode, event)
                         }
                     }
 
@@ -2176,9 +2176,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                     CandidateShowFlag.Updating -> {
                         val inputString = inputString.value
                         setSuggestionOnView(mainView, inputString)
-                        mainView.suggestionRecyclerView.post {
-                            mainView.suggestionRecyclerView.requestLayout()
-                        }
                     }
                 }
                 prevFlag = currentFlag
@@ -3090,7 +3087,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
                 commitAndClearInput(readingCorrection.first)
             }
 
-            14 -> {
+            14, 28 -> {
                 commitAndClearInput(candidate.string)
             }
 
@@ -3540,7 +3537,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection {
             candidates
         }
         suggestionAdapter?.suggestions = filtered
-        mainView.suggestionRecyclerView.scrollToPosition(0)
         updateUIinHenkan(mainView, insertString)
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -242,8 +242,7 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         val paddingLength = when {
             position == 0 -> 4
             suggestion.string.length == 1 -> 4
-            suggestion.string.length == 2 -> 2
-            else -> 1
+            else -> 2
         }
 
         val readingCorrectionString =

--- a/app/src/main/res/layout/suggestion_item.xml
+++ b/app/src/main/res/layout/suggestion_item.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:background="@drawable/recyclerview_item_bg"
-    android:paddingHorizontal="5dp">
+    android:background="@drawable/recyclerview_item_bg">
 
     <com.google.android.material.textview.MaterialTextView
         android:id="@+id/suggestion_item_text_view"


### PR DESCRIPTION
## Issue
#114 

## 概要
一部のデバイスで、KeyEvent.KEYCODE_BACK を検知できない問題が報告されていました。

以前の実装では、KEYCODE_BACK を検知してキーボードを閉じる処理を追加していましたが、。このとき、一部のアプリにおいて戻るボタンの挙動が効かなくなるバグが発生していました。
また else 節で super.onKeyDown(keyCode, event) を返すようにしていたがなぜか KEYCODE_BACK を検知できない。

今回の修正では、KeyEvent.KEYCODE_BACK に対しても明示的に super.onKeyDown(keyCode, event) を返すように処理を分けることで、正常に動作するように修正しました。

```kotlin
KeyEvent.KEYCODE_BACK -> {
    return super.onKeyDown(keyCode, event)
}
```

この変更により、戻るキーでキーボードを閉じつつ、アプリ側の戻る操作も正しく反映されるようになります。

[back_gesture.webm](https://github.com/user-attachments/assets/8cf88277-fe75-4dae-9d9c-cbf2fc0423b5)

