### PR TITLE
クリップボードから画像を貼り付ける機能の実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 407
+        versionCode 408
         versionName "1.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
@@ -124,5 +124,5 @@ dependencies {
 
     implementation "androidx.hilt:hilt-navigation-fragment:1.2.0"
 
-    //debugImplementation("com.squareup.leakcanary:leakcanary-android:2.14")
+//    debugImplementation("com.squareup.leakcanary:leakcanary-android:2.14")
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,14 +9,14 @@
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
+        android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:largeHeap="true"
         android:supportsRtl="true"
         android:theme="@style/Theme.MarkdownKeyboard"
         android:usesCleartextTraffic="true"
-        tools:targetApi="35"
-        android:largeHeap="true"
-        android:hardwareAccelerated="true">
+        tools:targetApi="35">
 
         <activity
             android:name=".setting_activity.MainActivity"
@@ -45,6 +45,17 @@
                 <action android:name="android.view.InputMethod" />
             </intent-filter>
         </service>
+
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="com.kazumaproject.markdownhelperkeyboard.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path
+        name="shared_images"
+        path="images/" />
+</paths>


### PR DESCRIPTION
## Issue
#84 

## 概要
従来は クリップボードから “テキストだけ” を取り出してコピー & ペーストする 機能しかありませんでしたが、本 PR では 画像（ビットマップ／PNG・JPEG など）も同じワークフローに統合 しました。これにより、ユーザーはチャットアプリやメモ帳、メール作成画面などで テキストと画像をシームレスに貼り付け できます。

[demo_image_clip_board.webm](https://github.com/user-attachments/assets/7821ecd3-6b68-4cfb-89a2-5c77fda429e0)
