### PR TITLE
クリップボードの履歴を表示するカスタムViewの作成

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 431
+        versionCode 432
         versionName "1.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/BitmapConverter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/BitmapConverter.kt
@@ -1,0 +1,22 @@
+package com.kazumaproject.markdownhelperkeyboard.clipboard_history
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import androidx.room.TypeConverter
+import java.io.ByteArrayOutputStream
+
+class BitmapConverter {
+    @TypeConverter
+    fun fromBitmap(bitmap: Bitmap?): ByteArray? {
+        if (bitmap == null) return null
+        val outputStream = ByteArrayOutputStream()
+        bitmap.compress(Bitmap.CompressFormat.PNG, 100, outputStream)
+        return outputStream.toByteArray()
+    }
+
+    @TypeConverter
+    fun toBitmap(byteArray: ByteArray?): Bitmap? {
+        if (byteArray == null) return null
+        return BitmapFactory.decodeByteArray(byteArray, 0, byteArray.size)
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/ClipBoardConverter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/ClipBoardConverter.kt
@@ -1,0 +1,45 @@
+package com.kazumaproject.markdownhelperkeyboard.clipboard_history
+
+import com.kazumaproject.core.data.clipboard.ClipboardItem
+import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ClipboardHistoryItem
+import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ItemType
+
+fun ClipboardHistoryItem.toClipboardItem(): ClipboardItem {
+    return when (this.itemType) {
+        ItemType.TEXT -> ClipboardItem.Text(
+            id = this.id, // <<< id を渡す
+            text = this.textData ?: ""
+        )
+
+        ItemType.IMAGE -> {
+            this.imageData?.let { bitmap ->
+                ClipboardItem.Image(
+                    id = this.id, // <<< id を渡す
+                    bitmap = bitmap
+                )
+            } ?: ClipboardItem.Empty // Bitmapが何らかの理由でnullならEmpty扱い
+        }
+    }
+}
+
+/**
+ *【参考】
+ * 逆方向の変換（ClipboardItem → ClipboardHistoryItem）です。
+ * こちらはDBに新規挿入する際に使われるため、idはRoomが自動生成するので不要です。
+ * そのため、こちらの関数は修正の必要はありません。
+ */
+fun ClipboardItem.toHistoryItem(): ClipboardHistoryItem? = when (this) {
+    is ClipboardItem.Text -> ClipboardHistoryItem(
+        itemType = ItemType.TEXT,
+        textData = this.text,
+        imageData = null
+    )
+
+    is ClipboardItem.Image -> ClipboardHistoryItem(
+        itemType = ItemType.IMAGE,
+        textData = null,
+        imageData = this.bitmap
+    )
+
+    is ClipboardItem.Empty -> null
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ClipboardHistoryDao.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ClipboardHistoryDao.kt
@@ -17,6 +17,9 @@ interface ClipboardHistoryDao {
     @Query("SELECT * FROM clipboard_history ORDER BY timestamp DESC")
     suspend fun getAllHistorySuspended(): List<ClipboardHistoryItem>
 
+    @Query("SELECT * FROM clipboard_history ORDER BY timestamp DESC LIMIT 1")
+    suspend fun getLatestItem(): ClipboardHistoryItem?
+
     @Query("DELETE FROM clipboard_history WHERE id = :id")
     suspend fun deleteById(id: Long)
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ClipboardHistoryDao.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ClipboardHistoryDao.kt
@@ -1,0 +1,22 @@
+package com.kazumaproject.markdownhelperkeyboard.clipboard_history.database
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+
+@Dao
+interface ClipboardHistoryDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(item: ClipboardHistoryItem)
+
+    @Query("SELECT * FROM clipboard_history ORDER BY timestamp DESC")
+    fun getAllHistory(): Flow<List<ClipboardHistoryItem>>
+
+    @Query("SELECT * FROM clipboard_history ORDER BY timestamp DESC")
+    suspend fun getAllHistorySuspended(): List<ClipboardHistoryItem>
+
+    @Query("DELETE FROM clipboard_history WHERE id = :id")
+    suspend fun deleteById(id: Long)
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ClipboardHistoryItem.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ClipboardHistoryItem.kt
@@ -1,0 +1,21 @@
+package com.kazumaproject.markdownhelperkeyboard.clipboard_history.database
+
+import android.graphics.Bitmap
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+// アイテムの種類を区別するためのEnum
+enum class ItemType {
+    TEXT,
+    IMAGE
+}
+
+@Entity(tableName = "clipboard_history")
+data class ClipboardHistoryItem(
+    @PrimaryKey(autoGenerate = true)
+    val id: Long = 0,
+    val itemType: ItemType,
+    val textData: String?,   // テキスト用
+    val imageData: Bitmap?, // 画像用
+    val timestamp: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ItemTypeConverter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/clipboard_history/database/ItemTypeConverter.kt
@@ -1,0 +1,15 @@
+package com.kazumaproject.markdownhelperkeyboard.clipboard_history.database
+
+import androidx.room.TypeConverter
+
+class ItemTypeConverter {
+    @TypeConverter
+    fun fromItemType(value: ItemType?): String? {
+        return value?.name
+    }
+
+    @TypeConverter
+    fun toItemType(value: String?): ItemType? {
+        return value?.let { ItemType.valueOf(it) }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -5511,7 +5511,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             // For the default keyboard, use the user's preference.
             // **FIXED**: Clamp the height to the same range as the settings UI (180-280).
             else -> {
-                val clampedHeight = heightPref.coerceIn(180, 280)
+                val clampedHeight = heightPref.coerceIn(180, 420)
                 (clampedHeight * density).toInt()
             }
         }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -292,6 +292,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var mozcUTNeologd: Boolean? = false
     private var mozcUTWeb: Boolean? = false
     private var sumireInputKeyType: String? = "flick-default"
+    private var symbolKeyboardFirstItem: SymbolMode? = SymbolMode.EMOJI
 
     private var isTablet: Boolean? = false
 
@@ -490,6 +491,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             isVibration = vibration_preference ?: true
             vibrationTimingStr = vibration_timing_preference ?: "both"
             sumireInputKeyType = sumire_input_selection_preference ?: "flick-default"
+            symbolKeyboardFirstItem = symbol_mode_preference
             if (mozcUTPersonName == true) {
                 if (!kanaKanjiEngine.isMozcUTPersonDictionariesInitialized()) {
                     kanaKanjiEngine.buildPersonNamesDictionary(
@@ -598,6 +600,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         mozcUTWeb = null
         sumireInputKeyType = null
         isTablet = null
+        symbolKeyboardFirstItem = null
         actionInDestroy()
         System.gc()
     }
@@ -3635,7 +3638,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private suspend fun setSymbols(mainView: MainLayoutBinding) {
-        var clipboardItems = emptyList<ClipboardItem>()
         coroutineScope {
             if (cachedEmoji == null || cachedEmoticons == null || cachedSymbols == null) {
                 val emojiDeferred =
@@ -3657,7 +3659,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             emoticons = cachedEmoticons ?: emptyList(),
             symbols = cachedSymbols ?: emptyList(),
             clipBoardItems = currentClipboardItems,
-            symbolsHistory = cachedClickedSymbolHistory ?: emptyList()
+            symbolsHistory = cachedClickedSymbolHistory ?: emptyList(),
+            symbolMode = symbolKeyboardFirstItem ?: SymbolMode.EMOJI
+
         )
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/clipboard/ClipboardUtil.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/clipboard/ClipboardUtil.kt
@@ -6,23 +6,8 @@ import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Build
-import android.util.Log
+import com.kazumaproject.core.data.clipboard.ClipboardItem
 import timber.log.Timber
-
-/**
- * クリップボードのコンテンツの種類を表すsealed class。
- * これにより、クリップボードの内容がテキストか画像かを安全に判定できます。
- */
-sealed class ClipboardItem {
-    /** テキストコンテンツを保持します。 */
-    data class Text(val text: String) : ClipboardItem()
-
-    /** 画像コンテンツ (Bitmap) を保持します。 */
-    data class Image(val bitmap: Bitmap) : ClipboardItem()
-
-    /** クリップボードが空、またはサポートされていないコンテンツの場合を表します。 */
-    object Empty : ClipboardItem()
-}
 
 /**
  * クリップボードの操作を補助するユーティリティクラス。
@@ -47,20 +32,17 @@ class ClipboardUtil(private val context: Context) {
 
         // 1. 画像の取得を最優先で試みる
         getClipboardImageBitmap()?.let { bitmap ->
-            Log.d("ClipboardUtil", "クリップボードから画像Bitmapを取得しました。")
             return ClipboardItem.Image(bitmap)
         }
 
         // 2. 画像が取得できなかった場合、テキストの取得を試みる
         getFirstClipboardTextOrNull()?.let { text ->
             if (text.isNotBlank()) {
-                Log.d("ClipboardUtil", "クリップボードからテキストを取得しました。")
                 return ClipboardItem.Text(text)
             }
         }
 
         // 3. 画像も有効なテキストも見つからなかった場合
-        Log.d("ClipboardUtil", "クリップボードに有効なコンテンツが見つかりませんでした。")
         return ClipboardItem.Empty
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/clipboard/ClipboardUtil.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/clipboard/ClipboardUtil.kt
@@ -32,13 +32,13 @@ class ClipboardUtil(private val context: Context) {
 
         // 1. 画像の取得を最優先で試みる
         getClipboardImageBitmap()?.let { bitmap ->
-            return ClipboardItem.Image(bitmap)
+            return ClipboardItem.Image(id = 0, bitmap)
         }
 
         // 2. 画像が取得できなかった場合、テキストの取得を試みる
         getFirstClipboardTextOrNull()?.let { text ->
             if (text.isNotBlank()) {
-                return ClipboardItem.Text(text)
+                return ClipboardItem.Text(id = 0, text)
             }
         }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
@@ -9,6 +9,7 @@ import com.kazumaproject.Louds.with_term_id.LOUDSWithTermId
 import com.kazumaproject.connection_id.ConnectionIdBuilder
 import com.kazumaproject.dictionary.TokenArray
 import com.kazumaproject.markdownhelperkeyboard.clicked_symbol.database.ClickedSymbolDao
+import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ClipboardHistoryDao
 import com.kazumaproject.markdownhelperkeyboard.converter.bitset.SuccinctBitVector
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.EnglishEngine
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.KanaKanjiEngine
@@ -23,6 +24,7 @@ import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.M
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_5_6
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_6_7
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_7_8
+import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_8_9
 import com.kazumaproject.markdownhelperkeyboard.ime_service.clipboard.ClipboardUtil
 import com.kazumaproject.markdownhelperkeyboard.ime_service.models.PressedKeyStatus
 import com.kazumaproject.markdownhelperkeyboard.ime_service.romaji_kana.RomajiKanaConverter
@@ -63,7 +65,8 @@ object AppModule {
             MIGRATION_4_5,
             MIGRATION_5_6,
             MIGRATION_6_7,
-            MIGRATION_7_8
+            MIGRATION_7_8,
+            MIGRATION_8_9
         )
         .build()
 
@@ -86,6 +89,10 @@ object AppModule {
     @Singleton
     @Provides
     fun providesUserTemplateDao(db: AppDatabase): UserTemplateDao = db.userTemplateDao()
+
+    @Singleton
+    @Provides
+    fun providesClipBoardHistoryDao(db: AppDatabase): ClipboardHistoryDao = db.clipboardHistoryDao()
 
     @Singleton
     @Provides

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/ClipboardHistoryRepository.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/ClipboardHistoryRepository.kt
@@ -1,0 +1,51 @@
+package com.kazumaproject.markdownhelperkeyboard.repository
+
+import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ClipboardHistoryDao
+import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ClipboardHistoryItem
+import kotlinx.coroutines.flow.Flow
+import javax.inject.Inject
+
+/**
+ * クリップボード履歴のデータ操作を抽象化するリポジトリクラス。
+ * ViewModelなどアプリの他の部分はこのリポジトリを介してデータにアクセスします。
+ *
+ * @property dao Hilt/DaggerなどのDIフレームワークによって注入されるDAOのインスタンス。
+ */
+class ClipboardHistoryRepository @Inject constructor(
+    private val dao: ClipboardHistoryDao
+) {
+
+    /**
+     * すべてのクリップボード履歴をFlowとして提供します。
+     * UIはこのFlowを監視することで、データベースの変更を自動的に反映できます。
+     */
+    val allHistory: Flow<List<ClipboardHistoryItem>> = dao.getAllHistory()
+
+    /**
+     * 新しいクリップボード履歴アイテムをデータベースに挿入します。
+     *
+     * @param item 保存するClipboardHistoryItem
+     */
+    suspend fun insert(item: ClipboardHistoryItem) {
+        dao.insert(item)
+    }
+
+    /**
+     * 指定されたIDの履歴アイテムをデータベースから削除します。
+     *
+     * @param id 削除するアイテムのID
+     */
+    suspend fun deleteById(id: Long) {
+        dao.deleteById(id)
+    }
+
+    /**
+     * 現在のクリップボード履歴のスナップショット（一度きりのリスト）を取得します。
+     * バックグラウンド処理などで、一度だけ最新のリストが必要な場合に使用します。
+     *
+     * @return ClipboardHistoryItemのリスト
+     */
+    suspend fun getHistorySnapshot(): List<ClipboardHistoryItem> {
+        return dao.getAllHistorySuspended()
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/ClipboardHistoryRepository.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/ClipboardHistoryRepository.kt
@@ -48,4 +48,15 @@ class ClipboardHistoryRepository @Inject constructor(
     suspend fun getHistorySnapshot(): List<ClipboardHistoryItem> {
         return dao.getAllHistorySuspended()
     }
+
+    /**
+     * データベースに保存されている最新の履歴アイテムを取得します。
+     * 履歴が空の場合はnullを返します。
+     *
+     * @return 最新の ClipboardHistoryItem、または null
+     */
+    suspend fun getLatestItem(): ClipboardHistoryItem? {
+        return dao.getLatestItem()
+    }
+
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import androidx.preference.PreferenceManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
+import com.kazumaproject.core.data.clicked_symbol.SymbolMode
 import com.kazumaproject.markdownhelperkeyboard.ime_service.state.KeyboardType
 
 object AppPreference {
@@ -46,6 +47,7 @@ object AppPreference {
         )
     )
     private val KEYBOARD_ORDER = Pair("keyboard_order_preference", defaultKeyboardOrderJson)
+    private val SYMBOL_MODE_PREFERENCE = Pair("symbol_mode_preference", "EMOJI")
 
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -75,6 +77,25 @@ object AppPreference {
         set(value) = preferences.edit {
             val json = gson.toJson(value)
             it.putString(KEYBOARD_ORDER.first, json)
+        }
+
+    var symbol_mode_preference: SymbolMode
+        get() {
+            val modeString = preferences.getString(
+                SYMBOL_MODE_PREFERENCE.first,
+                SYMBOL_MODE_PREFERENCE.second
+            )
+            return try {
+                // 保存されている文字列からEnumを復元
+                SymbolMode.valueOf(modeString ?: SYMBOL_MODE_PREFERENCE.second)
+            } catch (e: IllegalArgumentException) {
+                // 不正な値が保存されていた場合はデフォルト値を返す
+                SymbolMode.valueOf(SYMBOL_MODE_PREFERENCE.second)
+            }
+        }
+        set(value) = preferences.edit {
+            // Enumを文字列として保存
+            it.putString(SYMBOL_MODE_PREFERENCE.first, value.name)
         }
 
     var vibration_preference: Boolean?

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -12,6 +12,7 @@ object AppPreference {
     private lateinit var preferences: SharedPreferences
     private val gson = Gson()
 
+    private val CLIPBOARD_HISTORY_ENABLE = Pair("clipboard_history_preference", false)
     private val TIME_SAME_PRONOUNCE_TYPING = Pair("time_same_pronounce_typing_preference", 1000)
     private val VIBRATION_PREFERENCE = Pair("vibration_preference", true)
     private val VIBRATION_TIMING_PREFERENCE = Pair("vibration_timing", "both")
@@ -55,6 +56,15 @@ object AppPreference {
         operation(editor)
         editor.apply()
     }
+
+    var clipboard_history_enable: Boolean?
+        get() = preferences.getBoolean(
+            CLIPBOARD_HISTORY_ENABLE.first,
+            CLIPBOARD_HISTORY_ENABLE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(CLIPBOARD_HISTORY_ENABLE.first, value ?: false)
+        }
 
     var keyboard_order: List<KeyboardType>
         get() {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
@@ -36,7 +36,7 @@ class KeyboardSettingFragment : Fragment() {
 
     // Define min/max dimensions for the keyboard
     private val minHeightDp = 170
-    private val maxHeightDp = 280
+    private val maxHeightDp = 420
     private val minWidthPercent = 74
     private val maxWidthPercent = 100
 

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -39,6 +39,16 @@
             android:summaryOn="ライブ変換は有効です"
             android:title="ライブ変換 β" />
 
+        <PreferenceCategory android:title="記号キーボード">
+            <ListPreference
+                android:defaultValue="EMOJI"
+                android:dialogTitle="初期画面を選択"
+                android:entries="@array/symbol_mode_entries"
+                android:entryValues="@array/symbol_mode_values"
+                android:key="symbol_mode_preference"
+                android:summary="記号キーボードの初期画面を選択します"
+                android:title="記号キーボードの初期画面" />
+        </PreferenceCategory>
         <PreferenceCategory
             android:key="sumire_input_preference_category"
             android:title="スミレ入力キーボード"

--- a/core/src/main/java/com/kazumaproject/core/data/clicked_symbol/SymbolMode.kt
+++ b/core/src/main/java/com/kazumaproject/core/data/clicked_symbol/SymbolMode.kt
@@ -1,5 +1,5 @@
 package com.kazumaproject.core.data.clicked_symbol
 
 enum class SymbolMode {
-    EMOJI, EMOTICON, SYMBOL, CLIPBOARD, Template
+    EMOJI, EMOTICON, SYMBOL, CLIPBOARD
 }

--- a/core/src/main/java/com/kazumaproject/core/data/clicked_symbol/SymbolMode.kt
+++ b/core/src/main/java/com/kazumaproject/core/data/clicked_symbol/SymbolMode.kt
@@ -1,5 +1,5 @@
 package com.kazumaproject.core.data.clicked_symbol
 
 enum class SymbolMode {
-    EMOJI, EMOTICON, SYMBOL
+    EMOJI, EMOTICON, SYMBOL, CLIPBOARD, Template
 }

--- a/core/src/main/java/com/kazumaproject/core/data/clipboard/ClipboardItem.kt
+++ b/core/src/main/java/com/kazumaproject/core/data/clipboard/ClipboardItem.kt
@@ -3,13 +3,16 @@ package com.kazumaproject.core.data.clipboard
 import android.graphics.Bitmap
 
 sealed class ClipboardItem {
-    /** テキストコンテンツを保持します。 */
-    data class Text(val text: String) : ClipboardItem()
+    /** * テキストコンテンツを保持します。
+     * @param id データベース上のユニークID
+     */
+    data class Text(val id: Long, val text: String) : ClipboardItem()
 
-    /** 画像コンテンツ (Bitmap) を保持します。 */
-    data class Image(val bitmap: Bitmap) : ClipboardItem()
+    /** * 画像コンテンツ (Bitmap) を保持します。
+     * @param id データベース上のユニークID
+     */
+    data class Image(val id: Long, val bitmap: Bitmap) : ClipboardItem()
 
     /** クリップボードが空、またはサポートされていないコンテンツの場合を表します。 */
-    // If you're on Kotlin 1.9+, you can keep `data object Empty : ClipboardItem()`
     data object Empty : ClipboardItem()
 }

--- a/core/src/main/java/com/kazumaproject/core/data/clipboard/ClipboardItem.kt
+++ b/core/src/main/java/com/kazumaproject/core/data/clipboard/ClipboardItem.kt
@@ -1,0 +1,15 @@
+package com.kazumaproject.core.data.clipboard
+
+import android.graphics.Bitmap
+
+sealed class ClipboardItem {
+    /** テキストコンテンツを保持します。 */
+    data class Text(val text: String) : ClipboardItem()
+
+    /** 画像コンテンツ (Bitmap) を保持します。 */
+    data class Image(val bitmap: Bitmap) : ClipboardItem()
+
+    /** クリップボードが空、またはサポートされていないコンテンツの場合を表します。 */
+    // If you're on Kotlin 1.9+, you can keep `data object Empty : ClipboardItem()`
+    data object Empty : ClipboardItem()
+}

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -58,4 +58,19 @@
         <item>右フリック</item>
         <item>下フリック</item>
     </string-array>
+
+    <string-array name="symbol_mode_entries">
+        <item>絵文字</item>
+        <item>顔文字</item>
+        <item>記号</item>
+        <item>クリップボード履歴</item>
+    </string-array>
+
+    <!-- SymbolMode の選択肢に対応する値 (プログラム側で扱う値) -->
+    <string-array name="symbol_mode_values">
+        <item>EMOJI</item>
+        <item>EMOTICON</item>
+        <item>SYMBOL</item>
+        <item>CLIPBOARD</item>
+    </string-array>
 </resources>

--- a/symbol_keyboard/src/main/java/com/kazumaproject/listeners/ClipboardHistoryToggleListener.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/listeners/ClipboardHistoryToggleListener.kt
@@ -1,0 +1,5 @@
+package com.kazumaproject.listeners
+
+fun interface ClipboardHistoryToggleListener {
+    fun onToggled(isEnabled: Boolean)
+}

--- a/symbol_keyboard/src/main/java/com/kazumaproject/listeners/ClipboardItemLongClickListener.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/listeners/ClipboardItemLongClickListener.kt
@@ -1,0 +1,7 @@
+package com.kazumaproject.listeners
+
+import com.kazumaproject.core.data.clipboard.ClipboardItem
+
+fun interface ClipboardItemLongClickListener {
+    fun onLongClick(item: ClipboardItem, position: Int)
+}

--- a/symbol_keyboard/src/main/java/com/kazumaproject/listeners/ImageItemClickListener.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/listeners/ImageItemClickListener.kt
@@ -1,0 +1,7 @@
+package com.kazumaproject.listeners
+
+import android.graphics.Bitmap
+
+fun interface ImageItemClickListener {
+    fun onImageClick(bitmap: Bitmap)
+}

--- a/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardAdapter.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardAdapter.kt
@@ -14,9 +14,14 @@ class ClipboardAdapter :
     PagingDataAdapter<ClipboardItem, ClipboardAdapter.ClipboardViewHolder>(DIFF_CALLBACK) {
 
     private var onItemClickListener: ((ClipboardItem) -> Unit)? = null
+    private var onItemLongClickListener: ((ClipboardItem, Int) -> Unit)? = null
 
     fun setOnItemClickListener(listener: (ClipboardItem) -> Unit) {
         this.onItemClickListener = listener
+    }
+
+    fun setOnItemLongClickListener(listener: (ClipboardItem, Int) -> Unit) {
+        this.onItemLongClickListener = listener
     }
 
     inner class ClipboardViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -31,6 +36,15 @@ class ClipboardAdapter :
                         onItemClickListener?.invoke(item)
                     }
                 }
+            }
+            itemView.setOnLongClickListener {
+                val position = bindingAdapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    getItem(position)?.let { item ->
+                        onItemLongClickListener?.invoke(item, position)
+                    }
+                }
+                true
             }
         }
     }
@@ -49,11 +63,13 @@ class ClipboardAdapter :
                 holder.textView.visibility = View.GONE
                 holder.imageView.setImageBitmap(item.bitmap)
             }
+
             is ClipboardItem.Text -> {
                 holder.imageView.visibility = View.GONE
                 holder.textView.visibility = View.VISIBLE
                 holder.textView.text = item.text
             }
+
             is ClipboardItem.Empty, null -> {
                 holder.imageView.visibility = View.GONE
                 holder.textView.visibility = View.GONE

--- a/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardAdapter.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardAdapter.kt
@@ -1,0 +1,84 @@
+package com.kazumaproject.symbol_keyboard
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ImageView
+import androidx.paging.PagingDataAdapter
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.textview.MaterialTextView
+import com.kazumaproject.core.data.clipboard.ClipboardItem
+
+class ClipboardAdapter :
+    PagingDataAdapter<ClipboardItem, ClipboardAdapter.ClipboardViewHolder>(DIFF_CALLBACK) {
+
+    private var onItemClickListener: ((ClipboardItem) -> Unit)? = null
+
+    fun setOnItemClickListener(listener: (ClipboardItem) -> Unit) {
+        this.onItemClickListener = listener
+    }
+
+    inner class ClipboardViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val imageView: ImageView = itemView.findViewById(R.id.clipboard_image_view)
+        val textView: MaterialTextView = itemView.findViewById(R.id.clipboard_text_view)
+
+        init {
+            itemView.setOnClickListener {
+                val position = bindingAdapterPosition
+                if (position != RecyclerView.NO_POSITION) {
+                    getItem(position)?.let { item ->
+                        onItemClickListener?.invoke(item)
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ClipboardViewHolder {
+        val view = LayoutInflater.from(parent.context)
+            .inflate(R.layout.clipboard_item_view, parent, false)
+        return ClipboardViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ClipboardViewHolder, position: Int) {
+        val item = getItem(position)
+        when (item) {
+            is ClipboardItem.Image -> {
+                holder.imageView.visibility = View.VISIBLE
+                holder.textView.visibility = View.GONE
+                holder.imageView.setImageBitmap(item.bitmap)
+            }
+            is ClipboardItem.Text -> {
+                holder.imageView.visibility = View.GONE
+                holder.textView.visibility = View.VISIBLE
+                holder.textView.text = item.text
+            }
+            is ClipboardItem.Empty, null -> {
+                holder.imageView.visibility = View.GONE
+                holder.textView.visibility = View.GONE
+            }
+        }
+    }
+
+    companion object {
+        private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<ClipboardItem>() {
+            override fun areItemsTheSame(oldItem: ClipboardItem, newItem: ClipboardItem): Boolean {
+                return if (oldItem is ClipboardItem.Text && newItem is ClipboardItem.Text) {
+                    oldItem.text == newItem.text
+                } else if (oldItem is ClipboardItem.Image && newItem is ClipboardItem.Image) {
+                    oldItem.bitmap == newItem.bitmap
+                } else {
+                    false
+                }
+            }
+
+            override fun areContentsTheSame(
+                oldItem: ClipboardItem,
+                newItem: ClipboardItem
+            ): Boolean {
+                return oldItem == newItem
+            }
+        }
+    }
+}

--- a/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardAdapter.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardAdapter.kt
@@ -7,6 +7,7 @@ import android.widget.ImageView
 import androidx.paging.PagingDataAdapter
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.card.MaterialCardView
 import com.google.android.material.textview.MaterialTextView
 import com.kazumaproject.core.data.clipboard.ClipboardItem
 
@@ -26,6 +27,9 @@ class ClipboardAdapter :
 
     inner class ClipboardViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val imageView: ImageView = itemView.findViewById(R.id.clipboard_image_view)
+
+        // MaterialCardViewへの参照を追加
+        val textCardView: MaterialCardView = itemView.findViewById(R.id.clipboard_text_card_view)
         val textView: MaterialTextView = itemView.findViewById(R.id.clipboard_text_view)
 
         init {
@@ -60,19 +64,22 @@ class ClipboardAdapter :
         when (item) {
             is ClipboardItem.Image -> {
                 holder.imageView.visibility = View.VISIBLE
-                holder.textView.visibility = View.GONE
+                // textCardViewを非表示にする
+                holder.textCardView.visibility = View.GONE
                 holder.imageView.setImageBitmap(item.bitmap)
             }
 
             is ClipboardItem.Text -> {
                 holder.imageView.visibility = View.GONE
-                holder.textView.visibility = View.VISIBLE
+                // textCardViewを表示する
+                holder.textCardView.visibility = View.VISIBLE
                 holder.textView.text = item.text
             }
 
             is ClipboardItem.Empty, null -> {
                 holder.imageView.visibility = View.GONE
-                holder.textView.visibility = View.GONE
+                // textCardViewも非表示にする
+                holder.textCardView.visibility = View.GONE
             }
         }
     }

--- a/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardPagingSource.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/ClipboardPagingSource.kt
@@ -1,0 +1,38 @@
+package com.kazumaproject.symbol_keyboard
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.kazumaproject.core.data.clipboard.ClipboardItem
+
+class ClipboardPagingSource(
+    private val items: List<ClipboardItem>
+) : PagingSource<Int, ClipboardItem>() {
+
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, ClipboardItem> {
+        return try {
+            val position = params.key ?: 0
+            val loadSize = params.loadSize
+            val endPosition = minOf(position + loadSize, items.size)
+            val data = items.subList(position, endPosition)
+
+            val prevKey = if (position == 0) null else position - loadSize
+            val nextKey = if (endPosition == items.size) null else endPosition
+
+            LoadResult.Page(
+                data = data,
+                prevKey = prevKey,
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            LoadResult.Error(e)
+        }
+    }
+
+    override fun getRefreshKey(state: PagingState<Int, ClipboardItem>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            anchorPage?.prevKey?.plus(state.config.pageSize)
+                ?: anchorPage?.nextKey?.minus(state.config.pageSize)
+        }
+    }
+}

--- a/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/CustomSymbolKeyboardView.kt
+++ b/symbol_keyboard/src/main/java/com/kazumaproject/symbol_keyboard/CustomSymbolKeyboardView.kt
@@ -261,7 +261,7 @@ class CustomSymbolKeyboardView @JvmOverloads constructor(
         symbols: List<String>,
         clipBoardItems: List<ClipboardItem>,
         symbolsHistory: List<ClickedSymbol>,
-        defaultMode: SymbolMode = SymbolMode.EMOJI
+        symbolMode: SymbolMode = SymbolMode.EMOJI
     ) {
         this.symbolsHistory = symbolsHistory
         this.clipBoardItems = clipBoardItems
@@ -273,10 +273,10 @@ class CustomSymbolKeyboardView @JvmOverloads constructor(
         this.symbols = symbols
         emojiMap = emojiList.groupBy { it.category }.toSortedMap(categoryOrder)
 
-        currentMode = defaultMode
+        currentMode = symbolMode
         buildModeTabs()
         buildCategoryTabs()
-        modeTab.getTabAt(defaultMode.ordinal)?.select()
+        modeTab.getTabAt(symbolMode.ordinal)?.select()
         categoryTab.getTabAt(0)?.select()
         updateSymbolsForCategory(0)
     }

--- a/symbol_keyboard/src/main/res/layout/clipboard_item_view.xml
+++ b/symbol_keyboard/src/main/res/layout/clipboard_item_view.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginHorizontal="4dp"
-    android:layout_marginVertical="3dp">
+    android:layout_marginHorizontal="8dp"
+    android:layout_marginVertical="6dp">
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/clipboard_image_view"
@@ -12,20 +13,34 @@
         android:layout_height="wrap_content"
         android:scaleType="centerInside"
         android:visibility="gone"
-        app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Large" />
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Large"
+        tools:srcCompat="@tools:sample/avatars" />
 
-    <com.google.android.material.textview.MaterialTextView
-        android:id="@+id/clipboard_text_view"
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/clipboard_text_card_view"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:ellipsize="end"
-        android:gravity="center"
-        android:maxLines="3"
-        android:padding="8dp"
-        android:textAlignment="center"
-        android:textColor="@color/symbol_text_color"
-        android:textSize="14sp"
-        android:visibility="gone" />
+        android:visibility="gone"
+        app:cardCornerRadius="12dp"
+        app:cardElevation="0dp"
+        app:strokeColor="?attr/colorOutline"
+        app:strokeWidth="1dp"
+        tools:visibility="visible">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/clipboard_text_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:ellipsize="end"
+            android:gravity="center"
+            android:maxLines="5"
+            android:padding="8dp"
+            android:textAlignment="center"
+            android:textColor="?attr/colorOnSurface"
+            android:textSize="14sp"
+            tools:text="これはクリップボードのテキストサンプルです。複数行にわたる長いテキストの場合の表示を確認します。" />
+
+    </com.google.android.material.card.MaterialCardView>
 
 </FrameLayout>

--- a/symbol_keyboard/src/main/res/layout/clipboard_item_view.xml
+++ b/symbol_keyboard/src/main/res/layout/clipboard_item_view.xml
@@ -21,7 +21,7 @@
         android:layout_gravity="center"
         android:ellipsize="end"
         android:gravity="center"
-        android:maxLines="4"
+        android:maxLines="3"
         android:padding="8dp"
         android:textAlignment="center"
         android:textColor="@color/symbol_text_color"

--- a/symbol_keyboard/src/main/res/layout/clipboard_item_view.xml
+++ b/symbol_keyboard/src/main/res/layout/clipboard_item_view.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginHorizontal="4dp"
+    android:layout_marginVertical="3dp">
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/clipboard_image_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:scaleType="centerInside"
+        android:visibility="gone"
+        app:shapeAppearanceOverlay="@style/ShapeAppearance.Material3.Corner.Large" />
+
+    <com.google.android.material.textview.MaterialTextView
+        android:id="@+id/clipboard_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:ellipsize="end"
+        android:gravity="center"
+        android:maxLines="4"
+        android:padding="8dp"
+        android:textAlignment="center"
+        android:textColor="@color/symbol_text_color"
+        android:textSize="14sp"
+        android:visibility="gone" />
+
+</FrameLayout>

--- a/symbol_keyboard/src/main/res/layout/custom_tab_clipboard.xml
+++ b/symbol_keyboard/src/main/res/layout/custom_tab_clipboard.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="wrap_content"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="horizontal"
+    android:paddingHorizontal="12dp">
+
+    <TextView
+        android:id="@+id/clipboard_tab_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="クリップボード"
+        android:textColor="?attr/colorOnSurface"
+        android:textSize="14sp" />
+
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/clipboard_tab_switch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp" />
+
+</LinearLayout>


### PR DESCRIPTION
## Issue
#130 

## 概要

1. クリップボード履歴の保存機能の追加

スミレがデフォルトのキーボードに設定されている場合、ユーザーのコピー操作を検知し、コピー内容をクリップボード履歴としてDBに保存する機能を実装。

2. 履歴表示Viewの実装

記号キーボード内に、保存されたクリップボード履歴を一覧表示するViewを新たに追加。

3. 初期選択タブの設定機能の追加

記号キーボードを開いた際に表示される初期タブを設定できる新しいPreference（設定項目）を追加。

[demo_clipboard_2.webm](https://github.com/user-attachments/assets/7fe7e226-6768-4737-9421-1833dda724e7)
