### PR TITLE
ライブ変換でコミットする文字列を変換候補を取得した瞬間にセットするように修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 432
+        versionCode 433
         versionName "1.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1344,15 +1344,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
 
             Key.SideKeyDelete -> {
-                if (isHenkan.get()) {
-                    cancelHenkanByLongPressDeleteKey()
-                } else {
-                    onDeleteLongPressUp.set(true)
-                    deleteLongPress()
-                    _dakutenPressed.value = false
-                    englishSpaceKeyPressed.set(false)
-                    deleteKeyLongKeyPressed.set(true)
-                }
+                handleDeleteLongPress()
             }
 
             Key.SideKeyInputMode -> {}
@@ -1366,12 +1358,26 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
     }
 
+    private fun handleDeleteLongPress() {
+        if (isHenkan.get()) {
+            cancelHenkanByLongPressDeleteKey()
+            hasConvertedKatakana = false
+        } else {
+            onDeleteLongPressUp.set(true)
+            deleteLongPress()
+            _dakutenPressed.value = false
+            englishSpaceKeyPressed.set(false)
+            deleteKeyLongKeyPressed.set(true)
+        }
+    }
+
     private fun handleSpaceLongAction() {
         Timber.d("SideKeySpace LongPress: ${cursorMoveMode.value} $isSpaceKeyLongPressed")
         val insertString = inputString.value
         if (insertString.isNotEmpty()) {
             mainLayoutBinding?.let {
                 if (it.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
+                    if (isHenkan.get()) return
                     isSpaceKeyLongPressed = true
                     if (hasConvertedKatakana) {
                         if (isLiveConversionEnable == true) {
@@ -1725,15 +1731,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     }
 
                     KeyAction.Delete -> {
-                        if (isHenkan.get()) {
-                            cancelHenkanByLongPressDeleteKey()
-                        } else {
-                            onDeleteLongPressUp.set(true)
-                            deleteLongPress()
-                            _dakutenPressed.value = false
-                            englishSpaceKeyPressed.set(false)
-                            deleteKeyLongKeyPressed.set(true)
-                        }
+                        handleDeleteLongPress()
                     }
 
                     KeyAction.NewLine, KeyAction.Enter, KeyAction.Confirm -> {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1361,7 +1361,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun handleDeleteLongPress() {
         if (isHenkan.get()) {
             cancelHenkanByLongPressDeleteKey()
-            hasConvertedKatakana = false
+            hasConvertedKatakana = isLiveConversionEnable == true
         } else {
             onDeleteLongPressUp.set(true)
             deleteLongPress()

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -73,7 +73,8 @@
             android:title="入力待機時間"
             app:min="1"
             app:showSeekBarValue="true"
-            app:summary="ライブ変換やケータイ打ちで次の入力を待つ時間（ミリ秒）" />
+            android:dependency=""
+            app:summary="ケータイ打ちで次の入力を待つ時間（ミリ秒）" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="バイブレーション">

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/PetalFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/PetalFlickInputController.kt
@@ -8,6 +8,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.WindowManager
+import android.widget.Button
 import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
 import com.kazumaproject.custom_keyboard.data.FlickDirection
@@ -39,6 +40,7 @@ class PetalFlickInputController(private val context: Context) {
     private var initialTouchX = 0f
     private var initialTouchY = 0f
     private val flickThreshold = 80f
+    private var originalKeyText: CharSequence? = null
 
     // 各方向に対応するPopupWindowを保持するMap
     private val popupMap: MutableMap<FlickDirection, PopupWindow> = mutableMapOf()
@@ -245,6 +247,11 @@ class PetalFlickInputController(private val context: Context) {
                 initialTouchY = event.rawY
                 isLongPressModeActive = false
 
+                (anchorView as? Button)?.let { button ->
+                    originalKeyText = button.text
+                    button.text = ""
+                }
+
                 createPopups()
 
                 // 方向の状態を初期化
@@ -286,6 +293,10 @@ class PetalFlickInputController(private val context: Context) {
                     val finalDirection = calculateDirection(dx, dy)
                     characterMap[finalDirection]?.let { listener?.onFlick(it) }
                 }
+                (anchorView as? Button)?.let { button ->
+                    button.text = originalKeyText
+                }
+                originalKeyText = null
                 dismissAllPopups()
                 return true
             }


### PR DESCRIPTION
## 概要
これまでの実装ではライブ変換でコミットするテキストをユーザーがテキストを入力後、
最小で 100 ms の delay で行っていたが、変換結果を取得した即時にコミットするように変更した。
また個人的に使用していて、ライブ変換中にひらがなに戻せると便利なので変換ボタンを長押しするとひらがなに戻るように修正した。

