### PR TITLE
Clipboard Manager のメモリリークの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 438
+        versionCode 439
         versionName "1.0.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/clipboard/ClipboardUtil.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/clipboard/ClipboardUtil.kt
@@ -14,10 +14,10 @@ import timber.log.Timber
  *
  * @property context アプリケーションコンテキスト
  */
-class ClipboardUtil(
-    private val context: Context,
-    private val clipboard: ClipboardManager
-) {
+class ClipboardUtil(private val context: Context) {
+
+    private val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+
     /**
      * クリップボードの主要なコンテンツを取得します。
      * 画像の取得を最優先で試み、失敗した場合にテキストの取得を試みます。

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
@@ -28,6 +28,7 @@ import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.M
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_7_8
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_8_9
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_9_10
+import com.kazumaproject.markdownhelperkeyboard.ime_service.clipboard.ClipboardUtil
 import com.kazumaproject.markdownhelperkeyboard.ime_service.models.PressedKeyStatus
 import com.kazumaproject.markdownhelperkeyboard.learning.database.LearnDao
 import com.kazumaproject.markdownhelperkeyboard.learning.multiple.LearnMultiple
@@ -124,6 +125,11 @@ object AppModule {
             init(context)
         }
     }
+
+    @Singleton
+    @Provides
+    fun providesClipboardUtil(@ApplicationContext context: Context): ClipboardUtil =
+        ClipboardUtil(context)
 
     @Singleton
     @Provides


### PR DESCRIPTION
## 概要
Clipboard Manager  を宣言するときに `applicationContext` が必要。