### PR TITLE
ライブ変換中のチラつきを無くす試み

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,7 +29,7 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 443
+        versionCode 444
         versionName "1.0.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -3102,7 +3102,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private suspend fun handleTenKeyQwertyInput(string: String) {
         val spannable = createSpannableWithTail(string)
         _suggestionFlag.emit(CandidateShowFlag.Updating)
-
+        if (!(isLiveConversionEnable == true && isFlickOnlyMode == true)) {
+            setComposingTextPreEdit(
+                string,
+                spannable
+            )
+        }
         if (isLiveConversionEnable != true) {
             // ライブ変換が無効な場合は、入力されたテキストをそのまま表示します。
             setComposingTextAfterEdit(string, spannable)
@@ -3114,7 +3119,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
      */
     private suspend fun handleDefaultInput(string: String) {
         val spannable = createSpannableWithTail(string)
-        setComposingTextPreEdit(string, spannable)
+        if (!(isLiveConversionEnable == true && isFlickOnlyMode == true)) {
+            setComposingTextPreEdit(
+                string,
+                spannable
+            )
+        }
         _suggestionFlag.emit(CandidateShowFlag.Updating)
         val timeToDelay = delayTime?.toLong() ?: DEFAULT_DELAY_MS
         delay(timeToDelay)


### PR DESCRIPTION
## 概要
ライブ変換が ON の場合、PreEditText をコミットしないことでチラつきなくす。