### PR TITLE
スミレ入力の方式を変更した際に、１フリック目に前の設定が反映されるバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 455
-        versionName "1.4.334"
+        versionCode 456
+        versionName "1.4.335"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -71,7 +71,6 @@ import com.kazumaproject.core.domain.state.TenKeyQWERTYMode
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyAction
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
-import com.kazumaproject.custom_keyboard.data.KeyboardLayout
 import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
 import com.kazumaproject.data.clicked_symbol.ClickedSymbol
 import com.kazumaproject.data.emoji.Emoji
@@ -407,14 +406,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private val cachedEnglishDrawable: Drawable? by lazy {
         ContextCompat.getDrawable(
             applicationContext, com.kazumaproject.core.R.drawable.english_small
-        )
-    }
-
-    private val hiraganaLayout: KeyboardLayout? by lazy {
-        KeyboardDefaultLayouts.createFinalLayout(
-            mode = KeyboardInputMode.HIRAGANA, dynamicKeyStates = mapOf(
-                "enter_key" to 0, "dakuten_toggle_key" to 0
-            ), inputType = sumireInputKeyType ?: "flick-default"
         )
     }
 
@@ -1637,9 +1628,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     customLayoutDefault.isVisible = true
                     keyboardView.setCurrentMode(InputMode.ModeJapanese)
                     if (qwertyMode.value != TenKeyQWERTYMode.Number) {
-                        hiraganaLayout?.let { layout ->
-                            customLayoutDefault.setKeyboard(layout)
-                        }
+                        val hiraganaLayout = KeyboardDefaultLayouts.createFinalLayout(
+                            mode = KeyboardInputMode.HIRAGANA, dynamicKeyStates = mapOf(
+                                "enter_key" to 0, "dakuten_toggle_key" to 0
+                            ), inputType = sumireInputKeyType ?: "flick-default"
+                        )
+                        customLayoutDefault.setKeyboard(hiraganaLayout)
                         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.Sumire }
                     } else {
                         customLayoutDefault.setKeyboard(KeyboardDefaultLayouts.createNumberLayout())


### PR DESCRIPTION
## 概要
調査の結果、スミレ入力のレイアウトを lazy で読み込むことが原因で入力方式を変更しても１フリック目に変更前の設定が反映されてしまうことがわかった。
lazy を使わずにレイアウトを読み込むように修正した。

https://github.com/KazumaProject/JapaneseKeyboard/discussions/85#discussioncomment-13781712