### PR TITLE
Google Document 内でトグル入力の場合、Google Document のアプリがクラッシュするバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 458
-        versionName "1.4.337"
+        versionCode 459
+        versionName "1.4.338"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1796,7 +1796,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         mainView.customLayoutDefault.setOnKeyboardActionListener(object :
             com.kazumaproject.custom_keyboard.view.FlickKeyboardView.OnKeyboardActionListener {
 
-            override fun onKey(text: String) {
+            override fun onKey(text: String, isFlick: Boolean) {
                 // 通常の文字が入力された場合（変更なし）
                 clearDeleteBufferWithView()
                 Timber.d("onKey: $text")
@@ -1809,12 +1809,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             if (isCustomLayoutRomajiMode) {
                                 romajiConverter?.let { converter ->
                                     handleOnKeyForSumire(
-                                        converter.convert(text), mainView
+                                        converter.convert(text), mainView, isFlick
                                     )
                                 }
                             } else {
                                 handleOnKeyForSumire(
-                                    text, mainView
+                                    text, mainView, isFlick
                                 )
                             }
                         } else {
@@ -1826,13 +1826,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     TenKeyQWERTYMode.Sumire -> {
                         handleOnKeyForSumire(
-                            text, mainView
+                            text, mainView, isFlick
                         )
                     }
 
                     TenKeyQWERTYMode.Number -> {
                         handleOnKeyForSumire(
-                            text, mainView
+                            text, mainView, isFlick
                         )
                     }
 
@@ -2268,16 +2268,21 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun handleOnKeyForSumire(
-        text: String, mainView: MainLayoutBinding
+        text: String,
+        mainView: MainLayoutBinding,
+        isFlick: Boolean
     ) {
         val insertString = inputString.value
         val sb = StringBuilder()
-        val isFlickInputMode = appPreference.flick_input_only_preference ?: false
         text.forEach {
-            if (isFlickInputMode) {
+            if (isFlickOnlyMode == true) {
                 handleFlick(char = it, insertString, sb, mainView)
             } else {
-                handleTap(char = it, insertString, sb, mainView)
+                if (isFlick) {
+                    handleFlick(char = it, insertString, sb, mainView)
+                } else {
+                    handleTap(char = it, insertString, sb, mainView)
+                }
             }
         }
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -19,7 +19,6 @@ import android.os.Vibrator
 import android.os.VibratorManager
 import android.text.Spannable
 import android.text.SpannableString
-import android.text.TextUtils
 import android.text.style.BackgroundColorSpan
 import android.text.style.UnderlineSpan
 import android.view.Gravity
@@ -4253,19 +4252,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 )
             }
         } else {
-            // Use TextUtils.getOffsetBefore to handle surrogate pairs
-            val lastCharStart = TextUtils.getOffsetBefore(inputString, inputLength)
-
             spannableString.apply {
                 setSpan(
-                    BackgroundColorSpan(getColor(com.kazumaproject.core.R.color.green)),
-                    0,
-                    lastCharStart,
-                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE or Spannable.SPAN_COMPOSING
-                )
-                setSpan(
                     BackgroundColorSpan(getColor(com.kazumaproject.core.R.color.char_in_edit_color)),
-                    lastCharStart,
+                    0,
                     inputLength,
                     Spannable.SPAN_EXCLUSIVE_EXCLUSIVE or Spannable.SPAN_COMPOSING
                 )

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -2792,7 +2792,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             var prevFlag: CandidateShowFlag? = null
             suggestionFlag.collectLatest { currentFlag ->
                 if (prevFlag == CandidateShowFlag.Idle && currentFlag == CandidateShowFlag.Updating) {
-                    animateSuggestionImageViewVisibility(mainView.suggestionVisibility, true)
+                    if (!mainView.suggestionVisibility.isVisible) {
+                        animateSuggestionImageViewVisibility(mainView.suggestionVisibility, true)
+                    }
                     if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY && mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                         mainView.qwertyView.apply {
                             setSpaceKeyText("変換")

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/PetalFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/PetalFlickInputController.kt
@@ -31,7 +31,7 @@ class PetalFlickInputController(
 ) {
 
     interface PetalFlickListener {
-        fun onFlick(character: String)
+        fun onFlick(character: String, isFlick: Boolean)
     }
 
     var listener: PetalFlickListener? = null
@@ -293,7 +293,12 @@ class PetalFlickInputController(
                     val dx = event.rawX - initialTouchX
                     val dy = event.rawY - initialTouchY
                     val finalDirection = calculateDirection(dx, dy)
-                    characterMap[finalDirection]?.let { listener?.onFlick(it) }
+                    characterMap[finalDirection]?.let {
+                        listener?.onFlick(
+                            it,
+                            isFlick = finalDirection != FlickDirection.TAP
+                        )
+                    }
                 }
                 (anchorView as? Button)?.let { button ->
                     button.text = originalKeyText

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -41,7 +41,7 @@ class FlickKeyboardView @JvmOverloads constructor(
 ) : GridLayout(context, attrs, defStyleAttr) {
 
     interface OnKeyboardActionListener {
-        fun onKey(text: String)
+        fun onKey(text: String, isFlick: Boolean)
         fun onAction(action: KeyAction)
         fun onActionLongPress(action: KeyAction)
         fun onActionUpAfterLongPress(action: KeyAction)
@@ -196,7 +196,10 @@ class FlickKeyboardView @JvmOverloads constructor(
 
                                 override fun onFlick(direction: FlickDirection, character: String) {
                                     if (character.isNotEmpty()) {
-                                        this@FlickKeyboardView.listener?.onKey(character)
+                                        this@FlickKeyboardView.listener?.onKey(
+                                            text = character,
+                                            isFlick = direction != FlickDirection.TAP
+                                        )
                                     }
                                 }
 
@@ -236,7 +239,8 @@ class FlickKeyboardView @JvmOverloads constructor(
                                 override fun onFlick(flickAction: FlickAction) {
                                     when (flickAction) {
                                         is FlickAction.Input -> this@FlickKeyboardView.listener?.onKey(
-                                            flickAction.char
+                                            flickAction.char,
+                                            isFlick = true
                                         )
 
                                         is FlickAction.Action -> this@FlickKeyboardView.listener?.onAction(
@@ -298,7 +302,10 @@ class FlickKeyboardView @JvmOverloads constructor(
                             this.listener =
                                 object : StandardFlickInputController.StandardFlickListener {
                                     override fun onFlick(character: String) {
-                                        this@FlickKeyboardView.listener?.onKey(character)
+                                        this@FlickKeyboardView.listener?.onKey(
+                                            character,
+                                            isFlick = true
+                                        )
                                     }
                                 }
 
@@ -365,8 +372,11 @@ class FlickKeyboardView @JvmOverloads constructor(
                             elevation = 1f
 
                             this.listener = object : PetalFlickInputController.PetalFlickListener {
-                                override fun onFlick(character: String) {
-                                    this@FlickKeyboardView.listener?.onKey(character)
+                                override fun onFlick(character: String, isFlick: Boolean) {
+                                    this@FlickKeyboardView.listener?.onKey(
+                                        character,
+                                        isFlick = isFlick
+                                    )
                                 }
                             }
                             val stringMap = flickActionMap.mapValues { (_, flickAction) ->


### PR DESCRIPTION
## Issue
#166 

## 概要
Google Document  のアプリ内でトグル入力をすると Google Document のアプリがクラッシュしてしまう。
調査の結果、`setComposingTextPreEdit` の span の設定方法に問題があったので修正。