### PR TITLE
カスタムキーボードを複製した時に複製元が空のレイアウトになるバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 467
-        versionName "1.4.346"
+        versionCode 468
+        versionName "1.4.347"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -970,6 +970,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         }
 
                         KeyEvent.KEYCODE_ENTER -> {
+                            if (mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
+                                val stringWithLastCharN =
+                                    romajiConverter?.flush(insertString)?.first ?: insertString
+                                commitText(stringWithLastCharN, 1)
+                            }
                             if (insertString.isNotEmpty()) {
                                 handleNonEmptyInputEnterKey(suggestions, mainView, insertString)
                             } else {
@@ -5192,8 +5197,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         if (isHenkan.get()) {
                             handleHenkanModeEnterKey(suggestions, inputMode, insertString)
                         } else {
-                            finishInputEnterKey()
-                            setCusrorLeftAfterCloseBracket(insertString)
+                            if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY) {
+                                val lastCharN =
+                                    romajiConverter?.flush(insertString)?.first ?: insertString
+                                commitText(lastCharN, 1)
+                                finishInputEnterKey()
+                                setCusrorLeftAfterCloseBracket(insertString)
+                            } else {
+                                finishInputEnterKey()
+                                setCusrorLeftAfterCloseBracket(insertString)
+                            }
                         }
                     }
 

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/PetalFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/PetalFlickInputController.kt
@@ -26,8 +26,7 @@ import kotlin.math.abs
 import kotlin.math.sqrt
 
 class PetalFlickInputController(
-    private val context: Context,
-    private val flickSensitivity: Int
+    private val context: Context, private val flickSensitivity: Int
 ) {
 
     interface PetalFlickListener {
@@ -88,9 +87,6 @@ class PetalFlickInputController(
         )
 
         val currentAnchor = anchorView ?: return
-        val keyWidth = currentAnchor.width
-        val keyHeight = currentAnchor.height
-        val lengthExtension = 1.4f
 
         directions.forEach { direction ->
             val text = characterMap[direction] ?: ""
@@ -101,31 +97,36 @@ class PetalFlickInputController(
                     setFlickDirection(direction)
                 }
 
-                val popupWidth: Int
-                val popupHeight: Int
-                when (direction) {
-                    FlickDirection.TAP -> {
-                        popupWidth = keyWidth; popupHeight = keyHeight
-                    }
-
+                val popupHeight = when (direction) {
                     FlickDirection.UP, FlickDirection.DOWN -> {
-                        popupWidth = keyWidth; popupHeight = (keyHeight * lengthExtension).toInt()
+                        currentAnchor.height + (currentAnchor.height / 2 - currentAnchor.height / 4)
                     }
 
-                    FlickDirection.UP_LEFT_FAR, FlickDirection.UP_RIGHT_FAR -> {
-                        popupWidth = (keyWidth * lengthExtension).toInt(); popupHeight = keyHeight
+                    FlickDirection.TAP -> {
+                        currentAnchor.height
                     }
 
                     else -> {
-                        popupWidth = keyWidth; popupHeight = keyHeight
+                        currentAnchor.height
+                    }
+                }
+
+                val popupWidth = when (direction) {
+                    FlickDirection.UP, FlickDirection.DOWN -> {
+                        currentAnchor.width
+                    }
+
+                    FlickDirection.TAP -> {
+                        currentAnchor.width
+                    }
+
+                    else -> {
+                        currentAnchor.width + (currentAnchor.width / 2 - currentAnchor.width / 4)
                     }
                 }
 
                 val popup = PopupWindow(
-                    popupView,
-                    popupWidth,
-                    popupHeight,
-                    false
+                    popupView, popupWidth, popupHeight, false
                 ).apply {
                     isClippingEnabled = false
                     elevation = 8f
@@ -295,8 +296,7 @@ class PetalFlickInputController(
                     val finalDirection = calculateDirection(dx, dy)
                     characterMap[finalDirection]?.let {
                         listener?.onFlick(
-                            it,
-                            isFlick = finalDirection != FlickDirection.TAP
+                            it, isFlick = finalDirection != FlickDirection.TAP
                         )
                     }
                 }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/AutoSizeButton.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/AutoSizeButton.kt
@@ -1,0 +1,57 @@
+package com.kazumaproject.custom_keyboard.view
+
+import android.content.Context
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.util.TypedValue
+import androidx.appcompat.widget.AppCompatButton
+
+class AutoSizeButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.appcompat.R.attr.buttonStyle
+) : AppCompatButton(context, attrs, defStyleAttr) {
+
+    private val textBounds = Rect()
+
+    override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {
+        super.onSizeChanged(w, h, oldw, oldh)
+        if (w > 0 && h > 0) {
+            adjustTextSize(w, h)
+        }
+    }
+
+    private fun adjustTextSize(buttonWidth: Int, buttonHeight: Int) {
+        if (text.isNullOrEmpty() || buttonWidth <= 0 || buttonHeight <= 0) return
+
+        val defaultSpSize = 14f
+        var currentTextSizePx = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_SP,
+            defaultSpSize,
+            context.resources.displayMetrics
+        )
+        paint.textSize = currentTextSizePx
+
+        // ★修正点1: 利用可能な「高さ」も計算する
+        val availableWidth = buttonWidth - paddingLeft - paddingRight
+        val availableHeight = buttonHeight - paddingTop - paddingBottom
+
+        paint.getTextBounds(text.toString(), 0, text.length, textBounds)
+
+        // ★修正点2: 条件を更新 -> 幅「または」高さがはみ出す場合に縮小を開始
+        if (textBounds.width() > availableWidth || textBounds.height() > availableHeight) {
+            // ★修正点3: ループ条件も更新 -> 幅「または」高さが収まるまでループ
+            while (textBounds.width() > availableWidth || textBounds.height() > availableHeight) {
+                currentTextSizePx -= 1f // 1ピクセルずつ小さくする
+                if (currentTextSizePx <= 2f) { // 小さくなりすぎないように下限を設定
+                    break
+                }
+                paint.textSize = currentTextSizePx
+                paint.getTextBounds(text.toString(), 0, text.length, textBounds)
+            }
+        }
+
+        // 最終的なテキストサイズをピクセル単位で設定
+        setTextSize(TypedValue.COMPLEX_UNIT_PX, currentTextSizePx)
+    }
+}


### PR DESCRIPTION
## Issue
#191 #183 

## 概要
- カスタムキーボードを複製した時に複製元が空のレイアウトになるバグの修正
- 末尾が「n」で確定した場合、「ん」に変換する

[demo_n.webm](https://github.com/user-attachments/assets/4cad9e26-0060-4483-9718-d15e274f6f52)
