### PR TITLE
ショートカットキーとデフォルトのローマ字変換の修正

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1041,21 +1041,23 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     event?.let { e ->
                         Timber.d("onKeyDown: ${e.keyCode} $keyCode $e")
                         if (e.isShiftPressed || e.isCapsLockOn) {
-                            val char = PhysicalShiftKeyCodeMap.keymap[keyCode]
-                            char?.let { c ->
-                                if (insertString.isNotEmpty()) {
-                                    sb.append(
-                                        insertString
-                                    ).append(c)
-                                    _inputString.update {
-                                        sb.toString()
+                            if (insertString.isNotEmpty()) {
+                                val char = PhysicalShiftKeyCodeMap.keymap[keyCode]
+                                char?.let { c ->
+                                    if (insertString.isNotEmpty()) {
+                                        sb.append(
+                                            insertString
+                                        ).append(c)
+                                        _inputString.update {
+                                            sb.toString()
+                                        }
+                                    } else {
+                                        _inputString.update {
+                                            c.toString()
+                                        }
                                     }
-                                } else {
-                                    _inputString.update {
-                                        c.toString()
-                                    }
+                                    return true
                                 }
-                                return true
                             }
                             return super.onKeyDown(keyCode, event)
                         } else if (e.isCtrlPressed) {
@@ -1082,42 +1084,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 mainView.keyboardView.setCurrentMode(inputMode)
 
                                 showFloatingModeSwitchView(showInputModeText)
+                                finishComposingText()
+                                _inputString.update { "" }
                                 return true
                             }
-                            val char = PhysicalShiftKeyCodeMap.keymap[keyCode]
-                            char?.let { c ->
-                                Timber.d("isCtrlPressed: $c")
-                                when (c) {
-                                    'A' -> {
-                                        selectAllText()
-                                        return true
-                                    }
-
-                                    'C' -> {
-                                        copyAction()
-                                        return true
-                                    }
-
-                                    'V' -> {
-                                        pasteAction()
-                                        return true
-                                    }
-
-                                    'X' -> {
-                                        cutAction()
-                                        return true
-                                    }
-
-                                    'W' -> {
-                                        showOrHideKeyboard()
-                                        return true
-                                    }
-
-                                    else -> {
-
-                                    }
-                                }
-                            }
+                            if (insertString.isNotEmpty()) return true
+                            return super.onKeyDown(keyCode, event)
                         }
                     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/RomajiMapRepository.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/RomajiMapRepository.kt
@@ -190,6 +190,11 @@ class RomajiMapRepository @Inject constructor(
             "ze" to Pair("ぜ", 2),
             "zo" to Pair("ぞ", 2),
 
+            "jya" to Pair("じゃ", 3),
+            "jyi" to Pair("じぃ", 3),
+            "jyu" to Pair("じゅ", 3),
+            "jye" to Pair("じぇ", 3),
+            "jyo" to Pair("じょ", 3),
             "ja" to Pair("じゃ", 2),
             "ji" to Pair("じ", 2),
             "ju" to Pair("じゅ", 2),


### PR DESCRIPTION
## Issue
#218 #219 

## 概要
### デフォルトのローマ字のキーマップに以下の変換を追加
- jya じゃ
- jyi じぃ
- jyu じゅ
- jye じぇ
- jyo じょ

デフォルトのキーマップはアプリ起動後１度しか生成されないのでアプリのデータを削除して再生成する必要がある

### ショートカットキー
`onKeyDown` でキーボードアプリで使用しないコマンドは従来通りの挙動にするように修正