### PR TITLE
２段フリック入力の実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 481
-        versionName "1.4.360"
+        versionCode 482
+        versionName "1.4.361"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -3762,9 +3762,43 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         if (customLayoutDefault.isVisible) customLayoutDefault.visibility =
                             View.INVISIBLE
                     } else {
-                        animateViewVisibility(
-                            if (isTablet == true) this.tabletView else this.keyboardView, true
-                        )
+                        if (isTablet == true) {
+                            when (qwertyMode.value) {
+                                TenKeyQWERTYMode.Custom -> {
+                                    animateViewVisibility(
+                                        this.customLayoutDefault, true
+                                    )
+                                }
+
+                                TenKeyQWERTYMode.Default -> {
+                                    animateViewVisibility(
+                                        this.tabletView, true
+                                    )
+                                }
+
+                                TenKeyQWERTYMode.Number -> {
+                                    animateViewVisibility(
+                                        this.customLayoutDefault, true
+                                    )
+                                }
+
+                                TenKeyQWERTYMode.Sumire -> {
+                                    animateViewVisibility(
+                                        this.customLayoutDefault, true
+                                    )
+                                }
+
+                                TenKeyQWERTYMode.TenKeyQWERTY -> {
+                                    animateViewVisibility(
+                                        this.qwertyView, true
+                                    )
+                                }
+                            }
+                        } else {
+                            animateViewVisibility(
+                                if (isTablet == true) this.tabletView else this.keyboardView, true
+                            )
+                        }
                         animateViewVisibility(keyboardSymbolView, false)
                         suggestionRecyclerView.isVisible = true
                         if (customLayoutDefault.isInvisible) customLayoutDefault.visibility =

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -66,7 +66,6 @@ import com.kazumaproject.core.data.clicked_symbol.SymbolMode
 import com.kazumaproject.core.data.clipboard.ClipboardItem
 import com.kazumaproject.core.data.floating_candidate.CandidateItem
 import com.kazumaproject.core.domain.extensions.dpToPx
-import com.kazumaproject.core.domain.extensions.hiraganaToHankakuKatakana
 import com.kazumaproject.core.domain.extensions.hiraganaToKatakana
 import com.kazumaproject.core.domain.extensions.toHankakuKatakana
 import com.kazumaproject.core.domain.extensions.toHiragana
@@ -109,6 +108,7 @@ import com.kazumaproject.markdownhelperkeyboard.ime_service.clipboard.ClipboardU
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.correctReading
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getCurrentInputTypeForIME
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getLastCharacterAsString
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isAllEnglishLetters
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isOnlyTwoCharBracketPair
 import com.kazumaproject.markdownhelperkeyboard.ime_service.floating_view.BubbleTextView
 import com.kazumaproject.markdownhelperkeyboard.ime_service.floating_view.FloatingDockListener
@@ -1103,8 +1103,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         KeyEvent.KEYCODE_F6 -> {
                             if (insertString.isNotEmpty()) {
                                 Timber.d("onKeyDown: F6 Pressed $insertString")
-                                _inputString.update {
-                                    insertString.toHiragana()
+                                if (insertString.isAllEnglishLetters()) {
+                                    romajiConverter?.let { converter ->
+                                        _inputString.update {
+                                            converter.convert(insertString.lowercase()).toHiragana()
+                                        }
+                                    }
+                                } else {
+                                    _inputString.update {
+                                        insertString.toHiragana()
+                                    }
                                 }
                                 return true
                             }
@@ -1113,8 +1121,17 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         KeyEvent.KEYCODE_F7 -> {
                             if (insertString.isNotEmpty()) {
                                 Timber.d("onKeyDown: F7 Pressed $insertString")
-                                _inputString.update {
-                                    insertString.toZenkakuKatakana()
+                                if (insertString.isAllEnglishLetters()) {
+                                    romajiConverter?.let { converter ->
+                                        _inputString.update {
+                                            converter.convert(insertString.lowercase())
+                                                .toZenkakuKatakana()
+                                        }
+                                    }
+                                } else {
+                                    _inputString.update {
+                                        insertString.toZenkakuKatakana()
+                                    }
                                 }
                                 return true
                             }
@@ -1123,19 +1140,55 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         KeyEvent.KEYCODE_F8 -> {
                             if (insertString.isNotEmpty()) {
                                 Timber.d("onKeyDown: F8 Pressed $insertString")
-                                _inputString.update {
-                                    insertString.toHankakuKatakana()
+                                if (insertString.isAllEnglishLetters()) {
+                                    romajiConverter?.let { converter ->
+                                        _inputString.update {
+                                            converter.convert(insertString.lowercase())
+                                                .toHankakuKatakana()
+                                        }
+                                    }
+                                } else {
+                                    _inputString.update {
+                                        insertString.toHankakuKatakana()
+                                    }
                                 }
                                 return true
                             }
                         }
 
                         KeyEvent.KEYCODE_F9 -> {
-                            Timber.d("onKeyDown: F9 Pressed")
+                            if (insertString.isNotEmpty()) {
+                                Timber.d("onKeyDown: F9 Pressed")
+                                if (insertString.isAllEnglishLetters()) {
+                                    _inputString.update {
+                                        insertString.lowercase().uppercase()
+                                    }
+                                } else {
+                                    romajiConverter?.let { converter ->
+                                        _inputString.update {
+                                            converter.hiraganaToRomaji(insertString.toHiragana())
+                                                .uppercase()
+                                        }
+                                    }
+                                }
+                            }
                         }
 
                         KeyEvent.KEYCODE_F10 -> {
-                            Timber.d("onKeyDown: F10 Pressed")
+                            if (insertString.isNotEmpty()) {
+                                Timber.d("onKeyDown: F10 Pressed ${insertString.isAllEnglishLetters()} ${insertString.lowercase()}")
+                                if (insertString.isAllEnglishLetters()) {
+                                    _inputString.update {
+                                        insertString.lowercase()
+                                    }
+                                } else {
+                                    romajiConverter?.let { converter ->
+                                        _inputString.update {
+                                            converter.hiraganaToRomaji(insertString.toHiragana())
+                                        }
+                                    }
+                                }
+                            }
                         }
 
                         KeyEvent.KEYCODE_DEL -> {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1438,6 +1438,19 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 scope.launch {
                                     _physicalKeyboardEnable.emit(true)
                                 }
+                                if (isHenkan.get()) {
+                                    listAdapter.selectHighlightedItem()
+                                    scope.launch {
+                                        delay(64)
+                                        romajiConverter?.handleKeyEvent(e)?.let { romajiResult ->
+                                            Timber.d("KeyEvent Key Henkan: $e\n$insertString\n${romajiResult.first}")
+                                            _inputString.update {
+                                                romajiResult.first
+                                            }
+                                        }
+                                    }
+                                    return true
+                                }
                                 if (hardKeyboardShiftPressd) {
                                     val char = PhysicalShiftKeyCodeMap.keymap[keyCode]
                                     char?.let { c ->

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1441,7 +1441,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 if (isHenkan.get()) {
                                     listAdapter.selectHighlightedItem()
                                     scope.launch {
-                                        delay(64)
+                                        delay(32)
                                         romajiConverter?.handleKeyEvent(e)?.let { romajiResult ->
                                             Timber.d("KeyEvent Key Henkan: $e\n$insertString\n${romajiResult.first}")
                                             _inputString.update {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/FloatingCandidateListAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/FloatingCandidateListAdapter.kt
@@ -125,4 +125,28 @@ class FloatingCandidateListAdapter(
         override fun areContentsTheSame(oldItem: CandidateItem, newItem: CandidateItem): Boolean =
             oldItem == newItem
     }
+
+    /**
+     * ハイライトされているアイテムを選択し、対応するクリックイベントをトリガーします。
+     * アイテムが通常の候補（Suggestion）の場合にのみ onSuggestionClicked を呼び出します。
+     */
+    fun selectHighlightedItem() {
+        // highlightedPosition が有効な範囲にあるか確認
+        if (highlightedPosition == RecyclerView.NO_POSITION || highlightedPosition >= itemCount) {
+            Timber.w("No item selected or invalid position: $highlightedPosition")
+            return
+        }
+
+        // ハイライトされているアイテムがページャー（VIEW_TYPE_PAGER）でないことを確認
+        if (getItemViewType(highlightedPosition) == VIEW_TYPE_SUGGESTION) {
+            getHighlightedItem()?.let { item ->
+                Timber.d("Programmatically selecting item: ${item.word}")
+                onSuggestionClicked?.invoke(item)
+            }
+        } else {
+            // 必要であればページャーが選択された際の処理もここに書ける
+            Timber.d("Highlighted item is a pager. Not triggering onSuggestionClicked.")
+            // onPagerClicked?.invoke() などを呼び出すことも可能
+        }
+    }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
@@ -23,18 +23,13 @@ fun getCurrentInputTypeForIME(editorInfo: EditorInfo): InputTypeForIME {
                 InputType.TYPE_TEXT_FLAG_CAP_SENTENCES -> InputTypeForIME.TextCapSentences
                 InputType.TYPE_TEXT_FLAG_AUTO_CORRECT -> InputTypeForIME.TextAutoCorrect
                 InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE -> InputTypeForIME.TextAutoComplete
-                /**
-                 *  180385 : Gmail content
-                 *  131073 : EditText in Android App
-                 *  409601 : Line
-                 * */
-                InputType.TYPE_TEXT_FLAG_MULTI_LINE, 180385, 409601 -> InputTypeForIME.TextMultiLine
+                InputType.TYPE_TEXT_FLAG_MULTI_LINE,-> InputTypeForIME.TextMultiLine
 
                 /**
                  *  180225 : Twitter Tweet & Messenger
                  *  147457 : Facebook Messenger
                  * */
-                InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE, 180225, 147457 -> InputTypeForIME.TextImeMultiLine
+                InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE -> InputTypeForIME.TextImeMultiLine
                 InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS -> InputTypeForIME.TextNoSuggestion
                 InputType.TYPE_TEXT_VARIATION_URI -> InputTypeForIME.TextUri
                 InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS -> InputTypeForIME.TextEmailAddress
@@ -50,17 +45,7 @@ fun getCurrentInputTypeForIME(editorInfo: EditorInfo): InputTypeForIME {
                 InputType.TYPE_TEXT_VARIATION_PHONETIC -> InputTypeForIME.TextPhonetic
                 InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS -> InputTypeForIME.TextWebEmailAddress
                 InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD -> InputTypeForIME.TextWebPassword
-                /**
-                 * TD Bank Book First, Last Name and Phone Number
-                 * EditTexts in WebView in Chrome
-                 * **/
-                49313 -> {
-                    InputTypeForIME.TextEditTextInWebView
-                }
-
                 524305 -> InputTypeForIME.TextWebSearchView
-                17 -> InputTypeForIME.TextWebSearchViewFireFox
-                294913 -> InputTypeForIME.TextNotCursorUpdate
                 /**
                  *  524465 : Twitter (X) SearchView
                  *  589825 : SearchView in Android App
@@ -73,20 +58,14 @@ fun getCurrentInputTypeForIME(editorInfo: EditorInfo): InputTypeForIME {
                  *  524449: Brave SearchView on the top in WebView
                  *  1: SearchView in Nova Launcher, File Manager App
                  *  65537: SearchView in Default Message App
-                 *  131073: Instagram Search
                  * **/
                 524465, 589825, 1048577, 524289, 540833,
-                177, 573601, 655521, 524449, 131073,
+                177, 573601, 655521, 524449,
                 65537 -> InputTypeForIME.TextSearchView
 
                 1 -> {
                     editorInfo.imeOptions.inputTypeFromImeOptions(editorInfo)
                 }
-                /**
-                 *  33 : Gmail To section
-                 *  442417 : Gmail Subject
-                 * */
-                33, 442417 -> InputTypeForIME.TextNextLine
                 else -> {
                     editorInfo.imeOptions.inputTypeFromImeOptions(editorInfo)
                 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
@@ -28,7 +28,7 @@ fun getCurrentInputTypeForIME(editorInfo: EditorInfo): InputTypeForIME {
                  *  131073 : EditText in Android App
                  *  409601 : Line
                  * */
-                InputType.TYPE_TEXT_FLAG_MULTI_LINE, 180385, 131073, 409601 -> InputTypeForIME.TextMultiLine
+                InputType.TYPE_TEXT_FLAG_MULTI_LINE, 180385, 409601 -> InputTypeForIME.TextMultiLine
 
                 /**
                  *  180225 : Twitter Tweet & Messenger
@@ -73,9 +73,10 @@ fun getCurrentInputTypeForIME(editorInfo: EditorInfo): InputTypeForIME {
                  *  524449: Brave SearchView on the top in WebView
                  *  1: SearchView in Nova Launcher, File Manager App
                  *  65537: SearchView in Default Message App
+                 *  131073: Instagram Search
                  * **/
                 524465, 589825, 1048577, 524289, 540833,
-                177, 573601, 655521, 524449,
+                177, 573601, 655521, 524449, 131073,
                 65537 -> InputTypeForIME.TextSearchView
 
                 1 -> {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
@@ -343,6 +343,10 @@ class SettingFragment : PreferenceFragmentCompat() {
                 "flick-sumire" -> {
                     summary = "スミレ入力"
                 }
+
+                "second-flick" -> {
+                    summary = "２段フリック入力"
+                }
             }
             setOnPreferenceChangeListener { preference, newValue ->
                 if (newValue is String) {
@@ -361,6 +365,10 @@ class SettingFragment : PreferenceFragmentCompat() {
 
                         "flick-sumire" -> {
                             preference.summary = "スミレ入力"
+                        }
+
+                        "second-flick" -> {
+                            preference.summary = "２段フリック入力"
                         }
                     }
                 }

--- a/core/src/main/java/com/kazumaproject/core/domain/extensions/String.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/extensions/String.kt
@@ -22,6 +22,169 @@ fun String.hiraganaToKatakana(): String = buildString {
     }
 }
 
+fun String.toZenkakuKatakana(): String {
+    // 半角カタカナと全角カタカナのマッピング
+    val hankakuToZenkakuMap = mapOf(
+        "ｱ" to "ア", "ｲ" to "イ", "ｳ" to "ウ", "ｴ" to "エ", "ｵ" to "オ",
+        "ｶ" to "カ", "ｷ" to "キ", "ｸ" to "ク", "ｹ" to "ケ", "ｺ" to "コ",
+        "ｻ" to "サ", "ｼ" to "シ", "ｽ" to "ス", "ｾ" to "セ", "ｿ" to "ソ",
+        "ﾀ" to "タ", "ﾁ" to "チ", "ﾂ" to "ツ", "ﾃ" to "テ", "ﾄ" to "ト",
+        "ﾅ" to "ナ", "ﾆ" to "ニ", "ﾇ" to "ヌ", "ﾈ" to "ネ", "ﾉ" to "ノ",
+        "ﾊ" to "ハ", "ﾋ" to "ヒ", "ﾌ" to "フ", "ﾍ" to "ヘ", "ﾎ" to "ホ",
+        "ﾏ" to "マ", "ﾐ" to "ミ", "ﾑ" to "ム", "ﾒ" to "メ", "ﾓ" to "モ",
+        "ﾔ" to "ヤ", "ﾕ" to "ユ", "ﾖ" to "ヨ",
+        "ﾗ" to "ラ", "ﾘ" to "リ", "ﾙ" to "ル", "ﾚ" to "レ", "ﾛ" to "ロ",
+        "ﾜ" to "ワ", "ｦ" to "ヲ", "ﾝ" to "ン",
+        "ｧ" to "ァ", "ｨ" to "ィ", "ｩ" to "ゥ", "ｪ" to "ェ", "ｫ" to "ォ",
+        "ｬ" to "ャ", "ｭ" to "ュ", "ｮ" to "ョ",
+        "ｯ" to "ッ", "ｰ" to "ー",
+        "｡" to "。", "､" to "、", "｢" to "「", "｣" to "」",
+        // 濁点・半濁点付きの変換
+        "ｶﾞ" to "ガ", "ｷﾞ" to "ギ", "ｸﾞ" to "グ", "ｹﾞ" to "ゲ", "ｺﾞ" to "ゴ",
+        "ｻﾞ" to "ザ", "ｼﾞ" to "ジ", "ｽﾞ" to "ズ", "ｾﾞ" to "ゼ", "ｿﾞ" to "ゾ",
+        "ﾀﾞ" to "ダ", "ﾁﾞ" to "ヂ", "ﾂﾞ" to "ヅ", "ﾃﾞ" to "デ", "ﾄﾞ" to "ド",
+        "ﾊﾞ" to "バ", "ﾋﾞ" to "ビ", "ﾌﾞ" to "ブ", "ﾍﾞ" to "ベ", "ﾎﾞ" to "ボ",
+        "ﾊﾟ" to "パ", "ﾋﾟ" to "ピ", "ﾌﾟ" to "プ", "ﾍﾟ" to "ペ", "ﾎﾟ" to "ポ",
+        "ｳﾞ" to "ヴ"
+    )
+
+    val sb = StringBuilder()
+    var i = 0
+    while (i < this.length) {
+        // --- 半角カタカナの処理 ---
+        // 先に濁点・半濁点付きの2文字をチェック
+        if (i + 1 < this.length) {
+            val twoChars = this.substring(i, i + 2)
+            val zenkaku = hankakuToZenkakuMap[twoChars]
+            if (zenkaku != null) {
+                sb.append(zenkaku)
+                i += 2
+                continue
+            }
+        }
+        // 1文字の半角カタカナをチェック
+        val oneChar = this.substring(i, i + 1)
+        val zenkaku = hankakuToZenkakuMap[oneChar]
+        if (zenkaku != null) {
+            sb.append(zenkaku)
+            i += 1
+            continue
+        }
+
+        // --- ひらがな、その他の文字の処理 ---
+        val ch = this[i]
+        when (ch) {
+            // ひらがな (ぁ〜ゖ) を全角カタカナに
+            in '\u3041'..'\u3096' -> sb.append(ch + 0x60)
+            // 繰り返し記号
+            '\u309D' -> sb.append('\u30FD') // ゝ -> ヽ
+            '\u309E' -> sb.append('\u30FE') // ゞ -> ヾ
+            // 上記以外（全角カタカナ、漢字、英数字など）はそのまま
+            else -> sb.append(ch)
+        }
+        i++
+    }
+    return sb.toString()
+}
+
+fun String.hiraganaToHankakuKatakana(): String {
+    val hankakuKatakanaMap = mapOf(
+        'あ' to "ｱ", 'い' to "ｲ", 'う' to "ｳ", 'え' to "ｴ", 'お' to "ｵ",
+        'か' to "ｶ", 'き' to "ｷ", 'く' to "ｸ", 'け' to "ｹ", 'こ' to "ｺ",
+        'さ' to "ｻ", 'し' to "ｼ", 'す' to "ｽ", 'せ' to "ｾ", 'そ' to "ｿ",
+        'た' to "ﾀ", 'ち' to "ﾁ", 'つ' to "ﾂ", 'て' to "ﾃ", 'と' to "ﾄ",
+        'な' to "ﾅ", 'に' to "ﾆ", 'ぬ' to "ﾇ", 'ね' to "ﾈ", 'の' to "ﾉ",
+        'は' to "ﾊ", 'ひ' to "ﾋ", 'ふ' to "ﾌ", 'へ' to "ﾍ", 'ほ' to "ﾎ",
+        'ま' to "ﾏ", 'み' to "ﾐ", 'む' to "ﾑ", 'め' to "ﾒ", 'も' to "ﾓ",
+        'や' to "ﾔ", 'ゆ' to "ﾕ", 'よ' to "ﾖ",
+        'ら' to "ﾗ", 'り' to "ﾘ", 'る' to "ﾙ", 'れ' to "ﾚ", 'ろ' to "ﾛ",
+        'わ' to "ﾜ", 'を' to "ｦ", 'ん' to "ﾝ",
+        'が' to "ｶﾞ", 'ぎ' to "ｷﾞ", 'ぐ' to "ｸﾞ", 'げ' to "ｹﾞ", 'ご' to "ｺﾞ",
+        'ざ' to "ｻﾞ", 'じ' to "ｼﾞ", 'ず' to "ｽﾞ", 'ぜ' to "ｾﾞ", 'ぞ' to "ｿﾞ",
+        'だ' to "ﾀﾞ", 'ぢ' to "ﾁﾞ", 'づ' to "ﾂﾞ", 'で' to "ﾃﾞ", 'ど' to "ﾄﾞ",
+        'ば' to "ﾊﾞ", 'び' to "ﾋﾞ", 'ぶ' to "ﾌﾞ", 'べ' to "ﾍﾞ", 'ぼ' to "ﾎﾞ",
+        'ぱ' to "ﾊﾟ", 'ぴ' to "ﾋﾟ", 'ぷ' to "ﾌﾟ", 'ぺ' to "ﾍﾟ", 'ぽ' to "ﾎﾟ",
+        'ぁ' to "ｧ", 'ぃ' to "ｨ", 'ぅ' to "ｩ", 'ぇ' to "ｪ", 'ぉ' to "ｫ",
+        'ゃ' to "ｬ", 'ゅ' to "ｭ", 'ょ' to "ｮ",
+        'っ' to "ｯ",
+        'ー' to "ｰ",
+        '、' to "､", '。' to "｡",
+        '「' to "｢", '」' to "｣"
+    )
+
+    val sb = StringBuilder()
+    var i = 0
+    while (i < this.length) {
+        // 2文字で構成される濁音・半濁音を先にチェック
+        if (i + 1 < this.length) {
+            val twoChars = this.substring(i, i + 2)
+            if (hankakuKatakanaMap.containsKey(twoChars[0]) && (twoChars[1] == 'ﾞ' || twoChars[1] == 'ﾟ')) {
+                val base = hankakuKatakanaMap[twoChars[0]]
+                val diacritic = if (twoChars[1] == 'ﾞ') "ﾞ" else "ﾟ"
+                sb.append(base).append(diacritic)
+                i += 2
+                continue
+            }
+        }
+
+        val char = this[i]
+        sb.append(hankakuKatakanaMap[char] ?: char)
+        i++
+    }
+    return sb.toString()
+}
+
+fun String.toHankakuKatakana(): String {
+    // ひらがな・全角カタカナから半角カタカナへの統合マッピング
+    val conversionMap = mapOf(
+        'あ' to "ｱ", 'い' to "ｲ", 'う' to "ｳ", 'え' to "ｴ", 'お' to "ｵ",
+        'か' to "ｶ", 'き' to "ｷ", 'く' to "ｸ", 'け' to "ｹ", 'こ' to "ｺ",
+        'さ' to "ｻ", 'し' to "ｼ", 'す' to "ｽ", 'せ' to "ｾ", 'そ' to "ｿ",
+        'た' to "ﾀ", 'ち' to "ﾁ", 'つ' to "ﾂ", 'て' to "ﾃ", 'と' to "ﾄ",
+        'な' to "ﾅ", 'に' to "ﾆ", 'ぬ' to "ﾇ", 'ね' to "ﾈ", 'の' to "ﾉ",
+        'は' to "ﾊ", 'ひ' to "ﾋ", 'ふ' to "ﾌ", 'へ' to "ﾍ", 'ほ' to "ﾎ",
+        'ま' to "ﾏ", 'み' to "ﾐ", 'む' to "ﾑ", 'め' to "ﾒ", 'も' to "ﾓ",
+        'や' to "ﾔ", 'ゆ' to "ﾕ", 'よ' to "ﾖ",
+        'ら' to "ﾗ", 'り' to "ﾘ", 'る' to "ﾙ", 'れ' to "ﾚ", 'ろ' to "ﾛ",
+        'わ' to "ﾜ", 'を' to "ｦ", 'ん' to "ﾝ",
+        'が' to "ｶﾞ", 'ぎ' to "ｷﾞ", 'ぐ' to "ｸﾞ", 'げ' to "ｹﾞ", 'ご' to "ｺﾞ",
+        'ざ' to "ｻﾞ", 'じ' to "ｼﾞ", 'ず' to "ｽﾞ", 'ぜ' to "ｾﾞ", 'ぞ' to "ｿﾞ",
+        'だ' to "ﾀﾞ", 'ぢ' to "ﾁﾞ", 'づ' to "ﾂﾞ", 'で' to "ﾃﾞ", 'ど' to "ﾄﾞ",
+        'ば' to "ﾊﾞ", 'び' to "ﾋﾞ", 'ぶ' to "ﾌﾞ", 'べ' to "ﾍﾞ", 'ぼ' to "ﾎﾞ",
+        'ぱ' to "ﾊﾟ", 'ぴ' to "ﾋﾟ", 'ぷ' to "ﾌﾟ", 'ぺ' to "ﾍﾟ", 'ぽ' to "ﾎﾟ",
+        'ぁ' to "ｧ", 'ぃ' to "ｨ", 'ぅ' to "ｩ", 'ぇ' to "ｪ", 'ぉ' to "ｫ",
+        'ゃ' to "ｬ", 'ゅ' to "ｭ", 'ょ' to "ｮ", 'っ' to "ｯ",
+
+        'ア' to "ｱ", 'イ' to "ｲ", 'ウ' to "ｳ", 'エ' to "ｴ", 'オ' to "ｵ",
+        'カ' to "ｶ", 'キ' to "ｷ", 'ク' to "ｸ", 'ケ' to "ｹ", 'コ' to "ｺ",
+        'サ' to "ｻ", 'シ' to "ｼ", 'ス' to "ｽ", 'セ' to "ｾ", 'ソ' to "ｿ",
+        'タ' to "ﾀ", 'チ' to "ﾁ", 'ツ' to "ﾂ", 'テ' to "ﾃ", 'ト' to "ﾄ",
+        'ナ' to "ﾅ", 'ニ' to "ﾆ", 'ヌ' to "ﾇ", 'ネ' to "ﾈ", 'ノ' to "ﾉ",
+        'ハ' to "ﾊ", 'ヒ' to "ﾋ", 'フ' to "ﾌ", 'ヘ' to "ﾍ", 'ホ' to "ﾎ",
+        'マ' to "ﾏ", 'ミ' to "ﾐ", 'ム' to "ﾑ", 'メ' to "ﾒ", 'モ' to "ﾓ",
+        'ヤ' to "ﾔ", 'ユ' to "ﾕ", 'ヨ' to "ﾖ",
+        'ラ' to "ﾗ", 'リ' to "ﾘ", 'ル' to "ﾙ", 'レ' to "ﾚ", 'ロ' to "ﾛ",
+        'ワ' to "ﾜ", 'ヲ' to "ｦ", 'ン' to "ﾝ", 'ヴ' to "ｳﾞ",
+        'ガ' to "ｶﾞ", 'ギ' to "ｷﾞ", 'グ' to "ｸﾞ", 'ゲ' to "ｹﾞ", 'ゴ' to "ｺﾞ",
+        'ザ' to "ｻﾞ", 'ジ' to "ｼﾞ", 'ズ' to "ｽﾞ", 'ゼ' to "ｾﾞ", 'ゾ' to "ｿﾞ",
+        'ダ' to "ﾀﾞ", 'ヂ' to "ﾁﾞ", 'ヅ' to "ﾂﾞ", 'デ' to "ﾃﾞ", 'ド' to "ﾄﾞ",
+        'バ' to "ﾊﾞ", 'ビ' to "ﾋﾞ", 'ブ' to "ﾌﾞ", 'ベ' to "ﾍﾞ", 'ボ' to "ﾎﾞ",
+        'パ' to "ﾊﾟ", 'ピ' to "ﾋﾟ", 'プ' to "ﾌﾟ", 'ペ' to "ﾍﾟ", 'ポ' to "ﾎﾟ",
+        'ァ' to "ｧ", 'ィ' to "ｨ", 'ゥ' to "ｩ", 'ェ' to "ｪ", 'ォ' to "ｫ",
+        'ャ' to "ｬ", 'ュ' to "ｭ", 'ョ' to "ｮ", 'ッ' to "ｯ",
+
+        'ー' to "ｰ", '、' to "､", '。' to "｡", '「' to "｢", '」' to "｣"
+    )
+
+    return buildString {
+        for (char in this@toHankakuKatakana) {
+            // マップから変換後の文字を取得。なければ元の文字をそのまま使用。
+            append(conversionMap[char] ?: char)
+        }
+    }
+}
+
+
 /**
  * Extension function to convert all Katakana characters in this String to their corresponding Hiragana.
  *
@@ -42,6 +205,75 @@ fun String.katakanaToHiragana(): String = buildString {
             else -> append(ch)
         }
     }
+}
+
+fun String.toHiragana(): String {
+    // 半角カタカナとひらがなのマッピング
+    // 濁音・半濁音は結合後の2文字をキーにする
+    val hankakuKatakanaMap = mapOf(
+        "ｱ" to "あ", "ｲ" to "い", "ｳ" to "う", "ｴ" to "え", "ｵ" to "お",
+        "ｶ" to "か", "ｷ" to "き", "ｸ" to "く", "ｹ" to "け", "ｺ" to "こ",
+        "ｻ" to "さ", "ｼ" to "し", "ｽ" to "す", "ｾ" to "せ", "ｿ" to "そ",
+        "ﾀ" to "た", "ﾁ" to "ち", "ﾂ" to "つ", "ﾃ" to "て", "ﾄ" to "と",
+        "ﾅ" to "な", "ﾆ" to "に", "ﾇ" to "ぬ", "ﾈ" to "ね", "ﾉ" to "の",
+        "ﾊ" to "は", "ﾋ" to "ひ", "ﾌ" to "ふ", "ﾍ" to "へ", "ﾎ" to "ほ",
+        "ﾏ" to "ま", "ﾐ" to "み", "ﾑ" to "む", "ﾒ" to "め", "ﾓ" to "も",
+        "ﾔ" to "や", "ﾕ" to "ゆ", "ﾖ" to "よ",
+        "ﾗ" to "ら", "ﾘ" to "り", "ﾙ" to "る", "ﾚ" to "れ", "ﾛ" to "ろ",
+        "ﾜ" to "わ", "ｦ" to "を", "ﾝ" to "ん",
+        "ｧ" to "ぁ", "ｨ" to "ぃ", "ｩ" to "ぅ", "ｪ" to "ぇ", "ｫ" to "ぉ",
+        "ｬ" to "ゃ", "ｭ" to "ゅ", "ｮ" to "ょ",
+        "ｯ" to "っ", "ｰ" to "ー",
+        "｡" to "。", "､" to "、", "｢" to "「", "｣" to "」", "ﾞ" to "゛", "ﾟ" to "゜",
+
+        // 濁音
+        "ｶﾞ" to "が", "ｷﾞ" to "ぎ", "ｸﾞ" to "ぐ", "ｹﾞ" to "げ", "ｺﾞ" to "ご",
+        "ｻﾞ" to "ざ", "ｼﾞ" to "じ", "ｽﾞ" to "ず", "ｾﾞ" to "ぜ", "ｿﾞ" to "ぞ",
+        "ﾀﾞ" to "だ", "ﾁﾞ" to "ぢ", "ﾂﾞ" to "づ", "ﾃﾞ" to "で", "ﾄﾞ" to "ど",
+        "ﾊﾞ" to "ば", "ﾋﾞ" to "び", "ﾌﾞ" to "ぶ", "ﾍﾞ" to "べ", "ﾎﾞ" to "ぼ",
+
+        // 半濁音
+        "ﾊﾟ" to "ぱ", "ﾋﾟ" to "ぴ", "ﾌﾟ" to "ぷ", "ﾍﾟ" to "ぺ", "ﾎﾟ" to "ぽ"
+    )
+
+    val sb = StringBuilder()
+    var i = 0
+    while (i < this.length) {
+        // 2文字で構成される半角の濁音・半濁音を先にチェック
+        if (i + 1 < this.length) {
+            val twoChars = this.substring(i, i + 2)
+            val hiragana = hankakuKatakanaMap[twoChars]
+            if (hiragana != null) {
+                sb.append(hiragana)
+                i += 2
+                continue
+            }
+        }
+
+        // 1文字の処理
+        val ch = this[i]
+
+        // 1文字の半角カタカナをチェック
+        val singleHankakuHiragana = hankakuKatakanaMap[ch.toString()]
+        if (singleHankakuHiragana != null) {
+            sb.append(singleHankakuHiragana)
+        } else {
+            // 全角カタカナまたはその他の文字の処理
+            when (ch) {
+                // 全角カタカナ (ァ〜ヶ)
+                in '\u30A1'..'\u30F6' -> sb.append(ch - 0x60)
+                // カタカナ長音記号
+                'ー' -> sb.append('ー')
+                // 繰り返し記号
+                '\u30FD' -> sb.append('\u309D') // ヽ -> ゝ
+                '\u30FE' -> sb.append('\u309E') // ヾ -> ゞ
+                // 上記以外はそのまま追加
+                else -> sb.append(ch)
+            }
+        }
+        i++
+    }
+    return sb.toString()
 }
 
 /**

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -28,6 +28,7 @@
         <item>トグル入力 - Default</item>
         <item>フリック入力 - Default</item>
         <item>フリック入力 - Circle</item>
+        <item>２段階フリック入力</item>
         <item>スミレ入力</item>
     </string-array>
 
@@ -35,6 +36,7 @@
         <item>toggle-default</item>
         <item>flick-default</item>
         <item>flick-circle</item>
+        <item>second-flick</item>
         <item>flick-sumire</item>
     </string-array>
 

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -28,7 +28,7 @@
         <item>トグル入力 - Default</item>
         <item>フリック入力 - Default</item>
         <item>フリック入力 - Circle</item>
-        <item>２段階フリック入力</item>
+        <item>２段フリック入力</item>
         <item>スミレ入力</item>
     </string-array>
 

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
@@ -1,7 +1,7 @@
 package com.kazumaproject.custom_keyboard.data
 
 import androidx.annotation.DrawableRes
-import com.kazumaproject.custom_keyboard.view.FlickDirection as TfbiFlickDirection
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection as TfbiFlickDirection
 
 // キーボードの見た目ではなく、入力の「モード」を定義する
 enum class KeyboardInputMode {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
@@ -1,6 +1,7 @@
 package com.kazumaproject.custom_keyboard.data
 
 import androidx.annotation.DrawableRes
+import com.kazumaproject.custom_keyboard.view.FlickDirection as TfbiFlickDirection
 
 // キーボードの見た目ではなく、入力の「モード」を定義する
 enum class KeyboardInputMode {
@@ -45,7 +46,7 @@ sealed class KeyAction {
     data object SwitchToEnglishLayout : KeyAction()
     data object SwitchToNumberLayout : KeyAction()
     data object ShiftKey : KeyAction()
-    data object MoveCustomKeyboardTab: KeyAction()
+    data object MoveCustomKeyboardTab : KeyAction()
 
     // ひらがな・英語用
     data object ToggleDakuten : KeyAction() // 濁点・半濁点・小文字化
@@ -74,7 +75,8 @@ data class KeyboardLayout(
     val flickKeyMaps: Map<String, List<Map<FlickDirection, FlickAction>>>,
     val columnCount: Int,
     val rowCount: Int,
-    val isRomaji: Boolean = false
+    val isRomaji: Boolean = false,
+    val twoStepFlickKeyMaps: Map<String, Map<TfbiFlickDirection, Map<TfbiFlickDirection, String>>> = emptyMap(),
 )
 
 /**
@@ -92,7 +94,9 @@ enum class KeyType {
 
     STANDARD_FLICK,
 
-    PETAL_FLICK
+    PETAL_FLICK,
+
+    TWO_STEP_FLICK
 }
 
 enum class ShapeType {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -7,7 +7,7 @@ import com.kazumaproject.custom_keyboard.data.KeyData
 import com.kazumaproject.custom_keyboard.data.KeyType
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
 import com.kazumaproject.custom_keyboard.data.KeyboardLayout
-import com.kazumaproject.custom_keyboard.view.FlickDirection as TfbiFlickDirection
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 
 object KeyboardDefaultLayouts {
     /**
@@ -4570,7 +4570,7 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.LEFT to mapOf(
                     TfbiFlickDirection.TAP to "あ",
                     TfbiFlickDirection.LEFT to "い",
-                    TfbiFlickDirection.DOWN_LEFT to "ぃ"
+                    TfbiFlickDirection.DOWN_LEFT to "ぃ",
                 ),
                 TfbiFlickDirection.UP to mapOf(
                     TfbiFlickDirection.TAP to "あ",

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -4769,6 +4769,10 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "や",
                 ),
+                TfbiFlickDirection.UP_RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "や",
+                    TfbiFlickDirection.UP_RIGHT to "ゃ",
+                ),
                 TfbiFlickDirection.LEFT to mapOf(
                     TfbiFlickDirection.TAP to "や",
                     TfbiFlickDirection.LEFT to "(",

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -7,6 +7,7 @@ import com.kazumaproject.custom_keyboard.data.KeyData
 import com.kazumaproject.custom_keyboard.data.KeyType
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
 import com.kazumaproject.custom_keyboard.data.KeyboardLayout
+import com.kazumaproject.custom_keyboard.view.FlickDirection as TfbiFlickDirection
 
 object KeyboardDefaultLayouts {
     /**
@@ -76,6 +77,25 @@ object KeyboardDefaultLayouts {
                     KeyboardInputMode.HIRAGANA -> createHiraganaLayout()
                     KeyboardInputMode.ENGLISH -> createEnglishLayout(isUpperCase = false)
                     KeyboardInputMode.SYMBOLS -> createSymbolLayout()
+                }
+            }
+
+            "second-flick" -> {
+                when (mode) {
+                    KeyboardInputMode.HIRAGANA -> {
+                        createTwoStepFlickLayout(isDefaultKey = true)
+                    }
+
+                    KeyboardInputMode.ENGLISH -> {
+                        createFlickEnglishLayout(
+                            isDefaultKey = true,
+                            isUpperCase = false
+                        )
+                    }
+
+                    KeyboardInputMode.SYMBOLS -> {
+                        createFlickNumberLayout(isDefaultKey = true)
+                    }
                 }
             }
 
@@ -4195,6 +4215,537 @@ object KeyboardDefaultLayouts {
         )
 
         return KeyboardLayout(keys, flickMaps, 4, 4)
+    }
+
+    private fun createTwoStepFlickLayout(
+        isDefaultKey: Boolean
+    ): KeyboardLayout {
+        val keys = listOf(
+            KeyData(
+                "SwitchToNumber",
+                0,
+                0,
+                false,
+                KeyAction.SwitchToNumberLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
+            ),
+            KeyData(
+                "SwitchToEnglish",
+                1,
+                0,
+                false,
+                KeyAction.SwitchToEnglishLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+            ),
+            KeyData(
+                "SwitchToKana",
+                2,
+                0,
+                false,
+                KeyAction.SwitchToKanaLayout,
+                isSpecialKey = true,
+                isHiLighted = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+            ),
+            KeyData(
+                "",
+                3,
+                0,
+                false,
+                KeyAction.SwitchToNextIme,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+            ),
+            KeyData(
+                "あ",
+                0,
+                1,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "か",
+                0,
+                2,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "さ",
+                0,
+                3,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "た",
+                1,
+                1,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "な",
+                1,
+                2,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "は",
+                1,
+                3,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "ま",
+                2,
+                1,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "や",
+                2,
+                2,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "ら",
+                2,
+                3,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                dakutenToggleStates[0].label ?: "",
+                3,
+                1,
+                false,
+                dakutenToggleStates[0].action,
+                dynamicStates = dakutenToggleStates,
+                keyId = "dakuten_toggle_key",
+                keyType = KeyType.CROSS_FLICK
+            ),
+            KeyData(
+                "わ",
+                3,
+                2,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "、。?!",
+                3,
+                3,
+                true,
+                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+            ), // Label fixed to match map key
+            KeyData(
+                "Del",
+                0,
+                4,
+                false,
+                KeyAction.Delete,
+                isSpecialKey = true,
+                rowSpan = 1,
+                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+            ),
+            KeyData(
+                spaceConvertStates[0].label ?: "",
+                1,
+                4,
+                true,
+                spaceConvertStates[0].action,
+                dynamicStates = spaceConvertStates,
+                isSpecialKey = true,
+                rowSpan = 1,
+                keyId = "space_convert_key",
+                keyType = KeyType.CROSS_FLICK
+            ),
+            KeyData(
+                "CursorMoveLeft",
+                2,
+                4,
+                false,
+                KeyAction.MoveCursorRight,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
+                keyType = KeyType.CROSS_FLICK,
+            ),
+            KeyData(
+                enterKeyStates[0].label ?: "",
+                3,
+                4,
+                false,
+                enterKeyStates[0].action,
+                dynamicStates = enterKeyStates,
+                isSpecialKey = true,
+                rowSpan = 1,
+                drawableResId = enterKeyStates[0].drawableResId,
+                keyId = "enter_key"
+            )
+        )
+
+        val cursorMoveActionMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.MoveCursorRight,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+            ),
+            FlickDirection.UP_LEFT to FlickAction.Action(
+                KeyAction.MoveCursorLeft,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+            )
+        )
+
+        val spaceActionMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.Space,
+            ),
+            FlickDirection.UP_LEFT to FlickAction.Action(
+                KeyAction.Space,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+            )
+        )
+
+        val conversionActionMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.Convert,
+            ),
+        )
+
+        // 状態0 (^_^): タップ操作のみを持つマップ
+        val emojiStateFlickMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.InputText("^_^"),
+                label = "^_^"
+            )
+            // この状態ではフリックアクションを定義しない
+        )
+
+        // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+        val dakutenStateFlickMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.ToggleDakuten,
+                label = " 小゛゜"
+            ),
+            FlickDirection.UP to FlickAction.Action(
+                KeyAction.InputText("ひらがな小文字"),
+                label = "小"
+            ),
+            FlickDirection.UP_LEFT to FlickAction.Action(
+                KeyAction.InputText("濁点"),
+                label = "゛"
+            ),
+            FlickDirection.UP_RIGHT to FlickAction.Action(
+                KeyAction.InputText("半濁点"),
+                label = "゜"
+            )
+        )
+
+        val a = mapOf(
+            FlickDirection.TAP to FlickAction.Input("あ"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("い"),
+            FlickDirection.UP to FlickAction.Input("う"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え"),
+            FlickDirection.DOWN to FlickAction.Input("お")
+        )
+        val ka = mapOf(
+            FlickDirection.TAP to FlickAction.Input("か"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("き"),
+            FlickDirection.UP to FlickAction.Input("く"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("け"),
+            FlickDirection.DOWN to FlickAction.Input("こ")
+        )
+        val sa = mapOf(
+            FlickDirection.TAP to FlickAction.Input("さ"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("し"),
+            FlickDirection.UP to FlickAction.Input("す"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("せ"),
+            FlickDirection.DOWN to FlickAction.Input("そ")
+        )
+        val ta = mapOf(
+            FlickDirection.TAP to FlickAction.Input("た"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("ち"),
+            FlickDirection.UP to FlickAction.Input("つ"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("て"),
+            FlickDirection.DOWN to FlickAction.Input("と")
+        )
+        val na = mapOf(
+            FlickDirection.TAP to FlickAction.Input("な"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("に"),
+            FlickDirection.UP to FlickAction.Input("ぬ"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ね"),
+            FlickDirection.DOWN to FlickAction.Input("の")
+        )
+        val ha = mapOf(
+            FlickDirection.TAP to FlickAction.Input("は"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("ひ"),
+            FlickDirection.UP to FlickAction.Input("ふ"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("へ"),
+            FlickDirection.DOWN to FlickAction.Input("ほ")
+        )
+        val ma = mapOf(
+            FlickDirection.TAP to FlickAction.Input("ま"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("み"),
+            FlickDirection.UP to FlickAction.Input("む"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("め"),
+            FlickDirection.DOWN to FlickAction.Input("も")
+        )
+        val ya = mapOf(
+            FlickDirection.TAP to FlickAction.Input("や"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
+            FlickDirection.UP to FlickAction.Input("ゆ"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+            FlickDirection.DOWN to FlickAction.Input("よ")
+        )
+        val ra = mapOf(
+            FlickDirection.TAP to FlickAction.Input("ら"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("り"),
+            FlickDirection.UP to FlickAction.Input("る"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("れ"),
+            FlickDirection.DOWN to FlickAction.Input("ろ")
+        )
+        val wa = mapOf(
+            FlickDirection.TAP to FlickAction.Input("わ"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("を"),
+            FlickDirection.UP to FlickAction.Input("ん"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー")
+        )
+        val symbols = mapOf(
+            FlickDirection.TAP to FlickAction.Input("、"),
+            FlickDirection.UP to FlickAction.Input("？"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
+            FlickDirection.DOWN to FlickAction.Input("…")
+        )
+
+        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
+            "CursorMoveLeft" to listOf(cursorMoveActionMap),
+            "あ" to listOf(a),
+            "か" to listOf(ka),
+            "さ" to listOf(sa),
+            "た" to listOf(ta),
+            "な" to listOf(na),
+            "は" to listOf(ha),
+            "ま" to listOf(ma),
+            "や" to listOf(ya),
+            "ら" to listOf(ra),
+            "わ" to listOf(wa),
+            "、。?!" to listOf(symbols),
+        )
+
+        dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+            flickMaps.put(label, listOf(emojiStateFlickMap))
+        }
+        dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+            flickMaps.put(label, listOf(dakutenStateFlickMap))
+        }
+
+        spaceConvertStates.getOrNull(0)?.label?.let { label ->
+            flickMaps.put(label, listOf(spaceActionMap))
+        }
+
+        spaceConvertStates.getOrNull(1)?.label?.let { label ->
+            flickMaps.put(label, listOf(conversionActionMap))
+        }
+
+        // 2段階フリック用の文字マップ (isDefaultKey = true の場合に利用)
+        val twoStepFlickMaps = mapOf(
+            // あ行
+            "あ" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "あ",
+                    TfbiFlickDirection.DOWN to "ぁ"
+                ),
+                TfbiFlickDirection.UP_RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "あ",
+                    TfbiFlickDirection.UP_RIGHT to "ぁ",
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "あ",
+                    TfbiFlickDirection.LEFT to "い",
+                    TfbiFlickDirection.DOWN_LEFT to "ぃ"
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "あ",
+                    TfbiFlickDirection.UP to "う",
+                    TfbiFlickDirection.UP_LEFT to "ぅ"
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "あ",
+                    TfbiFlickDirection.RIGHT to "え",
+                    TfbiFlickDirection.DOWN_RIGHT to "ぇ"
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "あ",
+                    TfbiFlickDirection.DOWN to "お",
+                    TfbiFlickDirection.DOWN_RIGHT to "ぉ",
+                )
+            ),
+            // か行
+            "か" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "か",
+                    TfbiFlickDirection.LEFT to "が"
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "き",
+                    TfbiFlickDirection.LEFT to "ぎ"
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "く",
+                    TfbiFlickDirection.LEFT to "ぐ"
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "け",
+                    TfbiFlickDirection.LEFT to "げ"
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "こ",
+                    TfbiFlickDirection.LEFT to "ご"
+                )
+            ),
+            // さ行
+            "さ" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "さ",
+                    TfbiFlickDirection.LEFT to "ざ"
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "し",
+                    TfbiFlickDirection.LEFT to "じ"
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "す",
+                    TfbiFlickDirection.LEFT to "ず"
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "せ",
+                    TfbiFlickDirection.LEFT to "ぜ"
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "そ",
+                    TfbiFlickDirection.LEFT to "ぞ"
+                )
+            ),
+            // た行
+            "た" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "た",
+                    TfbiFlickDirection.LEFT to "だ"
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "ち",
+                    TfbiFlickDirection.LEFT to "ぢ"
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "つ",
+                    TfbiFlickDirection.LEFT to "づ",
+                    TfbiFlickDirection.DOWN to "っ"
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "て",
+                    TfbiFlickDirection.LEFT to "で"
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "と",
+                    TfbiFlickDirection.LEFT to "ど"
+                )
+            ),
+            // な行
+            "な" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "な"),
+                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "に"),
+                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "ぬ"),
+                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "ね"),
+                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "の")
+            ),
+            // は行
+            "は" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.LEFT to "ば",
+                    TfbiFlickDirection.RIGHT to "ぱ"
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "ひ",
+                    TfbiFlickDirection.LEFT to "び",
+                    TfbiFlickDirection.RIGHT to "ぴ"
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "ふ",
+                    TfbiFlickDirection.LEFT to "ぶ",
+                    TfbiFlickDirection.RIGHT to "ぷ"
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "へ",
+                    TfbiFlickDirection.LEFT to "べ",
+                    TfbiFlickDirection.RIGHT to "ぺ"
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "ほ",
+                    TfbiFlickDirection.LEFT to "ぼ",
+                    TfbiFlickDirection.RIGHT to "ぽ"
+                )
+            ),
+            // ま行
+            "ま" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "ま"),
+                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "み"),
+                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "む"),
+                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "め"),
+                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "も")
+            ),
+            // や行
+            "や" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "や",
+                    TfbiFlickDirection.DOWN to "ゃ"
+                ),
+                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "「"),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "ゆ",
+                    TfbiFlickDirection.DOWN to "ゅ"
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "」"),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "よ",
+                    TfbiFlickDirection.DOWN to "ょ"
+                )
+            ),
+            // ら行
+            "ら" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "ら"),
+                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "り"),
+                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "る"),
+                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "れ"),
+                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "ろ")
+            ),
+            // わ行
+            "わ" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "わ"),
+                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "を"),
+                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "ん"),
+                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "ー"),
+                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "〜")
+            ),
+            // 記号
+            "、。?!" to mapOf(
+                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "、"),
+                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "。"),
+                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "？"),
+                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "！"),
+                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "…")
+            )
+        )
+
+        return KeyboardLayout(keys, flickMaps, 5, 4, twoStepFlickKeyMaps = twoStepFlickMaps)
     }
 
 }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -87,14 +87,14 @@ object KeyboardDefaultLayouts {
                     }
 
                     KeyboardInputMode.ENGLISH -> {
-                        createFlickEnglishLayout(
+                        createEnglishStandardFlickLayout(
                             isDefaultKey = true,
                             isUpperCase = false
                         )
                     }
 
                     KeyboardInputMode.SYMBOLS -> {
-                        createFlickNumberLayout(isDefaultKey = true)
+                        createSymbolStandardFlickLayout(isDefaultKey = true)
                     }
                 }
             }
@@ -4222,32 +4222,33 @@ object KeyboardDefaultLayouts {
     ): KeyboardLayout {
         val keys = listOf(
             KeyData(
-                "SwitchToNumber",
+                "PasteActionKey",
                 0,
                 0,
                 false,
-                KeyAction.SwitchToNumberLayout,
+                KeyAction.Paste,
                 isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
+                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
+                keyType = KeyType.CROSS_FLICK
             ),
             KeyData(
-                "SwitchToEnglish",
+                "CursorMoveLeft",
                 1,
                 0,
                 false,
-                KeyAction.SwitchToEnglishLayout,
+                KeyAction.MoveCursorLeft,
                 isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
+                keyType = KeyType.CROSS_FLICK,
             ),
             KeyData(
-                "SwitchToKana",
+                "モード",
                 2,
                 0,
                 false,
-                KeyAction.SwitchToKanaLayout,
+                KeyAction.ChangeInputMode,
                 isSpecialKey = true,
-                isHiLighted = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
             ),
             KeyData(
                 "",
@@ -4368,37 +4369,41 @@ object KeyboardDefaultLayouts {
                 keyType = KeyType.CROSS_FLICK
             ),
             KeyData(
-                "CursorMoveLeft",
-                2,
-                4,
-                false,
-                KeyAction.MoveCursorRight,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
-                keyType = KeyType.CROSS_FLICK,
-            ),
-            KeyData(
                 enterKeyStates[0].label ?: "",
-                3,
+                2,
                 4,
                 false,
                 enterKeyStates[0].action,
                 dynamicStates = enterKeyStates,
                 isSpecialKey = true,
-                rowSpan = 1,
+                rowSpan = 2,
                 drawableResId = enterKeyStates[0].drawableResId,
                 keyId = "enter_key"
             )
         )
 
+        val pasteActionMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.Paste,
+                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+            ),
+            FlickDirection.UP to FlickAction.Action(
+                KeyAction.SelectAll,
+                drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+            ),
+            FlickDirection.UP_RIGHT to FlickAction.Action(
+                KeyAction.Copy,
+                drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+            )
+        )
         val cursorMoveActionMap = mapOf(
             FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
                 KeyAction.MoveCursorLeft,
                 drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+            ),
+            FlickDirection.UP_RIGHT to FlickAction.Action(
+                KeyAction.MoveCursorRight,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
             )
         )
 
@@ -4427,7 +4432,6 @@ object KeyboardDefaultLayouts {
             )
             // この状態ではフリックアクションを定義しない
         )
-
         // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
         val dakutenStateFlickMap = mapOf(
             FlickDirection.TAP to FlickAction.Action(
@@ -4561,7 +4565,6 @@ object KeyboardDefaultLayouts {
             "あ" to mapOf(
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.DOWN to "ぁ"
                 ),
                 TfbiFlickDirection.UP_RIGHT to mapOf(
                     TfbiFlickDirection.TAP to "あ",
@@ -4592,156 +4595,268 @@ object KeyboardDefaultLayouts {
             "か" to mapOf(
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.LEFT to "が"
+                ),
+                TfbiFlickDirection.UP_RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "か",
+                    TfbiFlickDirection.UP_RIGHT to "が",
                 ),
                 TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "き",
-                    TfbiFlickDirection.LEFT to "ぎ"
+                    TfbiFlickDirection.TAP to "か",
+                    TfbiFlickDirection.LEFT to "き",
+                    TfbiFlickDirection.DOWN_LEFT to "ぎ",
                 ),
                 TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "く",
-                    TfbiFlickDirection.LEFT to "ぐ"
+                    TfbiFlickDirection.TAP to "か",
+                    TfbiFlickDirection.UP to "く",
+                    TfbiFlickDirection.UP_LEFT to "ぐ"
                 ),
                 TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "け",
-                    TfbiFlickDirection.LEFT to "げ"
+                    TfbiFlickDirection.TAP to "か",
+                    TfbiFlickDirection.RIGHT to "け",
+                    TfbiFlickDirection.DOWN_RIGHT to "げ"
                 ),
                 TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "こ",
-                    TfbiFlickDirection.LEFT to "ご"
+                    TfbiFlickDirection.TAP to "か",
+                    TfbiFlickDirection.DOWN to "こ",
+                    TfbiFlickDirection.DOWN_RIGHT to "ご",
                 )
             ),
             // さ行
             "さ" to mapOf(
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.LEFT to "ざ"
+                ),
+                TfbiFlickDirection.UP_RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "さ",
+                    TfbiFlickDirection.UP_RIGHT to "ざ",
                 ),
                 TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "し",
-                    TfbiFlickDirection.LEFT to "じ"
+                    TfbiFlickDirection.TAP to "さ",
+                    TfbiFlickDirection.LEFT to "し",
+                    TfbiFlickDirection.DOWN_LEFT to "じ",
                 ),
                 TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "す",
-                    TfbiFlickDirection.LEFT to "ず"
+                    TfbiFlickDirection.TAP to "さ",
+                    TfbiFlickDirection.UP to "す",
+                    TfbiFlickDirection.UP_LEFT to "ず"
                 ),
                 TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "せ",
-                    TfbiFlickDirection.LEFT to "ぜ"
+                    TfbiFlickDirection.TAP to "さ",
+                    TfbiFlickDirection.RIGHT to "せ",
+                    TfbiFlickDirection.DOWN_RIGHT to "ぜ"
                 ),
                 TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "そ",
-                    TfbiFlickDirection.LEFT to "ぞ"
+                    TfbiFlickDirection.TAP to "さ",
+                    TfbiFlickDirection.DOWN to "そ",
+                    TfbiFlickDirection.DOWN_RIGHT to "ぞ",
                 )
             ),
             // た行
             "た" to mapOf(
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.LEFT to "だ"
+                ),
+                TfbiFlickDirection.UP_RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "た",
+                    TfbiFlickDirection.UP_RIGHT to "だ",
                 ),
                 TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "ち",
-                    TfbiFlickDirection.LEFT to "ぢ"
+                    TfbiFlickDirection.TAP to "た",
+                    TfbiFlickDirection.LEFT to "ち",
+                    TfbiFlickDirection.DOWN_LEFT to "ぢ",
                 ),
                 TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "つ",
-                    TfbiFlickDirection.LEFT to "づ",
-                    TfbiFlickDirection.DOWN to "っ"
+                    TfbiFlickDirection.TAP to "た",
+                    TfbiFlickDirection.UP to "つ",
+                    TfbiFlickDirection.UP_LEFT to "づ",
+                    TfbiFlickDirection.UP_RIGHT to "っ"
                 ),
                 TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "て",
-                    TfbiFlickDirection.LEFT to "で"
+                    TfbiFlickDirection.TAP to "た",
+                    TfbiFlickDirection.RIGHT to "て",
+                    TfbiFlickDirection.DOWN_RIGHT to "で"
                 ),
                 TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "と",
-                    TfbiFlickDirection.LEFT to "ど"
+                    TfbiFlickDirection.TAP to "た",
+                    TfbiFlickDirection.DOWN to "と",
+                    TfbiFlickDirection.DOWN_RIGHT to "ど",
                 )
             ),
             // な行
             "な" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "な"),
-                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "に"),
-                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "ぬ"),
-                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "ね"),
-                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "の")
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "な",
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "な",
+                    TfbiFlickDirection.LEFT to "に",
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "な",
+                    TfbiFlickDirection.UP to "ぬ",
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "な",
+                    TfbiFlickDirection.RIGHT to "ね",
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "な",
+                    TfbiFlickDirection.DOWN to "の",
+                )
             ),
             // は行
             "は" to mapOf(
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.LEFT to "ば",
-                    TfbiFlickDirection.RIGHT to "ぱ"
+                ),
+                TfbiFlickDirection.UP_RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.UP_RIGHT to "ば",
+                ),
+                TfbiFlickDirection.UP_LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.UP_LEFT to "ぱ",
                 ),
                 TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "ひ",
-                    TfbiFlickDirection.LEFT to "び",
-                    TfbiFlickDirection.RIGHT to "ぴ"
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.LEFT to "ひ",
+                    TfbiFlickDirection.DOWN_LEFT to "び",
+                    TfbiFlickDirection.UP_LEFT to "ぴ",
                 ),
                 TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "ふ",
-                    TfbiFlickDirection.LEFT to "ぶ",
-                    TfbiFlickDirection.RIGHT to "ぷ"
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.UP to "ふ",
+                    TfbiFlickDirection.UP_RIGHT to "ぷ",
+                    TfbiFlickDirection.UP_LEFT to "ぶ",
                 ),
                 TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "へ",
-                    TfbiFlickDirection.LEFT to "べ",
-                    TfbiFlickDirection.RIGHT to "ぺ"
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.RIGHT to "へ",
+                    TfbiFlickDirection.DOWN_RIGHT to "べ",
+                    TfbiFlickDirection.UP_RIGHT to "ぺ"
                 ),
                 TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "ほ",
-                    TfbiFlickDirection.LEFT to "ぼ",
-                    TfbiFlickDirection.RIGHT to "ぽ"
+                    TfbiFlickDirection.TAP to "は",
+                    TfbiFlickDirection.DOWN to "ほ",
+                    TfbiFlickDirection.DOWN_RIGHT to "ぼ",
+                    TfbiFlickDirection.DOWN_LEFT to "ぽ",
                 )
             ),
             // ま行
             "ま" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "ま"),
-                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "み"),
-                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "む"),
-                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "め"),
-                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "も")
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "ま",
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "ま",
+                    TfbiFlickDirection.LEFT to "み",
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "ま",
+                    TfbiFlickDirection.UP to "む",
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "ま",
+                    TfbiFlickDirection.RIGHT to "め",
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "ま",
+                    TfbiFlickDirection.DOWN to "も",
+                )
             ),
             // や行
             "や" to mapOf(
                 TfbiFlickDirection.TAP to mapOf(
                     TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.DOWN to "ゃ"
                 ),
-                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "「"),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "や",
+                    TfbiFlickDirection.LEFT to "(",
+                    TfbiFlickDirection.DOWN_LEFT to "「",
+                ),
                 TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "ゆ",
-                    TfbiFlickDirection.DOWN to "ゅ"
+                    TfbiFlickDirection.TAP to "や",
+                    TfbiFlickDirection.UP to "ゆ",
+                    TfbiFlickDirection.UP_LEFT to "ゅ",
                 ),
-                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "」"),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "や",
+                    TfbiFlickDirection.RIGHT to ")",
+                    TfbiFlickDirection.DOWN_RIGHT to "」",
+                ),
                 TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "よ",
-                    TfbiFlickDirection.DOWN to "ょ"
+                    TfbiFlickDirection.TAP to "や",
+                    TfbiFlickDirection.DOWN to "よ",
+                    TfbiFlickDirection.DOWN_RIGHT to "ょ",
                 )
             ),
             // ら行
             "ら" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "ら"),
-                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "り"),
-                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "る"),
-                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "れ"),
-                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "ろ")
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "ら",
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "ら",
+                    TfbiFlickDirection.LEFT to "り",
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "ら",
+                    TfbiFlickDirection.UP to "る",
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "ら",
+                    TfbiFlickDirection.RIGHT to "れ",
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "ら",
+                    TfbiFlickDirection.DOWN to "ろ",
+                )
             ),
             // わ行
             "わ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "わ"),
-                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "を"),
-                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "ん"),
-                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "ー"),
-                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "〜")
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "わ",
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "わ",
+                    TfbiFlickDirection.LEFT to "を",
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "わ",
+                    TfbiFlickDirection.UP to "ん",
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "わ",
+                    TfbiFlickDirection.RIGHT to "ー",
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "わ",
+                    TfbiFlickDirection.DOWN to "〜",
+                )
             ),
             // 記号
             "、。?!" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(TfbiFlickDirection.TAP to "、"),
-                TfbiFlickDirection.LEFT to mapOf(TfbiFlickDirection.TAP to "。"),
-                TfbiFlickDirection.UP to mapOf(TfbiFlickDirection.TAP to "？"),
-                TfbiFlickDirection.RIGHT to mapOf(TfbiFlickDirection.TAP to "！"),
-                TfbiFlickDirection.DOWN to mapOf(TfbiFlickDirection.TAP to "…")
+                TfbiFlickDirection.TAP to mapOf(
+                    TfbiFlickDirection.TAP to "、",
+                ),
+                TfbiFlickDirection.LEFT to mapOf(
+                    TfbiFlickDirection.TAP to "。",
+                    TfbiFlickDirection.LEFT to "、",
+                ),
+                TfbiFlickDirection.UP to mapOf(
+                    TfbiFlickDirection.TAP to "、",
+                    TfbiFlickDirection.UP to "？",
+                    TfbiFlickDirection.UP_LEFT to "：",
+                    TfbiFlickDirection.UP_RIGHT to "・",
+                ),
+                TfbiFlickDirection.RIGHT to mapOf(
+                    TfbiFlickDirection.TAP to "、",
+                    TfbiFlickDirection.RIGHT to "！",
+                ),
+                TfbiFlickDirection.DOWN to mapOf(
+                    TfbiFlickDirection.TAP to "、",
+                    TfbiFlickDirection.DOWN to "…",
+                )
             )
         )
 

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -35,7 +35,6 @@ import com.kazumaproject.custom_keyboard.data.KeyboardLayout
 import com.kazumaproject.custom_keyboard.layout.SegmentedBackgroundDrawable
 import kotlin.math.pow
 import kotlin.math.sqrt
-import com.kazumaproject.custom_keyboard.view.FlickDirection as TfbiFlickDirection
 
 class FlickKeyboardView @JvmOverloads constructor(
     context: Context, attrs: AttributeSet? = null, defStyleAttr: Int = 0

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/TfbiButton.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/TfbiButton.kt
@@ -1,0 +1,337 @@
+package com.kazumaproject.custom_keyboard.view
+
+import android.content.Context
+import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.util.AttributeSet
+import android.view.Gravity
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.ViewGroup
+import android.widget.PopupWindow
+import android.widget.TextView
+import androidx.appcompat.widget.AppCompatButton
+import com.kazumaproject.custom_keyboard.R
+import kotlin.math.atan2
+import kotlin.math.hypot
+
+enum class FlickDirection {
+    UP, DOWN, LEFT, RIGHT,
+    UP_RIGHT, DOWN_RIGHT, DOWN_LEFT, UP_LEFT,
+    TAP
+}
+
+class TfbiButton @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = androidx.appcompat.R.attr.buttonStyle
+) : AppCompatButton(context, attrs, defStyleAttr) {
+
+    interface OnTwoStepFlickListener {
+        fun onFlick(first: FlickDirection, second: FlickDirection)
+    }
+
+    companion object {
+        private const val FIRST_FLICK_THRESHOLD = 65f
+        private const val SECOND_FLICK_THRESHOLD = 40f
+    }
+
+    private enum class FlickState { NEUTRAL, FIRST_FLICK_DETERMINED }
+
+    private var flickState: FlickState = FlickState.NEUTRAL
+    private var firstFlickDirection: FlickDirection = FlickDirection.TAP
+    private var currentSecondFlickDirection: FlickDirection = FlickDirection.TAP
+
+    private var initialTouchX = 0f
+    private var initialTouchY = 0f
+    private var intermediateTouchX = 0f
+    private var intermediateTouchY = 0f
+
+    private val highlightPopupColor = Color.parseColor("#FF6200EE")
+    private val defaultPopupColor = Color.parseColor("#8037474F")
+
+    private var onTwoStepFlickListener: OnTwoStepFlickListener? = null
+    private var characterMapProvider: ((FlickDirection, FlickDirection) -> String)? = null
+    private val petalPopups = mutableMapOf<FlickDirection, PopupWindow>()
+    private var arePopupsVisible: Boolean = false
+
+    fun setOnTwoStepFlickListener(
+        listener: OnTwoStepFlickListener,
+        provider: (FlickDirection, FlickDirection) -> String
+    ) {
+        this.onTwoStepFlickListener = listener
+        this.characterMapProvider = provider
+    }
+
+    override fun onTouchEvent(event: MotionEvent): Boolean {
+        when (event.action) {
+            MotionEvent.ACTION_DOWN -> handleTouchDown(event)
+            MotionEvent.ACTION_MOVE -> handleTouchMove(event)
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> handleTouchUp(event)
+        }
+        return true
+    }
+
+    private fun handleTouchDown(event: MotionEvent) {
+        flickState = FlickState.NEUTRAL
+        firstFlickDirection = FlickDirection.TAP
+        initialTouchX = event.x
+        initialTouchY = event.y
+        // 1段階目のフリック候補（TAPを終点とする文字）からポップアップを生成
+        createPetalPopups(getEnabledFirstFlickDirections())
+    }
+
+    private fun handleTouchMove(event: MotionEvent) {
+        if (flickState == FlickState.NEUTRAL) {
+            val dx = event.x - initialTouchX
+            val dy = event.y - initialTouchY
+            val distance = hypot(dx.toDouble(), dy.toDouble()).toFloat()
+
+            if (distance >= FIRST_FLICK_THRESHOLD) {
+                // 【FIXED】1段階目として有効な方向のみを取得
+                val enabledFirstDirections = getEnabledFirstFlickDirections()
+                val determinedDirection =
+                    calculateDirection(dx, dy, FIRST_FLICK_THRESHOLD, enabledFirstDirections)
+
+                if (determinedDirection == FlickDirection.TAP) return
+
+                firstFlickDirection = determinedDirection
+                intermediateTouchX = event.x
+                intermediateTouchY = event.y
+                flickState = FlickState.FIRST_FLICK_DETERMINED
+
+                // 2段階目のポップアップに更新
+                updatePetalCharacters(firstFlickDirection)
+            }
+        } else {
+            val dx = event.x - intermediateTouchX
+            val dy = event.y - intermediateTouchY
+
+            // 2段階目として有効な方向を取得
+            val enabledSecondDirections = getEnabledSecondFlickDirections(firstFlickDirection)
+            val secondDirection =
+                calculateDirection(dx, dy, SECOND_FLICK_THRESHOLD, enabledSecondDirections)
+
+            if (!arePopupsVisible) {
+                showPetalPopups()
+            }
+            highlightPetalFor(secondDirection)
+        }
+    }
+
+    private fun handleTouchUp(event: MotionEvent) {
+        val finalSecondDirection: FlickDirection
+        if (flickState == FlickState.FIRST_FLICK_DETERMINED) {
+            val dx = event.x - intermediateTouchX
+            val dy = event.y - intermediateTouchY
+            val enabledSecondDirections = getEnabledSecondFlickDirections(firstFlickDirection)
+            finalSecondDirection =
+                calculateDirection(dx, dy, SECOND_FLICK_THRESHOLD, enabledSecondDirections)
+        } else {
+            val dx = event.x - initialTouchX
+            val dy = event.y - initialTouchY
+            // 【FIXED】1段階目として有効な方向のみを取得
+            val enabledFirstDirections = getEnabledFirstFlickDirections()
+            firstFlickDirection =
+                calculateDirection(dx, dy, FIRST_FLICK_THRESHOLD, enabledFirstDirections)
+            finalSecondDirection = FlickDirection.TAP
+        }
+        onTwoStepFlickListener?.onFlick(firstFlickDirection, finalSecondDirection)
+        resetState()
+    }
+
+    /**
+     * 【NEW】1段階目のフリックとして有効な方向（= その方向を起点とし、TAPを終点とする文字が存在する）のセットを取得
+     */
+    private fun getEnabledFirstFlickDirections(): Set<FlickDirection> {
+        val provider = characterMapProvider ?: return emptySet()
+        return FlickDirection.values().filter {
+            it != FlickDirection.TAP && provider(it, FlickDirection.TAP).isNotEmpty()
+        }.toSet()
+    }
+
+    /**
+     * 【NEW】2段階目のフリックとして有効な方向のセットを取得
+     */
+    private fun getEnabledSecondFlickDirections(baseDirection: FlickDirection): Set<FlickDirection> {
+        val provider = characterMapProvider ?: return emptySet()
+        return FlickDirection.values().filter {
+            it != FlickDirection.TAP && provider(baseDirection, it).isNotEmpty()
+        }.toSet()
+    }
+
+    private fun calculateDirection(
+        dx: Float,
+        dy: Float,
+        threshold: Float,
+        enabledDirections: Set<FlickDirection>
+    ): FlickDirection {
+        val distance = hypot(dx.toDouble(), dy.toDouble()).toFloat()
+        if (distance < threshold) return FlickDirection.TAP
+        if (enabledDirections.isEmpty()) return FlickDirection.TAP
+
+        val angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble()))
+
+        val ranges = mutableMapOf(
+            FlickDirection.RIGHT to (-22.5..22.5),
+            FlickDirection.DOWN_RIGHT to (22.5..67.5),
+            FlickDirection.DOWN to (67.5..112.5),
+            FlickDirection.DOWN_LEFT to (112.5..157.5),
+            FlickDirection.LEFT to (157.5..180.0),
+            FlickDirection.UP_LEFT to (-157.5..-112.5),
+            FlickDirection.UP to (-112.5..-67.5),
+            FlickDirection.UP_RIGHT to (-67.5..-22.5)
+        )
+        val leftRange2 = -180.0..-157.5
+
+        if (!enabledDirections.contains(FlickDirection.UP_RIGHT)) {
+            ranges[FlickDirection.UP] = ranges.getValue(FlickDirection.UP).start..-45.0
+            ranges[FlickDirection.RIGHT] = -45.0..ranges.getValue(FlickDirection.RIGHT).endInclusive
+        }
+        if (!enabledDirections.contains(FlickDirection.DOWN_RIGHT)) {
+            ranges[FlickDirection.RIGHT] = ranges.getValue(FlickDirection.RIGHT).start..45.0
+            ranges[FlickDirection.DOWN] = 45.0..ranges.getValue(FlickDirection.DOWN).endInclusive
+        }
+        if (!enabledDirections.contains(FlickDirection.DOWN_LEFT)) {
+            ranges[FlickDirection.DOWN] = ranges.getValue(FlickDirection.DOWN).start..135.0
+            ranges[FlickDirection.LEFT] = 135.0..ranges.getValue(FlickDirection.LEFT).endInclusive
+        }
+        if (!enabledDirections.contains(FlickDirection.UP_LEFT)) {
+            ranges[FlickDirection.UP] = -135.0..ranges.getValue(FlickDirection.UP).endInclusive
+            // leftRange2 の開始点を変更
+            // ranges[FlickDirection.LEFT] は 157.5..180.0 のまま
+        }
+
+
+        for (direction in FlickDirection.values()) {
+            if (direction == FlickDirection.TAP || !enabledDirections.contains(direction)) continue
+
+            if (direction == FlickDirection.LEFT) {
+                // UP_LEFTが無効な場合、LEFTの判定範囲を [-180, -135] と [135, 180] に広げる
+                val currentLeftRange2 =
+                    if (!enabledDirections.contains(FlickDirection.UP_LEFT)) -180.0..-135.0 else leftRange2
+                if (angle in ranges.getValue(FlickDirection.LEFT) || angle in currentLeftRange2) {
+                    return FlickDirection.LEFT
+                }
+            } else {
+                if (angle in ranges.getValue(direction)) {
+                    return direction
+                }
+            }
+        }
+        return FlickDirection.TAP
+    }
+
+    /**
+     * 【MODIFIED】ポップアップ生成ロジックを汎用化
+     */
+    private fun createPetalPopups(
+        enabledDirections: Set<FlickDirection>,
+        baseDirectionForChar: FlickDirection = FlickDirection.TAP
+    ) {
+        petalPopups.values.forEach { it.dismiss() }
+        petalPopups.clear()
+
+        val inflater = context.getSystemService(Context.LAYOUT_INFLATER_SERVICE) as LayoutInflater
+
+        for (direction in enabledDirections) {
+            val character = characterMapProvider?.invoke(
+                if (baseDirectionForChar == FlickDirection.TAP) direction else baseDirectionForChar, // 1段階目と2段階目で文字取得方法を切り替え
+                if (baseDirectionForChar == FlickDirection.TAP) FlickDirection.TAP else direction
+            ) ?: ""
+
+            if (character.isEmpty()) continue
+
+            val popupView = inflater.inflate(R.layout.popup_flick, null)
+            val popupTextView = popupView.findViewById<TextView>(R.id.popupTextView)
+            popupTextView.text = character
+            val popup = PopupWindow(
+                popupView,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                false
+            ).apply {
+                isTouchable = false
+                isFocusable = false
+                val background = GradientDrawable().apply {
+                    shape = GradientDrawable.OVAL
+                    setColor(defaultPopupColor)
+                    setStroke(2, Color.WHITE)
+                }
+                contentView.background = background
+            }
+            petalPopups[direction] = popup
+        }
+    }
+
+    private fun showPetalPopups() {
+        if (!isAttachedToWindow) return
+        val location = IntArray(2).also { getLocationInWindow(it) }
+        val anchorX = location[0]
+        val anchorY = location[1]
+
+        petalPopups.forEach { (direction, popup) ->
+            if (popup.isShowing) return@forEach
+            popup.contentView.measure(MeasureSpec.UNSPECIFIED, MeasureSpec.UNSPECIFIED)
+            val popupWidth = popup.contentView.measuredWidth
+            val popupHeight = popup.contentView.measuredHeight
+
+            // ポップアップ位置の微調整
+            val offset = 20
+            val (x, y) = when (direction) {
+                FlickDirection.UP -> Pair(
+                    anchorX + width / 2 - popupWidth / 2,
+                    anchorY - popupHeight - offset
+                )
+
+                FlickDirection.DOWN -> Pair(
+                    anchorX + width / 2 - popupWidth / 2,
+                    anchorY + height + offset
+                )
+
+                FlickDirection.LEFT -> Pair(
+                    anchorX - popupWidth - offset,
+                    anchorY + height / 2 - popupHeight / 2
+                )
+
+                FlickDirection.RIGHT -> Pair(
+                    anchorX + width + offset,
+                    anchorY + height / 2 - popupHeight / 2
+                )
+
+                FlickDirection.UP_RIGHT -> Pair(anchorX + width, anchorY - popupHeight)
+                FlickDirection.DOWN_RIGHT -> Pair(anchorX + width, anchorY + height)
+                FlickDirection.DOWN_LEFT -> Pair(anchorX - popupWidth, anchorY + height)
+                FlickDirection.UP_LEFT -> Pair(anchorX - popupWidth, anchorY - popupHeight)
+                else -> Pair(0, 0)
+            }
+            popup.showAtLocation(this, Gravity.NO_GRAVITY, x, y)
+        }
+        arePopupsVisible = true
+    }
+
+    private fun highlightPetalFor(direction: FlickDirection) {
+        if (direction == currentSecondFlickDirection) return
+        currentSecondFlickDirection = direction
+        petalPopups.forEach { (dir, popup) ->
+            val background = popup.contentView.background as? GradientDrawable
+            background?.setColor(if (dir == direction) highlightPopupColor else defaultPopupColor)
+        }
+    }
+
+    /**
+     * 【MODIFIED】2段階目の文字でポップアップを更新
+     */
+    private fun updatePetalCharacters(firstDirection: FlickDirection) {
+        val enabledSecondDirections = getEnabledSecondFlickDirections(firstDirection)
+        createPetalPopups(enabledSecondDirections, baseDirectionForChar = firstDirection)
+    }
+
+    private fun resetState() {
+        petalPopups.values.forEach { it.dismiss() }
+        arePopupsVisible = false
+        flickState = FlickState.NEUTRAL
+        firstFlickDirection = FlickDirection.TAP
+        currentSecondFlickDirection = FlickDirection.TAP
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/TfbiButton.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/TfbiButton.kt
@@ -8,7 +8,6 @@ import android.util.AttributeSet
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
-import android.view.View
 import android.view.ViewGroup
 import android.widget.PopupWindow
 import android.widget.TextView
@@ -227,18 +226,20 @@ class TfbiButton @JvmOverloads constructor(
         val popupView = inflater.inflate(R.layout.popup_flick, null)
         val popupTextView = popupView.findViewById<TextView>(R.id.popupTextView)
         popupTextView.text = tapCharacter
+        // Optional but recommended: Center the text inside the now larger popup view.
+        popupTextView.gravity = Gravity.CENTER
 
         tapPopup = PopupWindow(
             popupView,
-            ViewGroup.LayoutParams.WRAP_CONTENT,
-            ViewGroup.LayoutParams.WRAP_CONTENT,
+            width, // 1. Use the button's width
+            height, // 2. Use the button's height
             false
         ).apply {
             isTouchable = false
             isFocusable = false
             (contentView.background as? GradientDrawable)?.let {
                 val background = it.mutate() as GradientDrawable
-                background.setColor(defaultPopupColor) // 初期色はデフォルト
+                background.setColor(defaultPopupColor)
                 background.setStroke(2, Color.WHITE)
                 contentView.background = background
             }
@@ -246,15 +247,12 @@ class TfbiButton @JvmOverloads constructor(
 
         if (!isAttachedToWindow) return
         val location = IntArray(2).also { getLocationInWindow(it) }
-        val popupContent = tapPopup?.contentView ?: return
-        popupContent.measure(
-            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED),
-            View.MeasureSpec.makeMeasureSpec(0, View.MeasureSpec.UNSPECIFIED)
-        )
-        val popupWidth = popupContent.measuredWidth
-        val popupHeight = popupContent.measuredHeight
-        val offsetX = location[0] + (width - popupWidth) / 2
-        val offsetY = location[1] + (height - popupHeight) / 2
+
+        // 3. Simplify positioning logic.
+        // The popup is the same size as the button, so it can be shown at the button's exact location.
+        val offsetX = location[0]
+        val offsetY = location[1]
+
         tapPopup?.showAtLocation(this, Gravity.NO_GRAVITY, offsetX, offsetY)
     }
 

--- a/custom_keyboard/src/main/res/drawable/popup_background.xml
+++ b/custom_keyboard/src/main/res/drawable/popup_background.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#80000000" />
+</shape>

--- a/custom_keyboard/src/main/res/drawable/popup_background.xml
+++ b/custom_keyboard/src/main/res/drawable/popup_background.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
-    <solid android:color="#80000000" />
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainer" />
+    <corners
+        android:bottomLeftRadius="8dp"
+        android:bottomRightRadius="12dp"
+        android:topLeftRadius="12dp"
+        android:topRightRadius="8dp" />
 </shape>

--- a/custom_keyboard/src/main/res/layout/popup_flick.xml
+++ b/custom_keyboard/src/main/res/layout/popup_flick.xml
@@ -6,7 +6,6 @@
     android:background="@drawable/popup_background"
     android:gravity="center"
     android:padding="8dp"
-    android:text="い"
-    android:textColor="@android:color/white"
+    android:textColor="@color/keyboard_icon_color"
     android:textSize="16sp"
     android:textStyle="bold" />

--- a/custom_keyboard/src/main/res/layout/popup_flick.xml
+++ b/custom_keyboard/src/main/res/layout/popup_flick.xml
@@ -5,8 +5,8 @@
     android:layout_height="wrap_content"
     android:background="@drawable/popup_background"
     android:gravity="center"
-    android:padding="16dp"
+    android:padding="8dp"
     android:text="い"
     android:textColor="@android:color/white"
-    android:textSize="24sp"
+    android:textSize="16sp"
     android:textStyle="bold" />

--- a/custom_keyboard/src/main/res/layout/popup_flick.xml
+++ b/custom_keyboard/src/main/res/layout/popup_flick.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/popupTextView"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:background="@drawable/popup_background"
+    android:gravity="center"
+    android:padding="16dp"
+    android:text="い"
+    android:textColor="@android:color/white"
+    android:textSize="24sp"
+    android:textStyle="bold" />


### PR DESCRIPTION
## Issue
#167 #222 #223 #224 

## 概要
### ２段フリック入力の実装

スミレキーボードの入力モードに２段フリック入力を追加

8方向 + フリックにフラッグを持たせて２段階フリックを検知するように実装

[demo_curve_flick.webm](https://github.com/user-attachments/assets/baaef283-5af8-4f61-b829-5f4c39bd02a9)

### カスタムタブの裏側に別のキーボードの表示が残るバグの修正
タブレットの場合、記号キーボードに切り替えると別のキーボードが裏に表示されるバグの修正

### Fnキーでの変換の実装
Shiftを押下してEnterで確定するまでは一時的に英語入力になるように修正

- F6  ひらがなに変換
- F7 | カタカナに変換
- F8 | 半角カタカナに変換
- F9 |  大文字アルファベットに変換
- F10 | 小文字アルファベットに変換

### 変換候補をEnterキー以外で確定する機能の実装
変換候補を選択中に文字を入力されると、その変換を確定するように修正する。
