### PR TITLE
QWERTY キーボードの改善

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 486
-        versionName "1.4.365"
+        versionCode 487
+        versionName "1.4.366"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -337,6 +337,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var isLiveConversionEnable: Boolean? = false
     private var nBest: Int? = 4
     private var flickSensitivityPreferenceValue: Int? = 100
+    private var qwertyShowIMEButtonPreference: Boolean? = true
+    private var qwertyShowCursorButtonsPreference: Boolean? = false
     private var isVibration: Boolean? = true
     private var vibrationTimingStr: String? = "both"
     private var mozcUTPersonName: Boolean? = false
@@ -565,6 +567,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             isLiveConversionEnable = live_conversion_preference ?: false
             nBest = n_best_preference ?: 4
             flickSensitivityPreferenceValue = flick_sensitivity_preference ?: 100
+            qwertyShowIMEButtonPreference = qwerty_show_ime_button ?: true
+            qwertyShowCursorButtonsPreference = qwerty_show_cursor_buttons ?: false
             isNgWordEnable = ng_word_preference ?: true
             deleteKeyHighLight = delete_key_high_light_preference ?: true
             customKeyboardSuggestionPreference = custom_keyboard_suggestion_preference ?: true
@@ -634,6 +638,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 keyboardView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 tabletView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 customLayoutDefault.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
+                qwertyView.setSpecialKeyVisibility(
+                    showCursors = qwertyShowCursorButtonsPreference ?: false,
+                    showSwitchKey = qwertyShowIMEButtonPreference ?: true
+                )
             }
         }
         editorInfo?.let { info ->
@@ -740,6 +748,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         isLiveConversionEnable = null
         nBest = null
         flickSensitivityPreferenceValue = null
+        qwertyShowIMEButtonPreference = null
+        qwertyShowCursorButtonsPreference = null
         isVibration = null
         vibrationTimingStr = null
         mozcUTPersonName = null
@@ -5096,6 +5106,30 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 setCursorMode(true)
                                 isSpaceKeyLongPressed = true
                             }
+                        }
+
+                        QWERTYKey.QWERTYKeyCursorRight -> {
+                            handleRightLongPress()
+                            rightCursorKeyLongKeyPressed.set(true)
+                            if (selectMode.value) {
+                                clearDeletedBufferWithoutResetLayout()
+                            } else {
+                                clearDeletedBuffer()
+                            }
+                            suggestionAdapter?.setUndoEnabled(false)
+                            updateClipboardPreview()
+                        }
+
+                        QWERTYKey.QWERTYKeyCursorLeft -> {
+                            handleLeftLongPress()
+                            leftCursorKeyLongKeyPressed.set(true)
+                            if (selectMode.value) {
+                                clearDeletedBufferWithoutResetLayout()
+                            } else {
+                                clearDeletedBuffer()
+                            }
+                            suggestionAdapter?.setUndoEnabled(false)
+                            updateClipboardPreview()
                         }
 
                         else -> {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
@@ -28,7 +28,7 @@ fun getCurrentInputTypeForIME(editorInfo: EditorInfo): InputTypeForIME {
                  *  131073 : EditText in Android App
                  *  409601 : Line
                  * */
-                InputType.TYPE_TEXT_FLAG_MULTI_LINE, 180385, 409601 -> InputTypeForIME.TextMultiLine
+                InputType.TYPE_TEXT_FLAG_MULTI_LINE, 180385, 409601, 131073 -> InputTypeForIME.TextMultiLine
 
                 /**
                  *  180225 : Twitter Tweet & Messenger

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -33,6 +33,12 @@ object AppPreference {
     private val CUSTOM_KEYBOARD_TWO_WORDS_OUTPUTS =
         Pair("custom_keyboard_two_words_preference", true)
 
+    private val QWERTY_SHOW_IME_SWITCH_BUTTON =
+        Pair("qwerty_show_switch_ime_button_preference", true)
+
+    private val QWERTY_SHOW_CURSOR_BUTTONS =
+        Pair("qwerty_show_cursor_buttons_preference", true)
+
     private val KEYBOARD_HEIGHT = Pair("keyboard_height_preference", 220)
     private val KEYBOARD_WIDTH = Pair("keyboard_width_preference", 100)
     private val KEYBOARD_POSITION = Pair("keyboard_position_preference", true)
@@ -88,6 +94,24 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(CUSTOM_KEYBOARD_TWO_WORDS_OUTPUTS.first, value ?: false)
+        }
+
+    var qwerty_show_ime_button: Boolean?
+        get() = preferences.getBoolean(
+            QWERTY_SHOW_IME_SWITCH_BUTTON.first,
+            QWERTY_SHOW_IME_SWITCH_BUTTON.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(QWERTY_SHOW_IME_SWITCH_BUTTON.first, value ?: true)
+        }
+
+    var qwerty_show_cursor_buttons: Boolean?
+        get() = preferences.getBoolean(
+            QWERTY_SHOW_CURSOR_BUTTONS.first,
+            QWERTY_SHOW_CURSOR_BUTTONS.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(QWERTY_SHOW_CURSOR_BUTTONS.first, value ?: false)
         }
 
     var keyboard_order: List<KeyboardType>

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -84,6 +84,22 @@
                 app:summary="ローマ字の変換表を作成、選択します" />
         </PreferenceCategory>
 
+        <PreferenceCategory android:title="QWERTY キーボード">
+            <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:key="qwerty_show_cursor_buttons_preference"
+                android:summaryOff="QWERTY キーボードにカーソルボタンを表示しません。"
+                android:summaryOn="QWERTY キーボードにカーソルボタンを表示します。"
+                android:title="カーソルボタン" />
+
+            <SwitchPreferenceCompat
+                android:defaultValue="true"
+                android:key="qwerty_show_switch_ime_button_preference"
+                android:summaryOff="キーボード切り替え（地球儀アイコン）ボタンを表示しません。"
+                android:summaryOn="キーボード切り替え（地球儀アイコン）ボタンを表示します。"
+                android:title="IME 切り替えボタン" />
+        </PreferenceCategory>
+
         <PreferenceCategory android:title="記号キーボード">
             <ListPreference
                 android:defaultValue="EMOJI"

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -1,5 +1,6 @@
 package com.kazumaproject.custom_keyboard.layout
 
+import android.util.Log
 import com.kazumaproject.custom_keyboard.data.FlickAction
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyAction
@@ -21,6 +22,7 @@ object KeyboardDefaultLayouts {
         dynamicKeyStates: Map<String, Int>,
         inputType: String,
     ): KeyboardLayout {
+        Log.d("createFinalLayout:", "$dynamicKeyStates")
         val baseLayout = when (inputType) {
             "toggle-default" -> {
                 when (mode) {
@@ -165,7 +167,10 @@ object KeyboardDefaultLayouts {
         FlickAction.Action(KeyAction.NewLine, "改行"),
         FlickAction.Action(KeyAction.Confirm, "確定"),
         FlickAction.Action(
-            KeyAction.Enter, "実行", com.kazumaproject.core.R.drawable.baseline_keyboard_return_24
+            KeyAction.Enter, "実行",
+        ),
+        FlickAction.Action(
+            KeyAction.Enter, "検索",
         ),
     )
 

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -123,7 +123,9 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     private val longPressEnabledKeys = setOf(
         QWERTYKey.QWERTYKeyDelete,
         QWERTYKey.QWERTYKeySpace,
-        QWERTYKey.QWERTYKeySwitchDefaultLayout
+        QWERTYKey.QWERTYKeySwitchDefaultLayout,
+        QWERTYKey.QWERTYKeyCursorLeft,
+        QWERTYKey.QWERTYKeyCursorRight
     )
 
     init {
@@ -455,7 +457,9 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             binding.keySwitchDefault to QWERTYKey.QWERTYKeySwitchDefaultLayout,
             binding.key123 to QWERTYKey.QWERTYKeySwitchMode,   // AppCompatButton
             binding.keySpace to QWERTYKey.QWERTYKeySpace,      // QWERTYButton
-            binding.keyReturn to QWERTYKey.QWERTYKeyReturn     // AppCompatButton
+            binding.keyReturn to QWERTYKey.QWERTYKeyReturn,
+            binding.cursorLeft to QWERTYKey.QWERTYKeyCursorLeft,
+            binding.cursorRight to QWERTYKey.QWERTYKeyCursorRight
         )
     }
 
@@ -763,8 +767,16 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                         shiftDoubleTapped = false
                     } else {
                         val qwertyKey = qwertyButtonMap[it] ?: QWERTYKey.QWERTYKeyNotSelect
-                        logVariationIfNeeded(qwertyKey)
-                        setToggleShiftState(view)
+                        when (qwertyKey) {
+                            QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight -> {
+                                qwertyKeyListener?.onReleasedQWERTYKey(qwertyKey, null, null)
+                            }
+
+                            else -> {
+                                logVariationIfNeeded(qwertyKey)
+                                setToggleShiftState(view)
+                            }
+                        }
                     }
                 }
                 pointerButtonMap.remove(pointerId)
@@ -815,8 +827,20 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                                 } else {
                                     val qwertyKey =
                                         qwertyButtonMap[it] ?: QWERTYKey.QWERTYKeyNotSelect
-                                    logVariationIfNeeded(qwertyKey)
-                                    setToggleShiftState(view)
+                                    when (qwertyKey) {
+                                        QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight -> {
+                                            qwertyKeyListener?.onReleasedQWERTYKey(
+                                                qwertyKey,
+                                                null,
+                                                null
+                                            )
+                                        }
+
+                                        else -> {
+                                            logVariationIfNeeded(qwertyKey)
+                                            setToggleShiftState(view)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -912,7 +936,15 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             }
 
             // ⑥ Show preview for non‐edge, non‐icon keys
-            if (it.id != binding.keySpace.id && it.id != binding.keyDelete.id && it.id != binding.keyShift.id && it.id != binding.key123.id && it.id != binding.keyReturn.id && it.id != binding.keySwitchDefault.id) {
+            if (it.id != binding.keySpace.id &&
+                it.id != binding.keyDelete.id &&
+                it.id != binding.keyShift.id &&
+                it.id != binding.key123.id &&
+                it.id != binding.keyReturn.id &&
+                it.id != binding.keySwitchDefault.id &&
+                it.id != binding.cursorLeft.id &&
+                it.id != binding.cursorRight.id
+            ) {
                 showKeyPreview(it)
             }
 
@@ -1353,6 +1385,17 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             characterKeys.forEach { it.text = "" }
             keySpace.text = ""
         }
+    }
+
+    /**
+     * 特定のキーの表示・非表示を切り替えます。
+     * @param showCursors trueの場合、左右のカーソルキーを表示します。
+     * @param showSwitchKey trueの場合、レイアウト切り替えキーを表示します。
+     */
+    fun setSpecialKeyVisibility(showCursors: Boolean, showSwitchKey: Boolean) {
+        binding.cursorLeft.isVisible = showCursors
+        binding.cursorRight.isVisible = showCursors
+        binding.keySwitchDefault.isVisible = showSwitchKey
     }
 
 }

--- a/qwerty_keyboard/src/main/res/layout-land/qwerty_layout.xml
+++ b/qwerty_keyboard/src/main/res/layout-land/qwerty_layout.xml
@@ -636,9 +636,41 @@
         android:textColor="@color/keyboard_icon_color"
         android:textSize="@dimen/qwerty_side_key_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/key_return"
+        app:layout_constraintEnd_toStartOf="@+id/cursor_left"
         app:layout_constraintHorizontal_weight="2"
         app:layout_constraintStart_toEndOf="@id/key_switch_default"
+        app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/cursor_left"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:contentDescription="Move cursor left"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:scaleType="center"
+        android:src="@drawable/baseline_arrow_left_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/cursor_right"
+        app:layout_constraintHorizontal_weight="0.5"
+        app:layout_constraintStart_toEndOf="@id/key_space"
+        app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/cursor_right"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:contentDescription="Move cursor right"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:scaleType="center"
+        android:src="@drawable/baseline_arrow_right_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key_return"
+        app:layout_constraintHorizontal_weight="0.5"
+        app:layout_constraintStart_toEndOf="@id/cursor_left"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -656,7 +688,8 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_weight="1"
-        app:layout_constraintStart_toEndOf="@id/key_space"
+        app:layout_constraintStart_toEndOf="@id/cursor_right"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
 
 </merge>

--- a/qwerty_keyboard/src/main/res/layout/qwerty_layout.xml
+++ b/qwerty_keyboard/src/main/res/layout/qwerty_layout.xml
@@ -601,7 +601,7 @@
         android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/key_switch_default"
-        app:layout_constraintHorizontal_weight="0.5"
+        app:layout_constraintHorizontal_weight="0.75"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
 
@@ -636,9 +636,42 @@
         android:textColor="@color/keyboard_icon_color"
         android:textSize="@dimen/qwerty_side_key_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/key_return"
+        app:layout_constraintEnd_toStartOf="@+id/cursor_left"
         app:layout_constraintHorizontal_weight="2"
         app:layout_constraintStart_toEndOf="@id/key_switch_default"
+        app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/cursor_left"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:contentDescription="Move cursor left"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:scaleType="center"
+        android:src="@drawable/baseline_arrow_left_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/cursor_right"
+        app:layout_constraintHorizontal_weight="0.5"
+        app:layout_constraintStart_toEndOf="@id/key_space"
+        app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
+    <androidx.appcompat.widget.AppCompatImageButton
+        android:id="@+id/cursor_right"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginHorizontal="4dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:contentDescription="Move cursor right"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:scaleType="center"
+        android:src="@drawable/baseline_arrow_right_24"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key_return"
+        app:layout_constraintHorizontal_weight="0.5"
+        app:layout_constraintStart_toEndOf="@id/cursor_left"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -656,7 +689,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_weight="1"
-        app:layout_constraintStart_toEndOf="@id/key_space"
+        app:layout_constraintStart_toEndOf="@id/cursor_right"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
 
 </merge>


### PR DESCRIPTION
## 概要
QWERTY キーボードに以下の設定を追加した
- カーソルボタンの表示・非表示
- IME切り替えボタンの表示・非表示

QWERTY キーボードにて Shift キーが押されたら英語を入力できるように修正。

- Enter キーで改行にならないバグの修正
- 変換ボタンの修正