### PR TITLE
修飾キー省略入力の修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 490
-        versionName "1.4.369"
+        versionCode 491
+        versionName "1.4.370"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/graph/GraphBuilder.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/graph/GraphBuilder.kt
@@ -2,6 +2,7 @@ package com.kazumaproject.markdownhelperkeyboard.converter.graph
 
 import com.kazumaproject.Louds.LOUDS
 import com.kazumaproject.Louds.with_term_id.LOUDSWithTermId
+import com.kazumaproject.core.domain.extensions.hasNConsecutiveChars
 import com.kazumaproject.dictionary.TokenArray
 import com.kazumaproject.graph.Node
 import com.kazumaproject.hiraToKata
@@ -15,7 +16,7 @@ import timber.log.Timber
 class GraphBuilder {
 
     companion object {
-        private const val SCORE_BONUS_PER_OMISSION = 250
+        private const val SCORE_BONUS_PER_OMISSION = 350
     }
 
 
@@ -117,16 +118,16 @@ class GraphBuilder {
                 graph.computeIfAbsent(endIndex) { mutableListOf() }.add(node)
             }
 
-            Timber.d("learnedWords: $learnedWords")
-
             // 3. システム辞書からCommon Prefix Searchを実行
-            if (isOmissionSearchEnable) {
+            if (isOmissionSearchEnable && !subStr.hasNConsecutiveChars(4)) {
                 val commonPrefixSearchSystem: List<OmissionSearchResult> =
                     yomiTrie.commonPrefixSearchWithOmission(
                         str = subStr,
                         succinctBitVector = succinctBitVectorLBSYomi
                     )
                 if (commonPrefixSearchSystem.isNotEmpty()) foundInAnyDictionary = true
+
+                Timber.d("omissionResult: ${commonPrefixSearchSystem.size} $str $subStr")
 
                 for (omissionResult in commonPrefixSearchSystem) {
                     val nodeIndex = yomiTrie.getNodeIndex(

--- a/core/src/main/java/com/kazumaproject/core/domain/extensions/String.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/extensions/String.kt
@@ -359,3 +359,12 @@ fun String.isAllFullWidthNumericSymbol(): Boolean {
     if (this.isEmpty() || this.length > 2) return false
     return this.all { it.isFullWidthNumericSymbol() }
 }
+
+/**
+ * (拡張関数)
+ * 文字列内に同じ文字がN文字以上連続して出現するかどうかを判定します。
+ */
+fun String.hasNConsecutiveChars(n: Int): Boolean {
+    val regex = Regex("(.)\\1{$n,}")
+    return regex.containsMatchIn(this)
+}


### PR DESCRIPTION
## 概要
- 同じ文字が連続して打たれた時にメモリを使いすぎるので判定を追加 (かかかかかかかか)など。
- 濁点や小文字のものより清音のものを優先するようにスコアを調整