### PR TITLE
EdgeToEdge に対応する試み

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 511
-        versionName "1.4.390"
+        versionCode 512
+        versionName "1.4.391"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -51,10 +51,13 @@ import androidx.appcompat.view.ContextThemeWrapper
 import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.inputmethod.InputConnectionCompat
 import androidx.core.view.inputmethod.InputContentInfoCompat
 import androidx.core.view.isInvisible
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.LifecycleRegistry
@@ -743,6 +746,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         keyboardSelectionPopupWindow?.dismiss()
         mainLayoutBinding?.let { mainView ->
             mainView.apply {
+                ViewCompat.setOnApplyWindowInsetsListener(mainView.root) { view, windowInsets ->
+                    val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+                    view.updatePadding(
+                        left = insets.left,
+                        top = insets.top,
+                        right = insets.right,
+                        bottom = insets.bottom
+                    )
+                    WindowInsetsCompat.CONSUMED
+                }
                 keyboardView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 tabletView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 customLayoutDefault.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)


### PR DESCRIPTION
## 概要

これまで onComputeInsets を用いて全画面描画を行い、Floating 表示やハードウェアキーボード接続時にも背景要素へタッチ判定を渡せるようにしていた。
しかしこの実装では、他アプリでフローティング画面を表示した状態でキーボードを出すと、システムのボトムナビゲーションと重なって描画されてしまう問題があった。

本PRでは、onComputeInsets の処理を調整し、キーボード描画時にシステムUIと重ならないよう修正した。