### PR TITLE
フローティングキーボードで変換候補を表示すると重くなるバグの修正の試み

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 517
-        versionName "1.4.396"
+        versionCode 518
+        versionName "1.4.397"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -758,6 +758,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         }
                     })
                 }
+                floatingKeyboardLayoutBinding.suggestionRecyclerView.adapter = suggestionAdapter
+                floatingKeyboardLayoutBinding.candidatesRowView.adapter = suggestionAdapter
+                mainLayoutBinding?.suggestionRecyclerView?.adapter = null
+                mainLayoutBinding?.candidatesRowView?.adapter = null
             }
         }
 
@@ -773,6 +777,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     showSwitchKey = qwertyShowIMEButtonPreference ?: true,
                     showKutouten = qwertyShowKutoutenButtonsPreference ?: false
                 )
+                if (isKeyboardFloatingMode == true) {
+                    suggestionRecyclerView.adapter = null
+                    candidatesRowView.adapter = null
+                } else {
+                    suggestionRecyclerView.adapter = suggestionAdapter
+                    candidatesRowView.adapter = suggestionAdapter
+                }
             }
             val flexboxLayoutManagerColumn = FlexboxLayoutManager(applicationContext).apply {
                 flexDirection = FlexDirection.COLUMN
@@ -6301,13 +6312,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
 
         suggestionAdapter.apply {
-            mainView.suggestionRecyclerView.adapter = this
             mainView.candidatesRowView.adapter = this
             mainView.candidatesRowView.layoutManager = flexboxLayoutManagerRow
 
             floatingKeyboardBinding?.let { floatingKeyboardLayoutBinding ->
                 floatingKeyboardLayoutBinding.suggestionRecyclerView.let { sRecyclerView ->
-                    sRecyclerView.adapter = this
                     sRecyclerView.layoutManager = FlexboxLayoutManager(applicationContext).apply {
                         flexDirection = FlexDirection.COLUMN
                     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1142,7 +1142,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             floatingKeyboardView = PopupWindow(
                 floatingKeyboardLayoutBinding.root,
                 widthPx,
-                WindowManager.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT,
             )
         }
 
@@ -4769,6 +4769,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         launch {
             var prevFlag: CandidateShowFlag? = null
             suggestionFlag.collectLatest { currentFlag ->
+                val insertString = inputString.value
                 if (prevFlag == CandidateShowFlag.Idle && currentFlag == CandidateShowFlag.Updating) {
                     when {
                         physicalKeyboardEnable.replayCache.isEmpty() && isKeyboardFloatingMode == true || (physicalKeyboardEnable.replayCache.isNotEmpty() && !physicalKeyboardEnable.replayCache.first()) && isKeyboardFloatingMode == true -> {
@@ -4796,7 +4797,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         }
 
                     }
-                    val insertString = inputString.value
                     if (isKeyboardFloatingMode == true) {
                         floatingKeyboardBinding?.let { floatingKeyboard ->
                             updateUIinHenkanFloating(floatingKeyboard, insertString)
@@ -5011,8 +5011,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     }
 
                     CandidateShowFlag.Updating -> {
-                        val inputString = inputString.value
-                        setSuggestionOnView(inputString)
+                        setSuggestionOnView(insertString)
                     }
                 }
                 prevFlag = currentFlag

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -4796,6 +4796,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         }
 
                     }
+                    val insertString = inputString.value
+                    if (isKeyboardFloatingMode == true) {
+                        floatingKeyboardBinding?.let { floatingKeyboard ->
+                            updateUIinHenkanFloating(floatingKeyboard, insertString)
+                        }
+                    } else {
+                        updateUIinHenkan(mainView, insertString)
+                    }
                     if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY && mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                         mainView.qwertyView.apply {
                             setSpaceKeyText("変換")
@@ -5004,7 +5012,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     CandidateShowFlag.Updating -> {
                         val inputString = inputString.value
-                        setSuggestionOnView(mainView, inputString)
+                        setSuggestionOnView(inputString)
                     }
                 }
                 prevFlag = currentFlag
@@ -7537,14 +7545,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private suspend fun setSuggestionOnView(
-        mainView: MainLayoutBinding, inputString: String
+        inputString: String
     ) {
         if (inputString.isEmpty() || suggestionClickNum != 0) return
-        setCandidates(mainView, inputString)
+        setCandidates(inputString)
     }
 
     private suspend fun setCandidates(
-        mainView: MainLayoutBinding,
         insertString: String,
     ) {
         val candidates = getSuggestionList(insertString)
@@ -7566,13 +7573,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 suggestionAdapter?.suggestions = filtered
             }
 
-        }
-        if (isKeyboardFloatingMode == true) {
-            floatingKeyboardBinding?.let { floatingKeyboard ->
-                updateUIinHenkanFloating(floatingKeyboard, insertString)
-            }
-        } else {
-            updateUIinHenkan(mainView, insertString)
         }
         if (isLiveConversionEnable == true && !hasConvertedKatakana) {
             if (isFlickOnlyMode != true) {

--- a/app/src/main/res/layout/suggestion_custom_layout_item.xml
+++ b/app/src/main/res/layout/suggestion_custom_layout_item.xml
@@ -2,7 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
-    android:layout_height="match_parent"
+    android:layout_height="58dp"
     android:background="?attr/selectableItemBackground"
     android:clickable="true"
     android:focusable="true"

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -49,6 +49,13 @@
                 android:summaryOff="パスワード入力中に変換候補を表示します"
                 android:summaryOn="パスワード入力中は変換候補を表示しません"
                 android:title="パスワード入力時の変換候補" />
+
+            <SwitchPreferenceCompat
+                android:defaultValue="true"
+                android:key="henkan_delete_key_action_preference"
+                android:summaryOff="削除キータップ：ハイライト解除"
+                android:summaryOn="削除キー長押し：ハイライト解除\n削除キータップ：選択位置を1つ前に戻す"
+                android:title="候補ハイライト時の削除キー動作" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="機能">
@@ -93,13 +100,6 @@
                 app:min="10"
                 app:seekBarIncrement="10"
                 app:showSeekBarValue="true" />
-
-            <SwitchPreferenceCompat
-                android:defaultValue="true"
-                android:key="henkan_delete_key_action_preference"
-                android:summaryOff="削除キータップ：ハイライト解除"
-                android:summaryOn="削除キー長押し：ハイライト解除\n削除キータップ：選択位置を1つ前に戻す"
-                android:title="候補ハイライト時の削除キー動作" />
         </PreferenceCategory>
 
         <PreferenceCategory android:title="ローマ字変換">

--- a/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKeyMap.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKeyMap.kt
@@ -97,7 +97,10 @@ class QWERTYKeyMap : QWERTYKeyMapHolder {
         QWERTYKey.QWERTYKeySwitchDefaultLayout to QWERTYKeyInfo.KeySwitchDefaultLayout,
         QWERTYKey.QWERTYKeySwitchMode to QWERTYKeyInfo.KeySwitchMode,
         QWERTYKey.QWERTYKeySpace to QWERTYKeyInfo.KeySpace,
-        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn
+        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn,
+
+        QWERTYKey.QWERTYKeyKuten to QWERTYKeyInfo.KeyDot,
+        QWERTYKey.QWERTYKeyTouten to QWERTYKeyInfo.KeyComma
     )
 
     private val listSymbol: Map<QWERTYKey, QWERTYKeyInfo> = mapOf(
@@ -138,7 +141,10 @@ class QWERTYKeyMap : QWERTYKeyMapHolder {
         QWERTYKey.QWERTYKeySwitchDefaultLayout to QWERTYKeyInfo.KeySwitchDefaultLayout,
         QWERTYKey.QWERTYKeySwitchMode to QWERTYKeyInfo.KeySwitchMode,
         QWERTYKey.QWERTYKeySpace to QWERTYKeyInfo.KeySpace,
-        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn
+        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn,
+
+        QWERTYKey.QWERTYKeyKuten to QWERTYKeyInfo.KeyDot,
+        QWERTYKey.QWERTYKeyTouten to QWERTYKeyInfo.KeyComma
     )
 
     private val listDefaultJP: Map<QWERTYKey, QWERTYKeyInfo> = mapOf(
@@ -175,6 +181,7 @@ class QWERTYKeyMap : QWERTYKeyMapHolder {
         QWERTYKey.QWERTYKeySwitchMode to QWERTYKeyInfo.KeySwitchMode,
         QWERTYKey.QWERTYKeySpace to QWERTYKeyInfo.KeySpace,
         QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn,
+
         QWERTYKey.QWERTYKeyKuten to QWERTYKeyInfo.KeyDotJP,
         QWERTYKey.QWERTYKeyTouten to QWERTYKeyInfo.KeyCommaJP
     )
@@ -217,7 +224,10 @@ class QWERTYKeyMap : QWERTYKeyMapHolder {
         QWERTYKey.QWERTYKeySwitchDefaultLayout to QWERTYKeyInfo.KeySwitchDefaultLayout,
         QWERTYKey.QWERTYKeySwitchMode to QWERTYKeyInfo.KeySwitchMode,
         QWERTYKey.QWERTYKeySpace to QWERTYKeyInfo.KeySpace,
-        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn
+        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn,
+
+        QWERTYKey.QWERTYKeyKuten to QWERTYKeyInfo.KeyDotJP,
+        QWERTYKey.QWERTYKeyTouten to QWERTYKeyInfo.KeyCommaJP
     )
 
     private val listSymbolJP: Map<QWERTYKey, QWERTYKeyInfo> = mapOf(
@@ -258,7 +268,10 @@ class QWERTYKeyMap : QWERTYKeyMapHolder {
         QWERTYKey.QWERTYKeySwitchDefaultLayout to QWERTYKeyInfo.KeySwitchDefaultLayout,
         QWERTYKey.QWERTYKeySwitchMode to QWERTYKeyInfo.KeySwitchMode,
         QWERTYKey.QWERTYKeySpace to QWERTYKeyInfo.KeySpace,
-        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn
+        QWERTYKey.QWERTYKeyReturn to QWERTYKeyInfo.KeyReturn,
+
+        QWERTYKey.QWERTYKeyKuten to QWERTYKeyInfo.KeyDotJP,
+        QWERTYKey.QWERTYKeyTouten to QWERTYKeyInfo.KeyCommaJP
     )
 
     override val keysDefault: Set<QWERTYKey>


### PR DESCRIPTION
## 概要

フローティングキーボードの場合、 main の recyclerView を null にする。