### PR TITLE
スミレキーボードにカーソル入力のレイアウトを追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 522
-        versionName "1.4.401"
+        versionCode 523
+        versionName "1.4.402"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 521
-        versionName "1.4.400"
+        versionCode 522
+        versionName "1.4.401"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -355,6 +355,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var qwertyShowCursorButtonsPreference: Boolean? = false
     private var qwertyShowKutoutenButtonsPreference: Boolean? = false
     private var showCandidateInPasswordPreference: Boolean? = true
+    private var showCandidateInPasswordComposePreference: Boolean? = false
     private var isVibration: Boolean? = true
     private var vibrationTimingStr: String? = "both"
     private var mozcUTPersonName: Boolean? = false
@@ -618,6 +619,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             qwertyShowCursorButtonsPreference = qwerty_show_cursor_buttons ?: false
             qwertyShowKutoutenButtonsPreference = qwerty_show_kutouten_buttons ?: false
             showCandidateInPasswordPreference = show_candidates_password ?: true
+            showCandidateInPasswordComposePreference = show_candidates_password_compose ?: false
             isNgWordEnable = ng_word_preference ?: true
             deleteKeyHighLight = delete_key_high_light_preference ?: true
             customKeyboardSuggestionPreference = custom_keyboard_suggestion_preference ?: true
@@ -922,6 +924,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         qwertyShowCursorButtonsPreference = null
         qwertyShowKutoutenButtonsPreference = null
         showCandidateInPasswordPreference = null
+        showCandidateInPasswordComposePreference = null
         isVibration = null
         vibrationTimingStr = null
         mozcUTPersonName = null
@@ -5887,7 +5890,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         if (string.isNotEmpty()) {
             hasConvertedKatakana = false
             if (suppressSuggestions) {
-                commitText(string, 1)
+                if (showCandidateInPasswordComposePreference == false) {
+                    commitText(string, 1)
+                } else {
+                    setComposingText(string, 1)
+                }
                 return
             }
             if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY) {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -591,7 +591,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
         Timber.d("onUpdate onStartInput called $restarting ${attribute?.imeOptions}")
-        resetAllFlags()
+        if (!restarting) resetAllFlags()
         physicalKeyboardFloatingXPosition = 200
         physicalKeyboardFloatingYPosition = 150
         _suggestionViewStatus.update { true }
@@ -678,7 +678,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         val hasPhysicalKeyboard = inputManager.inputDeviceIds.any { deviceId ->
             isDevicePhysicalKeyboard(inputManager.getInputDevice(deviceId))
         }
-        setCurrentInputType(editorInfo)
+        if (!restarting) {
+            setCurrentInputType(editorInfo)
+            resetKeyboard()
+        }
         Timber.d("onUpdate onStartInputView called $isPrivateMode $hasPhysicalKeyboard $currentInputType $restarting ${mainLayoutBinding?.keyboardView?.currentInputMode?.value}")
         updateClipboardPreview()
         if (!hasPhysicalKeyboard) {
@@ -777,8 +780,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 mainLayoutBinding?.candidatesRowView?.adapter = null
             }
         }
-
-        resetKeyboard()
         keyboardSelectionPopupWindow?.dismiss()
         mainLayoutBinding?.let { mainView ->
             mainView.apply {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -29,8 +29,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import timber.log.Timber
 
 class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
@@ -194,11 +192,7 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         set(value) {
             // submitListの第2引数にコールバックを渡す
             differ.submitList(value) {
-                adapterScope.launch {
-                    delay(50)
-                    // リストの更新が完了し、UIに反映された後にこのブロックが実行される
-                    onListUpdated?.invoke()
-                }
+                onListUpdated?.invoke()
             }
         }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
@@ -130,6 +130,7 @@ object AppModule {
     fun providesPreference(@ApplicationContext context: Context): AppPreference {
         return AppPreference.apply {
             init(context)
+            migrateSumirePreferenceIfNeeded()
         }
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
@@ -3,7 +3,6 @@ package com.kazumaproject.markdownhelperkeyboard.ime_service.extensions
 import android.text.InputType
 import android.view.inputmethod.EditorInfo
 import com.kazumaproject.markdownhelperkeyboard.ime_service.state.InputTypeForIME
-import timber.log.Timber
 
 /**
  * Return InputTypeForIME
@@ -169,119 +168,37 @@ fun InputTypeForIME.isPassword(): Boolean = when (this) {
     else -> false
 }
 
-fun analyzeInputType(inputType: Int) {
-    // 1. クラスの解析
-    val inputClass = when (inputType and InputType.TYPE_MASK_CLASS) {
-        InputType.TYPE_CLASS_TEXT -> "TYPE_CLASS_TEXT"
-        InputType.TYPE_CLASS_NUMBER -> "TYPE_CLASS_NUMBER"
-        InputType.TYPE_CLASS_PHONE -> "TYPE_CLASS_PHONE"
-        InputType.TYPE_CLASS_DATETIME -> "TYPE_CLASS_DATETIME"
-        else -> "UNKNOWN_CLASS"
-    }
-    Timber.d("InputTypeAnalyzer: Class: $inputClass")
-
-    // 2. バリエーションの解析
-    val variation = when (inputType and InputType.TYPE_MASK_VARIATION) {
-        InputType.TYPE_TEXT_VARIATION_NORMAL -> "NORMAL"
-        InputType.TYPE_TEXT_VARIATION_URI -> "URI"
-        InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS -> "EMAIL_ADDRESS"
-        InputType.TYPE_TEXT_VARIATION_PASSWORD -> "PASSWORD"
-        InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD -> "VISIBLE_PASSWORD"
-        InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT -> "WEB_EDIT_TEXT"
-        InputType.TYPE_NUMBER_VARIATION_PASSWORD -> "NUMBER_PASSWORD"
-        else -> "OTHER_VARIATION"
-    }
-    Timber.d("InputTypeAnalyzer: Variation: $variation")
-
-    // 3. フラグの解析
-    val flags = mutableListOf<String>()
-    if ((inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0) flags.add("FLAG_MULTI_LINE")
-    if ((inputType and InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE) != 0) flags.add("FLAG_IME_MULTI_LINE")
-    if ((inputType and InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS) != 0) flags.add("FLAG_NO_SUGGESTIONS")
-    if ((inputType and InputType.TYPE_TEXT_FLAG_AUTO_CORRECT) != 0) flags.add("FLAG_AUTO_CORRECT")
-    if ((inputType and InputType.TYPE_TEXT_FLAG_AUTO_COMPLETE) != 0) flags.add("FLAG_AUTO_COMPLETE")
-    if ((inputType and InputType.TYPE_TEXT_FLAG_CAP_SENTENCES) != 0) flags.add("FLAG_CAP_SENTENCES")
-
-    Timber.d("InputTypeAnalyzer: Flags: ${flags.joinToString(", ")}")
-}
-
 /**
- * EditorInfoから現在の入力フィールドのタイプをInputTypeForIMEとして返します。
- *
- * @param editorInfo IMEから提供される現在のエディタの状態。nullの場合もあります。
- * @return 対応するInputTypeForIME。不明な場合はNoneを返します。
+ * Returns the InputTypeForIME by correctly parsing the EditorInfo's inputType and imeOptions.
+ * This function uses bitwise masks for reliable detection instead of matching specific integer values.
  */
-fun getInputTypeForIME(editorInfo: EditorInfo?): InputTypeForIME {
-    if (editorInfo == null) {
+fun getCurrentInputTypeForIME2(editorInfo: EditorInfo?): InputTypeForIME {
+    if (editorInfo == null || editorInfo.inputType == InputType.TYPE_NULL) {
         return InputTypeForIME.None
     }
 
     val inputType = editorInfo.inputType
-    val variation = inputType and InputType.TYPE_MASK_VARIATION
+    val inputClass = inputType and InputType.TYPE_MASK_CLASS
 
-    // --- 最も具体的な条件から順にチェック ---
-
-    // 1. IMEアクションを最優先でチェック (フィールドの目的を判定)
-    val imeAction = editorInfo.imeOptions and EditorInfo.IME_MASK_ACTION
-    if (imeAction == EditorInfo.IME_ACTION_SEARCH) {
-        // WebView内かどうかに応じて、より詳細な型を返すことも可能
-        return if (variation == InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT) {
-            InputTypeForIME.TextWebSearchView
-        } else {
-            InputTypeForIME.TextSearchView
-        }
+    return when (inputClass) {
+        InputType.TYPE_CLASS_TEXT -> getTextRelatedInputType(editorInfo)
+        InputType.TYPE_CLASS_NUMBER -> getNumberRelatedInputType(inputType)
+        InputType.TYPE_CLASS_PHONE -> InputTypeForIME.Phone
+        InputType.TYPE_CLASS_DATETIME -> getDateTimeRelatedInputType(inputType)
+        else -> InputTypeForIME.None
     }
-    if (imeAction == EditorInfo.IME_ACTION_NEXT) {
-        return InputTypeForIME.TextNextLine
-    }
-    if (imeAction == EditorInfo.IME_ACTION_DONE) {
-        return InputTypeForIME.TextDone
-    }
-
-    // 2. パスワード関連をチェック (非常に特殊なケース)
-    when (variation) {
-        InputType.TYPE_TEXT_VARIATION_PASSWORD -> return InputTypeForIME.TextPassword
-        InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD -> return InputTypeForIME.TextVisiblePassword
-        InputType.TYPE_TEXT_VARIATION_WEB_PASSWORD -> return InputTypeForIME.TextWebPassword
-    }
-
-    // 3. 構造を定義するフラグをチェック
-    if ((inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0) {
-        return InputTypeForIME.TextMultiLine
-    }
-    if ((inputType and InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE) != 0) {
-        return InputTypeForIME.TextImeMultiLine
-    }
-    if ((inputType and InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS) != 0) {
-        return InputTypeForIME.TextNoSuggestion
-    }
-
-    // 4. その他のバリエーションをチェック
-    when (variation) {
-        InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS -> return InputTypeForIME.TextEmailAddress
-        InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS -> return InputTypeForIME.TextWebEmailAddress
-        InputType.TYPE_TEXT_VARIATION_URI -> return InputTypeForIME.TextUri
-        InputType.TYPE_TEXT_VARIATION_PERSON_NAME -> return InputTypeForIME.TextPersonName
-        InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS -> return InputTypeForIME.TextPostalAddress
-        InputType.TYPE_TEXT_VARIATION_FILTER -> return InputTypeForIME.TextFilter
-        InputType.TYPE_TEXT_VARIATION_PHONETIC -> return InputTypeForIME.TextPhonetic
-        // TextWebEditTextは他の条件に当てはまらない場合のフォールバックとして扱う
-        InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT -> return InputTypeForIME.TextWebEditText
-    }
-
-    // どの条件にも当てはまらない場合は、汎用的なテキストとして扱う
-    return InputTypeForIME.Text
 }
 
 /**
- * テキストクラス関連のInputTypeForIMEを返します。
+ * Handles all text-based input types with a refined priority logic.
+ * It correctly balances strong actions, structural flags, and weak actions.
  */
 private fun getTextRelatedInputType(editorInfo: EditorInfo): InputTypeForIME {
     val inputType = editorInfo.inputType
-    // inputTypeからバリエーション部分（パスワード、URIなど）を抽出
     val variation = inputType and InputType.TYPE_MASK_VARIATION
+    val imeAction = editorInfo.imeOptions and EditorInfo.IME_MASK_ACTION
 
-    // まずは特殊なバリエーションから判定
+    // 1. Check for the most specific variations first (e.g., Password).
     when (variation) {
         InputType.TYPE_TEXT_VARIATION_PASSWORD -> return InputTypeForIME.TextPassword
         InputType.TYPE_TEXT_VARIATION_VISIBLE_PASSWORD -> return InputTypeForIME.TextVisiblePassword
@@ -290,41 +207,47 @@ private fun getTextRelatedInputType(editorInfo: EditorInfo): InputTypeForIME {
         InputType.TYPE_TEXT_VARIATION_WEB_EMAIL_ADDRESS -> return InputTypeForIME.TextWebEmailAddress
         InputType.TYPE_TEXT_VARIATION_URI -> return InputTypeForIME.TextUri
         InputType.TYPE_TEXT_VARIATION_PERSON_NAME -> return InputTypeForIME.TextPersonName
-        InputType.TYPE_TEXT_VARIATION_POSTAL_ADDRESS -> return InputTypeForIME.TextPostalAddress
-        InputType.TYPE_TEXT_VARIATION_WEB_EDIT_TEXT -> return InputTypeForIME.TextWebEditText
-        InputType.TYPE_TEXT_VARIATION_FILTER -> return InputTypeForIME.TextFilter
-        InputType.TYPE_TEXT_VARIATION_PHONETIC -> return InputTypeForIME.TextPhonetic
     }
 
-    // 次に、IMEアクション（Enterキーの挙動）をチェック
-    val imeAction = editorInfo.imeOptions and EditorInfo.IME_MASK_ACTION
-    if (imeAction == EditorInfo.IME_ACTION_SEARCH) {
-        return InputTypeForIME.TextSearchView
-    }
-    if (imeAction == EditorInfo.IME_ACTION_NEXT) {
-        return InputTypeForIME.TextNextLine
-    }
-    if (imeAction == EditorInfo.IME_ACTION_DONE) {
-        return InputTypeForIME.TextDone
+    // 2. Check for strong, purpose-defining actions FIRST.
+    // These actions (like Search) are unambiguous and override any other flags.
+    when (imeAction) {
+        EditorInfo.IME_ACTION_SEARCH -> return InputTypeForIME.TextSearchView
+        EditorInfo.IME_ACTION_NEXT -> return InputTypeForIME.TextNextLine
     }
 
-    // 次に、フラグをチェック
+    // 3. THEN, check for structural flags.
+    // If a field is multi-line, it should be treated as such, even if it has a weaker
+    // "Done" action. This correctly identifies composition fields.
     if ((inputType and InputType.TYPE_TEXT_FLAG_MULTI_LINE) != 0) {
         return InputTypeForIME.TextMultiLine
     }
     if ((inputType and InputType.TYPE_TEXT_FLAG_IME_MULTI_LINE) != 0) {
         return InputTypeForIME.TextImeMultiLine
     }
+
+    // 4. FINALLY, check for weaker actions for non-multi-line fields.
+    // This will only be reached if the field is single-line.
+    if (imeAction == EditorInfo.IME_ACTION_DONE) {
+        return InputTypeForIME.TextDone
+    }
+
+    // 5. Fallbacks.
     if ((inputType and InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS) != 0) {
         return InputTypeForIME.TextNoSuggestion
     }
+    editorInfo.hintText?.toString()?.let {
+        val hint = it.lowercase()
+        if (hint.contains("search") || hint.contains("検索")) return InputTypeForIME.TextSearchView
+        if (hint.contains("password")) return InputTypeForIME.TextPassword
+    }
 
-    // どの条件にも当てはまらない場合は、汎用的なテキストとして扱う
+    // 6. Default.
     return InputTypeForIME.Text
 }
 
 /**
- * 数値クラス関連のInputTypeForIMEを返します。
+ * Handles number-based input types.
  */
 private fun getNumberRelatedInputType(inputType: Int): InputTypeForIME {
     val variation = inputType and InputType.TYPE_MASK_VARIATION
@@ -332,7 +255,6 @@ private fun getNumberRelatedInputType(inputType: Int): InputTypeForIME {
         return InputTypeForIME.NumberPassword
     }
 
-    // フラグをチェック
     if ((inputType and InputType.TYPE_NUMBER_FLAG_DECIMAL) != 0) {
         return InputTypeForIME.NumberDecimal
     }
@@ -344,11 +266,10 @@ private fun getNumberRelatedInputType(inputType: Int): InputTypeForIME {
 }
 
 /**
- * 日時クラス関連のInputTypeForIMEを返します。
+ * Handles date/time-based input types.
  */
 private fun getDateTimeRelatedInputType(inputType: Int): InputTypeForIME {
-    val variation = inputType and InputType.TYPE_MASK_VARIATION
-    return when (variation) {
+    return when (inputType and InputType.TYPE_MASK_VARIATION) {
         InputType.TYPE_DATETIME_VARIATION_DATE -> InputTypeForIME.Date
         InputType.TYPE_DATETIME_VARIATION_TIME -> InputTypeForIME.Time
         else -> InputTypeForIME.Datetime

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -56,6 +56,9 @@ object AppPreference {
     private val UNDO_ENABLE = Pair("undo_enable_preference", false)
     private val SPACE_HANKAKU_ENABLE = Pair("space_key_preference", false)
     private val LIVE_CONVERSION_ENABLE = Pair("live_conversion_preference", false)
+    private const val OLD_SUMIRE_PREFERENCE_KEY = "sumire_keyboard_input_type_preference"
+    private const val NEW_SUMIRE_STYLE_KEY = "sumire_keyboard_style_preference"
+    private const val NEW_SUMIRE_METHOD_KEY = "sumire_input_method_preference"
     private val SUMIRE_INPUT_SELECTION_PREFERENCE =
         Pair("sumire_keyboard_input_type_preference", "toggle-default")
 
@@ -370,6 +373,18 @@ object AppPreference {
             it.putString(SUMIRE_INPUT_SELECTION_PREFERENCE.first, value ?: "toggle-default")
         }
 
+    var sumire_keyboard_style: String
+        get() = preferences.getString(NEW_SUMIRE_STYLE_KEY, "default") ?: "default"
+        set(value) = preferences.edit {
+            it.putString(NEW_SUMIRE_STYLE_KEY, value)
+        }
+
+    var sumire_input_method: String
+        get() = preferences.getString(NEW_SUMIRE_METHOD_KEY, "toggle") ?: "toggle"
+        set(value) = preferences.edit {
+            it.putString(NEW_SUMIRE_METHOD_KEY, value)
+        }
+
     var is_floating_mode: Boolean?
         get() = preferences.getBoolean(
             KEYBOARD_FLOATING_PREFERENCE.first, KEYBOARD_FLOATING_PREFERENCE.second
@@ -411,4 +426,30 @@ object AppPreference {
         set(value) = preferences.edit {
             it.putString(CANDIDATE_VIEW_HEIGHT_PREFERENCE.first, value)
         }
+
+    fun migrateSumirePreferenceIfNeeded() {
+        // 古いキーが存在する場合のみ移行処理を実行
+        if (preferences.contains(OLD_SUMIRE_PREFERENCE_KEY)) {
+            val oldValue = preferences.getString(OLD_SUMIRE_PREFERENCE_KEY, "toggle-default")
+
+            val (newStyle, newMethod) = when (oldValue) {
+                "toggle-default" -> "default" to "toggle"
+                "flick-default" -> "default" to "flick"
+                "flick-circle" -> "circle" to "toggle"
+                "flick-circle-flick" -> "circle" to "flick"
+                "second-flick" -> "second-flick" to "toggle"
+                "second-flick-flick" -> "second-flick" to "flick"
+                "flick-sumire" -> "sumire" to "flick"
+                else -> "default" to "toggle"
+            }
+
+            preferences.edit {
+                // 新しいキーで値を保存
+                it.putString(NEW_SUMIRE_STYLE_KEY, newStyle)
+                it.putString(NEW_SUMIRE_METHOD_KEY, newMethod)
+                // 移行が完了したので古いキーを削除
+                it.remove(OLD_SUMIRE_PREFERENCE_KEY)
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -42,6 +42,9 @@ object AppPreference {
     private val CANDIDATE_IN_PASSWORD =
         Pair("hide_candidate_password_preference", true)
 
+    private val CANDIDATE_IN_PASSWORD_COMPOSE =
+        Pair("password_compose_preference", false)
+
     private val QWERTY_SHOW_KUTOUTEN_BUTTONS =
         Pair("qwerty_show_kutouten_buttons_preference", false)
 
@@ -138,6 +141,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(CANDIDATE_IN_PASSWORD.first, value ?: true)
+        }
+
+    var show_candidates_password_compose: Boolean?
+        get() = preferences.getBoolean(
+            CANDIDATE_IN_PASSWORD_COMPOSE.first,
+            CANDIDATE_IN_PASSWORD_COMPOSE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(CANDIDATE_IN_PASSWORD_COMPOSE.first, value ?: false)
         }
 
     var qwerty_show_kutouten_buttons: Boolean?

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -39,6 +39,9 @@ object AppPreference {
     private val QWERTY_SHOW_CURSOR_BUTTONS =
         Pair("qwerty_show_cursor_buttons_preference", false)
 
+    private val QWERTY_SHOW_POPUP_WINDOW =
+        Pair("qwerty_show_popup_window_preference", true)
+
     private val CANDIDATE_IN_PASSWORD =
         Pair("hide_candidate_password_preference", true)
 
@@ -132,6 +135,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(QWERTY_SHOW_CURSOR_BUTTONS.first, value ?: false)
+        }
+
+    var qwerty_show_popup_window: Boolean?
+        get() = preferences.getBoolean(
+            QWERTY_SHOW_POPUP_WINDOW.first,
+            QWERTY_SHOW_POPUP_WINDOW.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(QWERTY_SHOW_POPUP_WINDOW.first, value ?: true)
         }
 
     var show_candidates_password: Boolean?

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
@@ -98,51 +98,41 @@ class SettingFragment : PreferenceFragmentCompat() {
             requireContext().packageName, 0
         )
 
-        val sumireInputPreference =
-            findPreference<ListPreference>("sumire_keyboard_input_type_preference")
-
-        val originalEntries = sumireInputPreference?.entries
-        val originalEntryValues = sumireInputPreference?.entryValues
-
-        sumireInputPreference?.apply {
-            // 現在の値に基づいてsummaryを初期設定
-            summary = when (value) {
-                "flick-default" -> "フリック入力 - Default"
-                "flick-circle" -> "フリック入力 - Circle"
-                "flick-sumire" -> "スミレ入力"
-                else -> "入力スタイルを選択"
-            }
-
-            // ダイアログが表示される直前のクリックイベントをリッスン
-            setOnPreferenceClickListener { pref ->
-                // ★★★ 変更点：countの値に基づいて表示するリストを切り替える ★★★
-                if (originalEntries != null && originalEntryValues != null) {
-                    if (count >= 5) {
-                        // countが5以上なら、元の完全なリストを復元
-                        entries = originalEntries
-                        entryValues = originalEntryValues
-                    } else {
-                        // countが5未満なら、最後のアイテムを除いたリストを表示
-                        if (originalEntries.isNotEmpty()) {
-                            entries = originalEntries.copyOfRange(0, originalEntries.size - 1)
-                            entryValues =
-                                originalEntryValues.copyOfRange(0, originalEntryValues.size - 1)
-                        }
-                    }
+        val sumireStylePreference =
+            findPreference<ListPreference>("sumire_keyboard_style_preference")
+        sumireStylePreference?.apply {
+            val originalEntries = this.entries
+            val originalEntryValues = this.entryValues
+            setOnPreferenceClickListener {
+                if (count >= 5) {
+                    entries = originalEntries
+                    entryValues = originalEntryValues
+                } else {
+                    entries = originalEntries.dropLast(1).toTypedArray()
+                    entryValues = originalEntryValues.dropLast(1).toTypedArray()
                 }
-                // trueを返して通常のダイアログ表示処理を続行
+                return@setOnPreferenceClickListener true
+            }
+            summary = entries[findIndexOfValue(value)].toString()
+            setOnPreferenceChangeListener { preference, newValue ->
+                val listPreference = preference as ListPreference
+                val index = listPreference.findIndexOfValue(newValue as String)
+                if (index >= 0) {
+                    preference.summary = listPreference.entries[index].toString()
+                }
                 true
             }
+        }
 
-            // 値が変更されたときにsummaryを更新
+        val sumireMethodPreference =
+            findPreference<ListPreference>("sumire_input_method_preference")
+        sumireMethodPreference?.apply {
+            summary = entries[findIndexOfValue(value)].toString() // 現在の選択肢をサマリーに表示
             setOnPreferenceChangeListener { preference, newValue ->
-                if (newValue is String) {
-                    preference.summary = when (newValue) {
-                        "flick-default" -> "フリック入力 - Default"
-                        "flick-circle" -> "フリック入力 - Circle"
-                        "flick-sumire" -> "スミレ入力"
-                        else -> preference.summary
-                    }
+                val listPreference = preference as ListPreference
+                val index = listPreference.findIndexOfValue(newValue as String)
+                if (index >= 0) {
+                    preference.summary = listPreference.entries[index].toString()
                 }
                 true
             }

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -51,6 +51,14 @@
                 android:title="パスワード入力時の変換候補" />
 
             <SwitchPreferenceCompat
+                android:defaultValue="false"
+                android:dependency="hide_candidate_password_preference"
+                android:key="password_compose_preference"
+                android:summaryOff="パスワード入力中に確定文字として扱います。"
+                android:summaryOn="パスワード入力中に未確定文字として扱います。"
+                android:title="パスワード入力中の文字列の設定" />
+
+            <SwitchPreferenceCompat
                 android:defaultValue="true"
                 android:key="henkan_delete_key_action_preference"
                 android:summaryOff="削除キータップ：ハイライト解除"

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -172,13 +172,23 @@
             android:key="sumire_input_preference_category"
             android:title="スミレ入力キーボード"
             app:isPreferenceVisible="true">
+
             <ListPreference
-                android:defaultValue="flick-default"
-                android:dialogTitle="選択してください"
-                android:entries="@array/sumire_keyboard_input_options"
-                android:entryValues="@array/sumire_keyboard_input_values"
-                android:key="sumire_keyboard_input_type_preference"
-                android:summary="フリック入力 - Default"
+                android:defaultValue="toggle"
+                android:dialogTitle="方式を選択"
+                android:entries="@array/sumire_input_method_options"
+                android:entryValues="@array/sumire_input_method_values"
+                android:key="sumire_input_method_preference"
+                android:summary="%s"
+                android:title="キーの配置" />
+
+            <ListPreference
+                android:defaultValue="default"
+                android:dialogTitle="スタイルを選択"
+                android:entries="@array/sumire_keyboard_style_options"
+                android:entryValues="@array/sumire_keyboard_style_values"
+                android:key="sumire_keyboard_style_preference"
+                android:summary="%s"
                 android:title="入力スタイル" />
         </PreferenceCategory>
 

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -120,6 +120,13 @@
 
         <PreferenceCategory android:title="QWERTY キーボード">
             <SwitchPreferenceCompat
+                android:defaultValue="true"
+                android:key="qwerty_show_popup_window_preference"
+                android:summaryOff="キーを検知した際にウィンドウを表示しません。"
+                android:summaryOn="キーを検知した際にウィンドウを表示します。"
+                android:title="ポップアップウィンドウの表示" />
+
+            <SwitchPreferenceCompat
                 android:defaultValue="false"
                 android:key="qwerty_show_cursor_buttons_preference"
                 android:summaryOff="QWERTY キーボードにカーソルボタンを表示しません。"

--- a/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKey.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKey.kt
@@ -43,4 +43,6 @@ sealed class QWERTYKey {
     data object QWERTYKeyCursorRight : QWERTYKey()
     data object QWERTYKeyCursorUp : QWERTYKey()
     data object QWERTYKeyCursorDown : QWERTYKey()
+
+    data object QWERTYKeySwitchRomajiEnglish : QWERTYKey()
 }

--- a/core/src/main/java/com/kazumaproject/core/domain/state/TenKeyQWERTYMode.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/state/TenKeyQWERTYMode.kt
@@ -3,6 +3,7 @@ package com.kazumaproject.core.domain.state
 sealed class TenKeyQWERTYMode {
     data object Default : TenKeyQWERTYMode()
     data object TenKeyQWERTY : TenKeyQWERTYMode()
+    data object TenKeyQWERTYRomaji : TenKeyQWERTYMode()
     data object Sumire : TenKeyQWERTYMode()
     data object Custom : TenKeyQWERTYMode()
     data object Number : TenKeyQWERTYMode()

--- a/core/src/main/res/drawable/outline_arrow_left_alt_24.xml
+++ b/core/src/main/res/drawable/outline_arrow_left_alt_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="@color/keyboard_icon_color"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="@color/keyboard_icon_color"
+        android:pathData="M400,720L160,480L400,240L456,298L314,440L800,440L800,520L314,520L456,662L400,720Z" />
+
+</vector>

--- a/core/src/main/res/drawable/outline_arrow_right_alt_24.xml
+++ b/core/src/main/res/drawable/outline_arrow_right_alt_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="@color/keyboard_icon_color"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+
+    <path
+        android:fillColor="@color/keyboard_icon_color"
+        android:pathData="M560,720L504,662L646,520L160,520L160,440L646,440L504,298L560,240L800,480L560,720Z" />
+
+</vector>

--- a/core/src/main/res/values/arrays.xml
+++ b/core/src/main/res/values/arrays.xml
@@ -24,24 +24,30 @@
         <item>both</item>
     </string-array>
 
-    <string-array name="sumire_keyboard_input_options">
-        <item>トグル入力 - Toggle</item>
-        <item>フリック入力 - Flick</item>
-        <item>サークル入力 - Toggle</item>
-        <item>サークル入力 - Flick</item>
-        <item>２段フリック入力 - Toggle</item>
-        <item>２段フリック入力 - Flick</item>
+    <string-array name="sumire_keyboard_style_options">
+        <item>通常入力</item>
+        <item>サークル入力</item>
+        <item>２段フリック入力</item>
         <item>スミレ入力</item>
     </string-array>
 
-    <string-array name="sumire_keyboard_input_values">
-        <item>toggle-default</item>
-        <item>flick-default</item>
-        <item>flick-circle</item>
-        <item>flick-circle-flick</item>
+    <string-array name="sumire_keyboard_style_values">
+        <item>default</item>
+        <item>circle</item>
         <item>second-flick</item>
-        <item>second-flick-flick</item>
-        <item>flick-sumire</item>
+        <item>sumire</item>
+    </string-array>
+
+    <string-array name="sumire_input_method_options">
+        <item>トグル入力</item>
+        <item>フリック入力</item>
+        <item>カーソル入力</item>
+    </string-array>
+
+    <string-array name="sumire_input_method_values">
+        <item>toggle</item>
+        <item>flick</item>
+        <item>switch-mode-effective</item>
     </string-array>
 
     <string-array name="parts_of_speech">

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
@@ -1,7 +1,7 @@
 package com.kazumaproject.custom_keyboard.data
 
 import androidx.annotation.DrawableRes
-import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection as TfbiFlickDirection
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 
 // キーボードの見た目ではなく、入力の「モード」を定義する
 enum class KeyboardInputMode {
@@ -51,6 +51,7 @@ sealed class KeyAction {
     // ひらがな・英語用
     data object ToggleDakuten : KeyAction() // 濁点・半濁点・小文字化
     data object ToggleCase : KeyAction()    // 英語の大文字・小文字切り替え
+    data object ToggleKatakana : KeyAction()    // カタカナ切り替え
 }
 
 data class KeyData(

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -20,132 +20,84 @@ object KeyboardDefaultLayouts {
     fun createFinalLayout(
         mode: KeyboardInputMode,
         dynamicKeyStates: Map<String, Int>,
-        inputType: String,
+        inputLayoutType: String,
+        inputStyle: String
     ): KeyboardLayout {
-        Log.d("createFinalLayout:", "$dynamicKeyStates")
-        val baseLayout = when (inputType) {
-            "toggle-default" -> {
+        Log.d("createFinalLayout:", "$inputLayoutType $inputStyle $mode")
+        val baseLayout = when (inputLayoutType) {
+            "toggle" -> {
                 when (mode) {
                     KeyboardInputMode.HIRAGANA -> {
-                        createHiraganaStandardFlickLayout(isDefaultKey = true)
+                        createHiraganaToggleLayout(inputStyle)
                     }
 
                     KeyboardInputMode.ENGLISH -> {
-                        createEnglishStandardFlickLayout(
+                        createEnglishToggleLayout(
                             isUpperCase = false,
-                            isDefaultKey = true
+                            inputStyle = inputStyle
                         )
                     }
 
                     KeyboardInputMode.SYMBOLS -> {
-                        createSymbolStandardFlickLayout(isDefaultKey = true)
+                        createSymbolToggleLayout(inputStyle = inputStyle)
                     }
                 }
             }
 
-            "flick-default" -> {
+            "flick" -> {
                 when (mode) {
                     KeyboardInputMode.HIRAGANA -> {
-                        createFlickKanaLayout(isDefaultKey = true)
+                        createHiraganaFlickLayout(inputStyle)
                     }
 
                     KeyboardInputMode.ENGLISH -> {
-                        createFlickEnglishLayout(
-                            isDefaultKey = true,
-                            isUpperCase = false
+                        createEnglishFlickLayout(
+                            isUpperCase = false,
+                            inputStyle = inputStyle
                         )
                     }
 
                     KeyboardInputMode.SYMBOLS -> {
-                        createFlickNumberLayout(isDefaultKey = true)
+                        createSymbolFlickLayout(inputStyle = inputStyle)
                     }
                 }
             }
 
-            "flick-circle" -> {
-                when (mode) {
-                    KeyboardInputMode.HIRAGANA -> createHiraganaStandardFlickLayout(isDefaultKey = false)
-                    KeyboardInputMode.ENGLISH -> createEnglishStandardFlickLayout(
-                        isUpperCase = false,
-                        isDefaultKey = false
-                    )
-
-                    KeyboardInputMode.SYMBOLS -> createSymbolStandardFlickLayout(isDefaultKey = false)
-                }
-            }
-
-            "flick-circle-flick" -> {
-                when (mode) {
-                    KeyboardInputMode.HIRAGANA -> createFlickKanaLayout(isDefaultKey = false)
-                    KeyboardInputMode.ENGLISH -> createFlickEnglishLayout(
-                        isUpperCase = false,
-                        isDefaultKey = false
-                    )
-
-                    KeyboardInputMode.SYMBOLS -> createFlickNumberLayout(isDefaultKey = false)
-                }
-            }
-
-            "flick-sumire" -> {
-                when (mode) {
-                    KeyboardInputMode.HIRAGANA -> createHiraganaLayout()
-                    KeyboardInputMode.ENGLISH -> createEnglishLayout(isUpperCase = false)
-                    KeyboardInputMode.SYMBOLS -> createSymbolLayout()
-                }
-            }
-
-            "second-flick" -> {
+            "switch-mode-effective" -> {
                 when (mode) {
                     KeyboardInputMode.HIRAGANA -> {
-                        createTwoStepFlickLayout(isDefaultKey = true)
+                        createHiraganaEffectiveLayout(inputStyle)
                     }
 
                     KeyboardInputMode.ENGLISH -> {
-                        createEnglishStandardFlickLayout(
-                            isDefaultKey = true,
-                            isUpperCase = false
+                        createEnglishEffectiveLayout(
+                            isUpperCase = false,
+                            inputStyle = inputStyle
                         )
                     }
 
                     KeyboardInputMode.SYMBOLS -> {
-                        createSymbolStandardFlickLayout(isDefaultKey = true)
-                    }
-                }
-            }
-
-            "second-flick-flick" -> {
-                when (mode) {
-                    KeyboardInputMode.HIRAGANA -> {
-                        createTwoStepFlickFlickLayout(isDefaultKey = true)
-                    }
-
-                    KeyboardInputMode.ENGLISH -> {
-                        createFlickEnglishLayout(
-                            isDefaultKey = true,
-                            isUpperCase = false
-                        )
-                    }
-
-                    KeyboardInputMode.SYMBOLS -> {
-                        createFlickNumberLayout(isDefaultKey = true)
+                        createNumberEffectiveLayout()
                     }
                 }
             }
 
             else -> {
                 when (mode) {
-                    KeyboardInputMode.HIRAGANA -> createHiraganaStandardFlickLayout(
-                        isDefaultKey = true
-                    )
+                    KeyboardInputMode.HIRAGANA -> {
+                        createHiraganaToggleLayout(inputStyle)
+                    }
 
-                    KeyboardInputMode.ENGLISH -> createEnglishStandardFlickLayout(
-                        isUpperCase = false,
-                        isDefaultKey = true
-                    )
+                    KeyboardInputMode.ENGLISH -> {
+                        createEnglishToggleLayout(
+                            isUpperCase = false,
+                            inputStyle = inputStyle
+                        )
+                    }
 
-                    KeyboardInputMode.SYMBOLS -> createSymbolStandardFlickLayout(
-                        isDefaultKey = true
-                    )
+                    KeyboardInputMode.SYMBOLS -> {
+                        createSymbolToggleLayout(inputStyle = inputStyle)
+                    }
                 }
             }
         }
@@ -172,6 +124,7 @@ object KeyboardDefaultLayouts {
         FlickAction.Action(
             KeyAction.Enter, "検索",
         ),
+        FlickAction.Action(KeyAction.Enter, "次")
     )
 
     private val dakutenToggleStates = listOf(
@@ -186,9 +139,45 @@ object KeyboardDefaultLayouts {
         )
     )
 
+    private val katakanaToggleStates = listOf(
+        FlickAction.Action(
+            KeyAction.SwitchToNumberLayout,
+            drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom
+        ),
+        FlickAction.Action(
+            KeyAction.ToggleKatakana,
+            label = " カナ",
+        )
+    )
+
     private val spaceConvertStates = listOf(
         FlickAction.Action(KeyAction.Space, "空白"),
         FlickAction.Action(KeyAction.Convert, "変換")
+    )
+
+    private val spaceConvertStatesCursor = listOf(
+        FlickAction.Action(
+            KeyAction.Space,
+            label = "空白",
+            drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+        ),
+        FlickAction.Action(KeyAction.Convert, "変換")
+    )
+
+    private val enterKeyStatesCursor = listOf(
+        FlickAction.Action(KeyAction.NewLine, "改行"),
+        FlickAction.Action(
+            KeyAction.Confirm,
+            drawableResId = com.kazumaproject.core.R.drawable.baseline_keyboard_return_24
+        ),
+        FlickAction.Action(
+            KeyAction.Enter,
+            drawableResId = com.kazumaproject.core.R.drawable.baseline_keyboard_return_24,
+        ),
+        FlickAction.Action(
+            KeyAction.Enter, "Go",
+        ),
+        FlickAction.Action(KeyAction.Enter, "Next")
     )
 
     /**
@@ -218,8 +207,7 @@ object KeyboardDefaultLayouts {
         return baseLayout.copy(keys = newKeys)
     }
 
-    //region Hiragana Layout
-    fun createHiraganaLayout(): KeyboardLayout {
+    private fun createHiraganaLayout(): KeyboardLayout {
         val keys = listOf(
             KeyData(
                 label = "PasteActionKey",
@@ -540,9 +528,7 @@ object KeyboardDefaultLayouts {
 
         return KeyboardLayout(keys, flickMaps, 5, 4)
     }
-    //endregion
 
-    //region English Layout
     private fun createEnglishLayout(isUpperCase: Boolean): KeyboardLayout {
         // KeyDataのリストは変更ありません
         val keys = listOf(
@@ -866,7 +852,6 @@ object KeyboardDefaultLayouts {
         return KeyboardLayout(keys, flickMaps, 5, 4)
     }
 
-    //region Symbol Layout
     private fun createSymbolLayout(): KeyboardLayout {
         // --- KEY DEFINITIONS (Cleaned up) ---
         val keys = listOf(
@@ -1169,7 +1154,6 @@ object KeyboardDefaultLayouts {
         // The layout uses 5 columns and 4 rows
         return KeyboardLayout(keys, flickMaps, 5, 4)
     }
-    //endregion
 
     private fun createDefaultFlickLayout(
         isDefaultKey: Boolean
@@ -1632,1894 +1616,6 @@ object KeyboardDefaultLayouts {
         )
 
         return KeyboardLayout(keys, flickMaps, 4, 4)
-    }
-
-    private fun createHiraganaStandardFlickLayout(
-        isDefaultKey: Boolean
-    ): KeyboardLayout {
-        val keys = listOf(
-            KeyData(
-                "PasteActionKey",
-                0,
-                0,
-                false,
-                KeyAction.Paste,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "CursorMoveLeft",
-                1,
-                0,
-                false,
-                KeyAction.MoveCursorLeft,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
-                keyType = KeyType.CROSS_FLICK,
-            ),
-            KeyData(
-                "モード",
-                2,
-                0,
-                false,
-                KeyAction.ChangeInputMode,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
-            ),
-            KeyData(
-                "",
-                3,
-                0,
-                false,
-                KeyAction.SwitchToNextIme,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
-            ),
-            KeyData(
-                "あ",
-                0,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "か",
-                0,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "さ",
-                0,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "た",
-                1,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "な",
-                1,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "は",
-                1,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "ま",
-                2,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "や",
-                2,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "ら",
-                2,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                dakutenToggleStates[0].label ?: "",
-                3,
-                1,
-                false,
-                dakutenToggleStates[0].action,
-                dynamicStates = dakutenToggleStates,
-                keyId = "dakuten_toggle_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "わ",
-                3,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "、。?!",
-                3,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ), // Label fixed to match map key
-            KeyData(
-                "Del",
-                0,
-                4,
-                false,
-                KeyAction.Delete,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
-            ),
-            KeyData(
-                spaceConvertStates[0].label ?: "",
-                1,
-                4,
-                true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                keyId = "space_convert_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
-                2,
-                4,
-                false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
-                isSpecialKey = true,
-                rowSpan = 2,
-                drawableResId = enterKeyStates[0].drawableResId,
-                keyId = "enter_key"
-            )
-        )
-
-        val pasteActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Paste,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.SelectAll,
-                drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.Copy,
-                drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
-            )
-        )
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            )
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
-            )
-        )
-
-        val conversionActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Convert,
-            ),
-        )
-
-        // 状態0 (^_^): タップ操作のみを持つマップ
-        val emojiStateFlickMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.InputText("^_^"),
-                label = "^_^"
-            )
-            // この状態ではフリックアクションを定義しない
-        )
-
-        // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
-        val dakutenStateFlickMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.ToggleDakuten,
-                label = " 小゛゜"
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.InputText("ひらがな小文字"),
-                label = "小"
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.InputText("濁点"),
-                label = "゛"
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.InputText("半濁点"),
-                label = "゜"
-            )
-        )
-
-        val a = mapOf(
-            FlickDirection.TAP to FlickAction.Input("あ"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("い"),
-            FlickDirection.UP to FlickAction.Input("う"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え"),
-            FlickDirection.DOWN to FlickAction.Input("お")
-        )
-        val ka = mapOf(
-            FlickDirection.TAP to FlickAction.Input("か"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("き"),
-            FlickDirection.UP to FlickAction.Input("く"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("け"),
-            FlickDirection.DOWN to FlickAction.Input("こ")
-        )
-        val sa = mapOf(
-            FlickDirection.TAP to FlickAction.Input("さ"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("し"),
-            FlickDirection.UP to FlickAction.Input("す"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("せ"),
-            FlickDirection.DOWN to FlickAction.Input("そ")
-        )
-        val ta = mapOf(
-            FlickDirection.TAP to FlickAction.Input("た"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("ち"),
-            FlickDirection.UP to FlickAction.Input("つ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("て"),
-            FlickDirection.DOWN to FlickAction.Input("と")
-        )
-        val na = mapOf(
-            FlickDirection.TAP to FlickAction.Input("な"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("に"),
-            FlickDirection.UP to FlickAction.Input("ぬ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ね"),
-            FlickDirection.DOWN to FlickAction.Input("の")
-        )
-        val ha = mapOf(
-            FlickDirection.TAP to FlickAction.Input("は"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("ひ"),
-            FlickDirection.UP to FlickAction.Input("ふ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("へ"),
-            FlickDirection.DOWN to FlickAction.Input("ほ")
-        )
-        val ma = mapOf(
-            FlickDirection.TAP to FlickAction.Input("ま"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("み"),
-            FlickDirection.UP to FlickAction.Input("む"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("め"),
-            FlickDirection.DOWN to FlickAction.Input("も")
-        )
-        val ya = mapOf(
-            FlickDirection.TAP to FlickAction.Input("や"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
-            FlickDirection.UP to FlickAction.Input("ゆ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
-            FlickDirection.DOWN to FlickAction.Input("よ")
-        )
-        val ra = mapOf(
-            FlickDirection.TAP to FlickAction.Input("ら"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("り"),
-            FlickDirection.UP to FlickAction.Input("る"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("れ"),
-            FlickDirection.DOWN to FlickAction.Input("ろ")
-        )
-        val wa = mapOf(
-            FlickDirection.TAP to FlickAction.Input("わ"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("を"),
-            FlickDirection.UP to FlickAction.Input("ん"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー")
-        )
-        val symbols = mapOf(
-            FlickDirection.TAP to FlickAction.Input("、"),
-            FlickDirection.UP to FlickAction.Input("？"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
-            FlickDirection.DOWN to FlickAction.Input("…")
-        )
-
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "PasteActionKey" to listOf(pasteActionMap),
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "あ" to listOf(a),
-            "か" to listOf(ka),
-            "さ" to listOf(sa),
-            "た" to listOf(ta),
-            "な" to listOf(na),
-            "は" to listOf(ha),
-            "ま" to listOf(ma),
-            "や" to listOf(ya),
-            "ら" to listOf(ra),
-            "わ" to listOf(wa),
-            "、。?!" to listOf(symbols),
-        )
-
-        dakutenToggleStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(emojiStateFlickMap))
-        }
-        dakutenToggleStates.getOrNull(1)?.label?.let { label ->
-            flickMaps.put(label, listOf(dakutenStateFlickMap))
-        }
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        spaceConvertStates.getOrNull(1)?.label?.let { label ->
-            flickMaps.put(label, listOf(conversionActionMap))
-        }
-
-        return KeyboardLayout(keys, flickMaps, 5, 4)
-    }
-
-    //region English Layout
-    private fun createEnglishStandardFlickLayout(
-        isUpperCase: Boolean,
-        isDefaultKey: Boolean
-    ): KeyboardLayout {
-        val keys = listOf(
-            KeyData(
-                "PasteActionKey",
-                0,
-                0,
-                false,
-                KeyAction.Paste,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "CursorMoveLeft",
-                1,
-                0,
-                false,
-                KeyAction.MoveCursorLeft,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "モード",
-                2,
-                0,
-                false,
-                KeyAction.ChangeInputMode,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom
-            ),
-            KeyData(
-                "",
-                3,
-                0,
-                false,
-                KeyAction.SwitchToNextIme,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
-            ),
-            KeyData(
-                "@#/_",
-                0,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "ABC",
-                0,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "DEF",
-                0,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "GHI",
-                1,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "JKL",
-                1,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "MNO",
-                1,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "PQRS",
-                2,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "TUV",
-                2,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "WXYZ",
-                2,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "a/A",
-                3,
-                1,
-                false,
-                action = KeyAction.ToggleCase,
-                isSpecialKey = false
-            ),
-            KeyData(
-                "' \" ( )",
-                3,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                ". , ? !",
-                3,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "Del",
-                0,
-                4,
-                false,
-                KeyAction.Delete,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
-            ),
-            KeyData(
-                spaceConvertStates[0].label ?: "",
-                1,
-                4,
-                true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                keyId = "space_convert_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
-                2,
-                4,
-                false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
-                isSpecialKey = true,
-                rowSpan = 2,
-                drawableResId = enterKeyStates[0].drawableResId,
-                keyId = "enter_key"
-            )
-        )
-
-        val pasteActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Paste,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.SelectAll,
-                drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.Copy,
-                drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
-            )
-        )
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            )
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
-            )
-        )
-
-        fun getCase(c: Char) = if (isUpperCase) c.uppercaseChar() else c
-        val symbols1 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("@"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("#"),
-            FlickDirection.UP to FlickAction.Input("/"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("_"),
-            FlickDirection.DOWN to FlickAction.Input("1")
-        )
-        val abc = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('a').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('b').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('c').toString()),
-            FlickDirection.DOWN to FlickAction.Input("2")
-        )
-        val def = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('d').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('e').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('f').toString()),
-            FlickDirection.DOWN to FlickAction.Input("3")
-        )
-        val ghi = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('g').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('h').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('i').toString()),
-            FlickDirection.DOWN to FlickAction.Input("4")
-        )
-        val jkl = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('j').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('k').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('l').toString()),
-            FlickDirection.DOWN to FlickAction.Input("5")
-        )
-        val mno = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('m').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('n').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('o').toString()),
-            FlickDirection.DOWN to FlickAction.Input("6")
-        )
-        val pqrs = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('p').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('q').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('r').toString()),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('s').toString()),
-            FlickDirection.DOWN to FlickAction.Input("7")
-        )
-        val tuv = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('t').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('u').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('v').toString()),
-            FlickDirection.DOWN to FlickAction.Input("8")
-        )
-        val wxyz = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('w').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('x').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('y').toString()),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('z').toString()),
-            FlickDirection.DOWN to FlickAction.Input("9")
-        )
-        val symbols2 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("'"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("\""),
-            FlickDirection.UP to FlickAction.Input("("),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
-            FlickDirection.DOWN to FlickAction.Input("0")
-        )
-        val symbols3 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("."),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
-            FlickDirection.UP to FlickAction.Input("?"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("!"),
-            FlickDirection.DOWN to FlickAction.Input("-")
-        )
-
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "PasteActionKey" to listOf(pasteActionMap),
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "@#/_" to listOf(symbols1),
-            "ABC" to listOf(abc),
-            "DEF" to listOf(def),
-            "GHI" to listOf(ghi),
-            "JKL" to listOf(jkl),
-            "MNO" to listOf(mno),
-            "PQRS" to listOf(pqrs),
-            "TUV" to listOf(tuv),
-            "WXYZ" to listOf(wxyz),
-            "' \" ( )" to listOf(symbols2),
-            ". , ? !" to listOf(symbols3)
-        )
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        return KeyboardLayout(keys, flickMaps, 5, 4)
-    }
-    //endregion
-
-    //region Symbol Layout
-    private fun createSymbolStandardFlickLayout(
-        isDefaultKey: Boolean
-    ): KeyboardLayout {
-        val keys = listOf(
-            KeyData(
-                "PasteActionKey",
-                0,
-                0,
-                true,
-                KeyAction.Paste,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "CursorMoveLeft",
-                1,
-                0,
-                true,
-                KeyAction.MoveCursorLeft,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "モード",
-                2,
-                0,
-                false,
-                KeyAction.ChangeInputMode,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom
-            ),
-            KeyData(
-                "",
-                3,
-                0,
-                false,
-                KeyAction.SwitchToNextIme,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
-            ),
-            KeyData(
-                "1\n☆♪→",
-                0,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "2\n￥$€",
-                0,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "3\n%°#",
-                0,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "4\n○*・",
-                1,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "5\n+x÷",
-                1,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "6\n< = >",
-                1,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "7\n「」:",
-                2,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "8\n〒々〆",
-                2,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "9\n^|\\",
-                2,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "0\n〜…",
-                3,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "( ) [ ]",
-                3,
-                1,
-                true,
-                isSpecialKey = false,
-                colSpan = 1,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                ".,-/",
-                3,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "Del",
-                0,
-                4,
-                false,
-                KeyAction.Delete,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
-            ),
-            KeyData(
-                spaceConvertStates[0].label ?: "",
-                1,
-                4,
-                true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                keyId = "space_convert_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
-                2,
-                4,
-                false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
-                isSpecialKey = true,
-                rowSpan = 2,
-                drawableResId = enterKeyStates[0].drawableResId,
-                keyId = "enter_key"
-            )
-        )
-
-        val pasteActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Paste,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.SelectAll,
-                drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.Copy,
-                drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
-            )
-        )
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            )
-        )
-        val symbols3 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("."),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
-            FlickDirection.UP to FlickAction.Input("-"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("/")
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
-            )
-        )
-
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "PasteActionKey" to listOf(pasteActionMap),
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "1\n☆♪→" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("1"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("☆"),
-                    FlickDirection.UP to FlickAction.Input("♪"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("→"),
-                )
-            ),
-            "2\n￥$€" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("2"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("￥"),
-                    FlickDirection.UP to FlickAction.Input("$"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("€"),
-                )
-            ),
-            "3\n%°#" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("3"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("%"),
-                    FlickDirection.UP to FlickAction.Input("°"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("#"),
-                )
-            ),
-            "4\n○*・" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("4"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("○"),
-                    FlickDirection.UP to FlickAction.Input("*"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("・"),
-
-                    )
-            ),
-            "5\n+x÷" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("5"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("+"),
-                    FlickDirection.UP to FlickAction.Input("x"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("÷"),
-                ),
-            ),
-            "6\n< = >" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("6"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("<"),
-                    FlickDirection.UP to FlickAction.Input("="),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(">"),
-                )
-            ),
-            "7\n「」:" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("7"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("「"),
-                    FlickDirection.UP to FlickAction.Input("」"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(":"),
-                )
-            ),
-            "8\n〒々〆" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("8"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("〒"), // Double quote
-                    FlickDirection.UP to FlickAction.Input("々"),   // Single quote
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〆"),
-                )
-            ),
-            "9\n^|\\" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("9"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("^"),   // Square brackets
-                    FlickDirection.UP to FlickAction.Input("|"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("\\"),   // Curly braces
-                )
-            ),
-            "0\n〜…" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("0"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("〜"),
-                    FlickDirection.UP to FlickAction.Input("…"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("√"),
-                )
-            ),
-            "( ) [ ]" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("("),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(")"),
-                    FlickDirection.UP to FlickAction.Input("["),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("]"),
-                )
-            ),
-            ".,-/" to listOf(symbols3),
-        )
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        return KeyboardLayout(keys, flickMaps, 5, 4)
-    }
-
-    private fun createFlickKanaLayout(
-        isDefaultKey: Boolean
-    ): KeyboardLayout {
-        val keys = listOf(
-            KeyData(
-                "SwitchToNumber",
-                0,
-                0,
-                false,
-                KeyAction.SwitchToNumberLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
-            ),
-            KeyData(
-                "SwitchToEnglish",
-                1,
-                0,
-                false,
-                KeyAction.SwitchToEnglishLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
-            ),
-            KeyData(
-                "SwitchToKana",
-                2,
-                0,
-                false,
-                KeyAction.SwitchToKanaLayout,
-                isSpecialKey = true,
-                isHiLighted = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
-            ),
-            KeyData(
-                "",
-                3,
-                0,
-                false,
-                KeyAction.SwitchToNextIme,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
-            ),
-            KeyData(
-                "あ",
-                0,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "か",
-                0,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "さ",
-                0,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "た",
-                1,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "な",
-                1,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "は",
-                1,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "ま",
-                2,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "や",
-                2,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "ら",
-                2,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                dakutenToggleStates[0].label ?: "",
-                3,
-                1,
-                false,
-                dakutenToggleStates[0].action,
-                dynamicStates = dakutenToggleStates,
-                keyId = "dakuten_toggle_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "わ",
-                3,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "、。?!",
-                3,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ), // Label fixed to match map key
-            KeyData(
-                "Del",
-                0,
-                4,
-                false,
-                KeyAction.Delete,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
-            ),
-            KeyData(
-                spaceConvertStates[0].label ?: "",
-                1,
-                4,
-                true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                keyId = "space_convert_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "CursorMoveLeft",
-                2,
-                4,
-                false,
-                KeyAction.MoveCursorRight,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
-                keyType = KeyType.CROSS_FLICK,
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
-                3,
-                4,
-                false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = enterKeyStates[0].drawableResId,
-                keyId = "enter_key"
-            )
-        )
-
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            )
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
-            )
-        )
-
-        val conversionActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Convert,
-            ),
-        )
-
-        // 状態0 (^_^): タップ操作のみを持つマップ
-        val emojiStateFlickMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.InputText("^_^"),
-                label = "^_^"
-            )
-            // この状態ではフリックアクションを定義しない
-        )
-
-        // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
-        val dakutenStateFlickMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.ToggleDakuten,
-                label = " 小゛゜"
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.InputText("ひらがな小文字"),
-                label = "小"
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.InputText("濁点"),
-                label = "゛"
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.InputText("半濁点"),
-                label = "゜"
-            )
-        )
-
-        val a = mapOf(
-            FlickDirection.TAP to FlickAction.Input("あ"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("い"),
-            FlickDirection.UP to FlickAction.Input("う"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え"),
-            FlickDirection.DOWN to FlickAction.Input("お")
-        )
-        val ka = mapOf(
-            FlickDirection.TAP to FlickAction.Input("か"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("き"),
-            FlickDirection.UP to FlickAction.Input("く"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("け"),
-            FlickDirection.DOWN to FlickAction.Input("こ")
-        )
-        val sa = mapOf(
-            FlickDirection.TAP to FlickAction.Input("さ"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("し"),
-            FlickDirection.UP to FlickAction.Input("す"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("せ"),
-            FlickDirection.DOWN to FlickAction.Input("そ")
-        )
-        val ta = mapOf(
-            FlickDirection.TAP to FlickAction.Input("た"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("ち"),
-            FlickDirection.UP to FlickAction.Input("つ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("て"),
-            FlickDirection.DOWN to FlickAction.Input("と")
-        )
-        val na = mapOf(
-            FlickDirection.TAP to FlickAction.Input("な"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("に"),
-            FlickDirection.UP to FlickAction.Input("ぬ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ね"),
-            FlickDirection.DOWN to FlickAction.Input("の")
-        )
-        val ha = mapOf(
-            FlickDirection.TAP to FlickAction.Input("は"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("ひ"),
-            FlickDirection.UP to FlickAction.Input("ふ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("へ"),
-            FlickDirection.DOWN to FlickAction.Input("ほ")
-        )
-        val ma = mapOf(
-            FlickDirection.TAP to FlickAction.Input("ま"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("み"),
-            FlickDirection.UP to FlickAction.Input("む"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("め"),
-            FlickDirection.DOWN to FlickAction.Input("も")
-        )
-        val ya = mapOf(
-            FlickDirection.TAP to FlickAction.Input("や"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
-            FlickDirection.UP to FlickAction.Input("ゆ"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
-            FlickDirection.DOWN to FlickAction.Input("よ")
-        )
-        val ra = mapOf(
-            FlickDirection.TAP to FlickAction.Input("ら"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("り"),
-            FlickDirection.UP to FlickAction.Input("る"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("れ"),
-            FlickDirection.DOWN to FlickAction.Input("ろ")
-        )
-        val wa = mapOf(
-            FlickDirection.TAP to FlickAction.Input("わ"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("を"),
-            FlickDirection.UP to FlickAction.Input("ん"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー")
-        )
-        val symbols = mapOf(
-            FlickDirection.TAP to FlickAction.Input("、"),
-            FlickDirection.UP to FlickAction.Input("？"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
-            FlickDirection.DOWN to FlickAction.Input("…")
-        )
-
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "あ" to listOf(a),
-            "か" to listOf(ka),
-            "さ" to listOf(sa),
-            "た" to listOf(ta),
-            "な" to listOf(na),
-            "は" to listOf(ha),
-            "ま" to listOf(ma),
-            "や" to listOf(ya),
-            "ら" to listOf(ra),
-            "わ" to listOf(wa),
-            "、。?!" to listOf(symbols),
-        )
-
-        dakutenToggleStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(emojiStateFlickMap))
-        }
-        dakutenToggleStates.getOrNull(1)?.label?.let { label ->
-            flickMaps.put(label, listOf(dakutenStateFlickMap))
-        }
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        spaceConvertStates.getOrNull(1)?.label?.let { label ->
-            flickMaps.put(label, listOf(conversionActionMap))
-        }
-
-        return KeyboardLayout(keys, flickMaps, 5, 4)
-    }
-
-    private fun createFlickEnglishLayout(
-        isDefaultKey: Boolean,
-        isUpperCase: Boolean,
-    ): KeyboardLayout {
-        val keys = listOf(
-            KeyData(
-                "SwitchToNumber",
-                0,
-                0,
-                false,
-                KeyAction.SwitchToNumberLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
-            ),
-            KeyData(
-                "SwitchToEnglish",
-                1,
-                0,
-                false,
-                KeyAction.SwitchToEnglishLayout,
-                isSpecialKey = true,
-                isHiLighted = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
-            ),
-            KeyData(
-                "SwitchToKana",
-                2,
-                0,
-                false,
-                KeyAction.SwitchToKanaLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
-            ),
-            KeyData(
-                "",
-                3,
-                0,
-                false,
-                KeyAction.SwitchToNextIme,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
-            ),
-            KeyData(
-                "@#/_",
-                0,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "ABC",
-                0,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "DEF",
-                0,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "GHI",
-                1,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "JKL",
-                1,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "MNO",
-                1,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "PQRS",
-                2,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "TUV",
-                2,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "WXYZ",
-                2,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "a/A",
-                3,
-                1,
-                false,
-                action = KeyAction.ToggleCase,
-                isSpecialKey = false
-            ),
-            KeyData(
-                "' \" ( )",
-                3,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                ". , ? !",
-                3,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "Del",
-                0,
-                4,
-                false,
-                KeyAction.Delete,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
-            ),
-            KeyData(
-                spaceConvertStates[0].label ?: "",
-                1,
-                4,
-                true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                keyId = "space_convert_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "CursorMoveLeft",
-                2,
-                4,
-                false,
-                KeyAction.MoveCursorRight,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
-                keyType = KeyType.CROSS_FLICK,
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
-                3,
-                4,
-                false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = enterKeyStates[0].drawableResId,
-                keyId = "enter_key"
-            )
-        )
-
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            )
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
-            )
-        )
-
-        fun getCase(c: Char) = if (isUpperCase) c.uppercaseChar() else c
-        val symbols1 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("@"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("#"),
-            FlickDirection.UP to FlickAction.Input("/"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("_"),
-            FlickDirection.DOWN to FlickAction.Input("1")
-        )
-        val abc = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('a').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('b').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('c').toString()),
-            FlickDirection.DOWN to FlickAction.Input("2")
-        )
-        val def = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('d').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('e').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('f').toString()),
-            FlickDirection.DOWN to FlickAction.Input("3")
-        )
-        val ghi = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('g').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('h').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('i').toString()),
-            FlickDirection.DOWN to FlickAction.Input("4")
-        )
-        val jkl = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('j').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('k').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('l').toString()),
-            FlickDirection.DOWN to FlickAction.Input("5")
-        )
-        val mno = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('m').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('n').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('o').toString()),
-            FlickDirection.DOWN to FlickAction.Input("6")
-        )
-        val pqrs = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('p').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('q').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('r').toString()),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('s').toString()),
-            FlickDirection.DOWN to FlickAction.Input("7")
-        )
-        val tuv = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('t').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('u').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('v').toString()),
-            FlickDirection.DOWN to FlickAction.Input("8")
-        )
-        val wxyz = mapOf(
-            FlickDirection.TAP to FlickAction.Input(getCase('w').toString()),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('x').toString()),
-            FlickDirection.UP to FlickAction.Input(getCase('y').toString()),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('z').toString()),
-            FlickDirection.DOWN to FlickAction.Input("9")
-        )
-        val symbols2 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("'"),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input("\""),
-            FlickDirection.UP to FlickAction.Input("("),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
-            FlickDirection.DOWN to FlickAction.Input("0")
-        )
-        val symbols3 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("."),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
-            FlickDirection.UP to FlickAction.Input("?"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("!"),
-            FlickDirection.DOWN to FlickAction.Input("-")
-        )
-
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "@#/_" to listOf(symbols1),
-            "ABC" to listOf(abc),
-            "DEF" to listOf(def),
-            "GHI" to listOf(ghi),
-            "JKL" to listOf(jkl),
-            "MNO" to listOf(mno),
-            "PQRS" to listOf(pqrs),
-            "TUV" to listOf(tuv),
-            "WXYZ" to listOf(wxyz),
-            "' \" ( )" to listOf(symbols2),
-            ". , ? !" to listOf(symbols3)
-        )
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        return KeyboardLayout(keys, flickMaps, 5, 4)
-    }
-
-    private fun createFlickNumberLayout(
-        isDefaultKey: Boolean,
-    ): KeyboardLayout {
-        val keys = listOf(
-            KeyData(
-                "SwitchToNumber",
-                0,
-                0,
-                false,
-                KeyAction.SwitchToNumberLayout,
-                isSpecialKey = true,
-                isHiLighted = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
-            ),
-            KeyData(
-                "SwitchToEnglish",
-                1,
-                0,
-                false,
-                KeyAction.SwitchToEnglishLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
-            ),
-            KeyData(
-                "SwitchToKana",
-                2,
-                0,
-                false,
-                KeyAction.SwitchToKanaLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
-            ),
-            KeyData(
-                "",
-                3,
-                0,
-                false,
-                KeyAction.SwitchToNextIme,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
-            ),
-            KeyData(
-                "1\n☆♪→",
-                0,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "2\n￥$€",
-                0,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "3\n%°#",
-                0,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "4\n○*・",
-                1,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "5\n+x÷",
-                1,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "6\n< = >",
-                1,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "7\n「」:",
-                2,
-                1,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "8\n〒々〆",
-                2,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "9\n^|\\",
-                2,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "0\n〜…",
-                3,
-                2,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "( ) [ ]",
-                3,
-                1,
-                true,
-                isSpecialKey = false,
-                colSpan = 1,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                ".,-/",
-                3,
-                3,
-                true,
-                keyType = if (isDefaultKey) KeyType.PETAL_FLICK else KeyType.STANDARD_FLICK
-            ),
-            KeyData(
-                "Del",
-                0,
-                4,
-                false,
-                KeyAction.Delete,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
-            ),
-            KeyData(
-                spaceConvertStates[0].label ?: "",
-                1,
-                4,
-                true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                keyId = "space_convert_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "CursorMoveLeft",
-                2,
-                4,
-                false,
-                KeyAction.MoveCursorRight,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
-                keyType = KeyType.CROSS_FLICK,
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
-                3,
-                4,
-                false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
-                isSpecialKey = true,
-                rowSpan = 1,
-                drawableResId = enterKeyStates[0].drawableResId,
-                keyId = "enter_key"
-            )
-        )
-
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            )
-        )
-
-        val symbols3 = mapOf(
-            FlickDirection.TAP to FlickAction.Input("."),
-            FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
-            FlickDirection.UP to FlickAction.Input("-"),
-            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("/")
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
-            )
-        )
-
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-            "1\n☆♪→" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("1"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("☆"),
-                    FlickDirection.UP to FlickAction.Input("♪"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("→"),
-                )
-            ),
-            "2\n￥$€" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("2"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("￥"),
-                    FlickDirection.UP to FlickAction.Input("$"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("€"),
-                )
-            ),
-            "3\n%°#" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("3"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("%"),
-                    FlickDirection.UP to FlickAction.Input("°"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("#"),
-                )
-            ),
-            "4\n○*・" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("4"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("○"),
-                    FlickDirection.UP to FlickAction.Input("*"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("・"),
-
-                    )
-            ),
-            "5\n+x÷" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("5"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("+"),
-                    FlickDirection.UP to FlickAction.Input("x"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("÷"),
-                ),
-            ),
-            "6\n< = >" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("6"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("<"),
-                    FlickDirection.UP to FlickAction.Input("="),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(">"),
-                )
-            ),
-            "7\n「」:" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("7"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("「"),
-                    FlickDirection.UP to FlickAction.Input("」"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(":"),
-                )
-            ),
-            "8\n〒々〆" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("8"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("〒"), // Double quote
-                    FlickDirection.UP to FlickAction.Input("々"),   // Single quote
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〆"),
-                )
-            ),
-            "9\n^|\\" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("9"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("^"),   // Square brackets
-                    FlickDirection.UP to FlickAction.Input("|"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("\\"),   // Curly braces
-                )
-            ),
-            "0\n〜…" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("0"),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("〜"),
-                    FlickDirection.UP to FlickAction.Input("…"),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("√"),
-                )
-            ),
-            "( ) [ ]" to listOf(
-                mapOf(
-                    FlickDirection.TAP to FlickAction.Input("("),
-                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(")"),
-                    FlickDirection.UP to FlickAction.Input("["),
-                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("]"),
-                )
-            ),
-            ".,-/" to listOf(symbols3),
-        )
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        return KeyboardLayout(keys, flickMaps, 5, 4)
     }
 
     fun createFlickKanaTemplateLayout(
@@ -4253,15 +2349,1321 @@ object KeyboardDefaultLayouts {
         return KeyboardLayout(keys, flickMaps, 4, 4)
     }
 
-    private fun createTwoStepFlickLayout(
-        isDefaultKey: Boolean
+    private fun createHiraganaToggleLayout(
+        inputStyle: String
+    ): KeyboardLayout {
+        return when (inputStyle) {
+            "second-flick" -> {
+                val keys = listOf(
+                    KeyData(
+                        "PasteActionKey",
+                        0,
+                        0,
+                        false,
+                        KeyAction.Paste,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "CursorMoveLeft",
+                        1,
+                        0,
+                        false,
+                        KeyAction.MoveCursorLeft,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
+                        keyType = KeyType.CROSS_FLICK,
+                    ),
+                    KeyData(
+                        "モード",
+                        2,
+                        0,
+                        false,
+                        KeyAction.ChangeInputMode,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                    ),
+                    KeyData(
+                        "",
+                        3,
+                        0,
+                        false,
+                        KeyAction.SwitchToNextIme,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                    ),
+                    KeyData(
+                        "あ",
+                        0,
+                        1,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "か",
+                        0,
+                        2,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "さ",
+                        0,
+                        3,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "た",
+                        1,
+                        1,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "な",
+                        1,
+                        2,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "は",
+                        1,
+                        3,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "ま",
+                        2,
+                        1,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "や",
+                        2,
+                        2,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "ら",
+                        2,
+                        3,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        dakutenToggleStates[0].label ?: "",
+                        3,
+                        1,
+                        false,
+                        dakutenToggleStates[0].action,
+                        dynamicStates = dakutenToggleStates,
+                        keyId = "dakuten_toggle_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "わ",
+                        3,
+                        2,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "、。?!",
+                        3,
+                        3,
+                        true,
+                        keyType = KeyType.TWO_STEP_FLICK
+                    ),
+                    KeyData(
+                        "Del",
+                        0,
+                        4,
+                        false,
+                        KeyAction.Delete,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                    ),
+                    KeyData(
+                        spaceConvertStates[0].label ?: "",
+                        1,
+                        4,
+                        true,
+                        spaceConvertStates[0].action,
+                        dynamicStates = spaceConvertStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        keyId = "space_convert_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        enterKeyStates[0].label ?: "",
+                        2,
+                        4,
+                        false,
+                        enterKeyStates[0].action,
+                        dynamicStates = enterKeyStates,
+                        isSpecialKey = true,
+                        rowSpan = 2,
+                        drawableResId = enterKeyStates[0].drawableResId,
+                        keyId = "enter_key"
+                    )
+                )
+                val pasteActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Paste,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.SelectAll,
+                        drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.Copy,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+                    )
+                )
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    )
+                )
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+                val conversionActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Convert,
+                    ),
+                )
+                // 状態0 (^_^): タップ操作のみを持つマップ
+                val emojiStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.InputText("^_^"),
+                        label = "^_^"
+                    )
+                    // この状態ではフリックアクションを定義しない
+                )
+
+                // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+                val dakutenStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.ToggleDakuten,
+                        label = " 小゛゜"
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.InputText("ひらがな小文字"),
+                        label = "小"
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.InputText("濁点"),
+                        label = "゛"
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.InputText("半濁点"),
+                        label = "゜"
+                    )
+                )
+                val symbols = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("、"),
+                    FlickDirection.UP to FlickAction.Input("？"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
+                    FlickDirection.DOWN to FlickAction.Input("…")
+                )
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "PasteActionKey" to listOf(pasteActionMap),
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                        "、。?!" to listOf(symbols),
+                    )
+
+                dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(emojiStateFlickMap))
+                }
+                dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(dakutenStateFlickMap))
+                }
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                spaceConvertStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(conversionActionMap))
+                }
+                val twoStepFlickMaps = mapOf(
+                    // あ行
+                    "あ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.UP_RIGHT to "ぁ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.LEFT to "い",
+                            TfbiFlickDirection.DOWN_LEFT to "ぃ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.UP to "う",
+                            TfbiFlickDirection.UP_LEFT to "ぅ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.RIGHT to "え",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぇ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.DOWN to "お",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぉ",
+                        )
+                    ),
+                    // か行
+                    "か" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.UP_RIGHT to "が",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.LEFT to "き",
+                            TfbiFlickDirection.DOWN_LEFT to "ぎ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.UP to "く",
+                            TfbiFlickDirection.UP_LEFT to "ぐ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.RIGHT to "け",
+                            TfbiFlickDirection.DOWN_RIGHT to "げ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.DOWN to "こ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ご",
+                        )
+                    ),
+                    // さ行
+                    "さ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.UP_RIGHT to "ざ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.LEFT to "し",
+                            TfbiFlickDirection.DOWN_LEFT to "じ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.UP to "す",
+                            TfbiFlickDirection.UP_LEFT to "ず"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.RIGHT to "せ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぜ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.DOWN to "そ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぞ",
+                        )
+                    ),
+                    // た行
+                    "た" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.UP_RIGHT to "だ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.LEFT to "ち",
+                            TfbiFlickDirection.DOWN_LEFT to "ぢ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.UP to "つ",
+                            TfbiFlickDirection.UP_LEFT to "づ",
+                            TfbiFlickDirection.UP_RIGHT to "っ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.RIGHT to "て",
+                            TfbiFlickDirection.DOWN_RIGHT to "で"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.DOWN to "と",
+                            TfbiFlickDirection.DOWN_RIGHT to "ど",
+                        )
+                    ),
+                    // な行
+                    "な" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.LEFT to "に",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.UP to "ぬ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.RIGHT to "ね",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.DOWN to "の",
+                        )
+                    ),
+                    // は行
+                    "は" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP_RIGHT to "ば",
+                        ),
+                        TfbiFlickDirection.UP_LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP_LEFT to "ぱ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.LEFT to "ひ",
+                            TfbiFlickDirection.DOWN_LEFT to "び",
+                            TfbiFlickDirection.UP_LEFT to "ぴ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP to "ふ",
+                            TfbiFlickDirection.UP_RIGHT to "ぷ",
+                            TfbiFlickDirection.UP_LEFT to "ぶ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.RIGHT to "へ",
+                            TfbiFlickDirection.DOWN_RIGHT to "べ",
+                            TfbiFlickDirection.UP_RIGHT to "ぺ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.DOWN to "ほ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぼ",
+                            TfbiFlickDirection.DOWN_LEFT to "ぽ",
+                        )
+                    ),
+                    // ま行
+                    "ま" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.LEFT to "み",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.UP to "む",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.RIGHT to "め",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.DOWN to "も",
+                        )
+                    ),
+                    // や行
+                    "や" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.UP_RIGHT to "ゃ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.LEFT to "(",
+                            TfbiFlickDirection.DOWN_LEFT to "「",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.UP to "ゆ",
+                            TfbiFlickDirection.UP_LEFT to "ゅ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.RIGHT to ")",
+                            TfbiFlickDirection.DOWN_RIGHT to "」",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.DOWN to "よ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ょ",
+                        )
+                    ),
+                    // ら行
+                    "ら" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.LEFT to "り",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.UP to "る",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.RIGHT to "れ",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.DOWN to "ろ",
+                        )
+                    ),
+                    // わ行
+                    "わ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.UP_RIGHT to "ゎ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.LEFT to "を",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.UP to "ん",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.RIGHT to "ー",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.DOWN to "〜",
+                        )
+                    ),
+                    // 記号
+                    "、。?!" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.LEFT to "。",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.UP to "？",
+                            TfbiFlickDirection.UP_LEFT to "：",
+                            TfbiFlickDirection.UP_RIGHT to "・",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.RIGHT to "！",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.DOWN to "…",
+                        )
+                    )
+                )
+                KeyboardLayout(keys, flickMaps, 5, 4, twoStepFlickKeyMaps = twoStepFlickMaps)
+            }
+
+            "sumire" -> {
+                return createHiraganaLayout()
+            }
+
+            else -> {
+                val keys = listOf(
+                    KeyData(
+                        "PasteActionKey",
+                        0,
+                        0,
+                        false,
+                        KeyAction.Paste,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "CursorMoveLeft",
+                        1,
+                        0,
+                        false,
+                        KeyAction.MoveCursorLeft,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
+                        keyType = KeyType.CROSS_FLICK,
+                    ),
+                    KeyData(
+                        "モード",
+                        2,
+                        0,
+                        false,
+                        KeyAction.ChangeInputMode,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                    ),
+                    KeyData(
+                        "",
+                        3,
+                        0,
+                        false,
+                        KeyAction.SwitchToNextIme,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                    ),
+                    KeyData(
+                        "あ",
+                        0,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "か",
+                        0,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "さ",
+                        0,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "た",
+                        1,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "な",
+                        1,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "は",
+                        1,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ま",
+                        2,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "や",
+                        2,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ら",
+                        2,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        dakutenToggleStates[0].label ?: "",
+                        3,
+                        1,
+                        false,
+                        dakutenToggleStates[0].action,
+                        dynamicStates = dakutenToggleStates,
+                        keyId = "dakuten_toggle_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "わ",
+                        3,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "、。?!",
+                        3,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "Del",
+                        0,
+                        4,
+                        false,
+                        KeyAction.Delete,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                    ),
+                    KeyData(
+                        spaceConvertStates[0].label ?: "",
+                        1,
+                        4,
+                        true,
+                        spaceConvertStates[0].action,
+                        dynamicStates = spaceConvertStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        keyId = "space_convert_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        enterKeyStates[0].label ?: "",
+                        2,
+                        4,
+                        false,
+                        enterKeyStates[0].action,
+                        dynamicStates = enterKeyStates,
+                        isSpecialKey = true,
+                        rowSpan = 2,
+                        drawableResId = enterKeyStates[0].drawableResId,
+                        keyId = "enter_key"
+                    )
+                )
+                val pasteActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Paste,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.SelectAll,
+                        drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.Copy,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+                    )
+                )
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    )
+                )
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+                val conversionActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Convert,
+                    ),
+                )
+                // 状態0 (^_^): タップ操作のみを持つマップ
+                val emojiStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.InputText("^_^"),
+                        label = "^_^"
+                    )
+                    // この状態ではフリックアクションを定義しない
+                )
+
+                // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+                val dakutenStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.ToggleDakuten,
+                        label = " 小゛゜"
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.InputText("ひらがな小文字"),
+                        label = "小"
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.InputText("濁点"),
+                        label = "゛"
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.InputText("半濁点"),
+                        label = "゜"
+                    )
+                )
+
+                val a = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("あ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("い"),
+                    FlickDirection.UP to FlickAction.Input("う"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え"),
+                    FlickDirection.DOWN to FlickAction.Input("お")
+                )
+                val ka = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("か"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("き"),
+                    FlickDirection.UP to FlickAction.Input("く"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("け"),
+                    FlickDirection.DOWN to FlickAction.Input("こ")
+                )
+                val sa = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("さ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("し"),
+                    FlickDirection.UP to FlickAction.Input("す"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("せ"),
+                    FlickDirection.DOWN to FlickAction.Input("そ")
+                )
+                val ta = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("た"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("ち"),
+                    FlickDirection.UP to FlickAction.Input("つ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("て"),
+                    FlickDirection.DOWN to FlickAction.Input("と")
+                )
+                val na = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("な"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("に"),
+                    FlickDirection.UP to FlickAction.Input("ぬ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ね"),
+                    FlickDirection.DOWN to FlickAction.Input("の")
+                )
+                val ha = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("は"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("ひ"),
+                    FlickDirection.UP to FlickAction.Input("ふ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("へ"),
+                    FlickDirection.DOWN to FlickAction.Input("ほ")
+                )
+                val ma = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("ま"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("み"),
+                    FlickDirection.UP to FlickAction.Input("む"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("め"),
+                    FlickDirection.DOWN to FlickAction.Input("も")
+                )
+                val ya = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("や"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
+                    FlickDirection.UP to FlickAction.Input("ゆ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+                    FlickDirection.DOWN to FlickAction.Input("よ")
+                )
+                val ra = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("ら"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("り"),
+                    FlickDirection.UP to FlickAction.Input("る"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("れ"),
+                    FlickDirection.DOWN to FlickAction.Input("ろ")
+                )
+                val wa = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("わ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("を"),
+                    FlickDirection.UP to FlickAction.Input("ん"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー")
+                )
+                val symbols = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("、"),
+                    FlickDirection.UP to FlickAction.Input("？"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
+                    FlickDirection.DOWN to FlickAction.Input("…")
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "PasteActionKey" to listOf(pasteActionMap),
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                        "あ" to listOf(a),
+                        "か" to listOf(ka),
+                        "さ" to listOf(sa),
+                        "た" to listOf(ta),
+                        "な" to listOf(na),
+                        "は" to listOf(ha),
+                        "ま" to listOf(ma),
+                        "や" to listOf(ya),
+                        "ら" to listOf(ra),
+                        "わ" to listOf(wa),
+                        "、。?!" to listOf(symbols),
+                    )
+
+                dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(emojiStateFlickMap))
+                }
+                dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(dakutenStateFlickMap))
+                }
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                spaceConvertStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(conversionActionMap))
+                }
+                KeyboardLayout(keys, flickMaps, 5, 4)
+            }
+        }
+    }
+
+    private fun createEnglishToggleLayout(
+        isUpperCase: Boolean,
+        inputStyle: String
+    ): KeyboardLayout {
+        if (inputStyle == "sumire") {
+            return createEnglishLayout(isUpperCase)
+        } else {
+            val keys = listOf(
+                KeyData(
+                    "PasteActionKey",
+                    0,
+                    0,
+                    false,
+                    KeyAction.Paste,
+                    isSpecialKey = true,
+                    drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
+                    keyType = KeyType.CROSS_FLICK
+                ),
+                KeyData(
+                    "CursorMoveLeft",
+                    1,
+                    0,
+                    false,
+                    KeyAction.MoveCursorLeft,
+                    isSpecialKey = true,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
+                    keyType = KeyType.CROSS_FLICK
+                ),
+                KeyData(
+                    "モード",
+                    2,
+                    0,
+                    false,
+                    KeyAction.ChangeInputMode,
+                    isSpecialKey = true,
+                    drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom
+                ),
+                KeyData(
+                    "",
+                    3,
+                    0,
+                    false,
+                    KeyAction.SwitchToNextIme,
+                    isSpecialKey = true,
+                    drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                ),
+                KeyData(
+                    "@#/_",
+                    0,
+                    1,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "ABC",
+                    0,
+                    2,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "DEF",
+                    0,
+                    3,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "GHI",
+                    1,
+                    1,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "JKL",
+                    1,
+                    2,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "MNO",
+                    1,
+                    3,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "PQRS",
+                    2,
+                    1,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "TUV",
+                    2,
+                    2,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "WXYZ",
+                    2,
+                    3,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "a/A",
+                    3,
+                    1,
+                    false,
+                    action = KeyAction.ToggleCase,
+                    isSpecialKey = false
+                ),
+                KeyData(
+                    "' \" ( )",
+                    3,
+                    2,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    ". , ? !",
+                    3,
+                    3,
+                    true,
+                    keyType = when (inputStyle) {
+                        "default" -> KeyType.PETAL_FLICK
+                        "circle" -> KeyType.STANDARD_FLICK
+                        else -> KeyType.PETAL_FLICK
+                    }
+                ),
+                KeyData(
+                    "Del",
+                    0,
+                    4,
+                    false,
+                    KeyAction.Delete,
+                    isSpecialKey = true,
+                    rowSpan = 1,
+                    drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                ),
+                KeyData(
+                    spaceConvertStates[0].label ?: "",
+                    1,
+                    4,
+                    true,
+                    spaceConvertStates[0].action,
+                    dynamicStates = spaceConvertStates,
+                    isSpecialKey = true,
+                    rowSpan = 1,
+                    keyId = "space_convert_key",
+                    keyType = KeyType.CROSS_FLICK
+                ),
+                KeyData(
+                    enterKeyStates[0].label ?: "",
+                    2,
+                    4,
+                    false,
+                    enterKeyStates[0].action,
+                    dynamicStates = enterKeyStates,
+                    isSpecialKey = true,
+                    rowSpan = 2,
+                    drawableResId = enterKeyStates[0].drawableResId,
+                    keyId = "enter_key"
+                )
+            )
+            val pasteActionMap = mapOf(
+                FlickDirection.TAP to FlickAction.Action(
+                    KeyAction.Paste,
+                    drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+                ),
+                FlickDirection.UP to FlickAction.Action(
+                    KeyAction.SelectAll,
+                    drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+                ),
+                FlickDirection.UP_RIGHT to FlickAction.Action(
+                    KeyAction.Copy,
+                    drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+                )
+            )
+            val cursorMoveActionMap = mapOf(
+                FlickDirection.TAP to FlickAction.Action(
+                    KeyAction.MoveCursorLeft,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                ),
+                FlickDirection.UP_RIGHT to FlickAction.Action(
+                    KeyAction.MoveCursorRight,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                )
+            )
+
+            val spaceActionMap = mapOf(
+                FlickDirection.TAP to FlickAction.Action(
+                    KeyAction.Space,
+                ),
+                FlickDirection.UP_LEFT to FlickAction.Action(
+                    KeyAction.Space,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                )
+            )
+
+            fun getCase(c: Char) = if (isUpperCase) c.uppercaseChar() else c
+            val symbols1 = mapOf(
+                FlickDirection.TAP to FlickAction.Input("@"),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input("#"),
+                FlickDirection.UP to FlickAction.Input("/"),
+                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("_"),
+                FlickDirection.DOWN to FlickAction.Input("1")
+            )
+            val abc = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('a').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('b').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('c').toString()),
+                FlickDirection.DOWN to FlickAction.Input("2")
+            )
+            val def = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('d').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('e').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('f').toString()),
+                FlickDirection.DOWN to FlickAction.Input("3")
+            )
+            val ghi = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('g').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('h').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('i').toString()),
+                FlickDirection.DOWN to FlickAction.Input("4")
+            )
+            val jkl = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('j').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('k').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('l').toString()),
+                FlickDirection.DOWN to FlickAction.Input("5")
+            )
+            val mno = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('m').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('n').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('o').toString()),
+                FlickDirection.DOWN to FlickAction.Input("6")
+            )
+            val pqrs = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('p').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('q').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('r').toString()),
+                FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('s').toString()),
+                FlickDirection.DOWN to FlickAction.Input("7")
+            )
+            val tuv = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('t').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('u').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('v').toString()),
+                FlickDirection.DOWN to FlickAction.Input("8")
+            )
+            val wxyz = mapOf(
+                FlickDirection.TAP to FlickAction.Input(getCase('w').toString()),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('x').toString()),
+                FlickDirection.UP to FlickAction.Input(getCase('y').toString()),
+                FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('z').toString()),
+                FlickDirection.DOWN to FlickAction.Input("9")
+            )
+            val symbols2 = mapOf(
+                FlickDirection.TAP to FlickAction.Input("'"),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input("\""),
+                FlickDirection.UP to FlickAction.Input("("),
+                FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+                FlickDirection.DOWN to FlickAction.Input("0")
+            )
+            val symbols3 = mapOf(
+                FlickDirection.TAP to FlickAction.Input("."),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
+                FlickDirection.UP to FlickAction.Input("?"),
+                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("!"),
+                FlickDirection.DOWN to FlickAction.Input("-")
+            )
+
+            val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                mutableMapOf(
+                    "PasteActionKey" to listOf(pasteActionMap),
+                    "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                    "@#/_" to listOf(symbols1),
+                    "ABC" to listOf(abc),
+                    "DEF" to listOf(def),
+                    "GHI" to listOf(ghi),
+                    "JKL" to listOf(jkl),
+                    "MNO" to listOf(mno),
+                    "PQRS" to listOf(pqrs),
+                    "TUV" to listOf(tuv),
+                    "WXYZ" to listOf(wxyz),
+                    "' \" ( )" to listOf(symbols2),
+                    ". , ? !" to listOf(symbols3)
+                )
+
+            spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                flickMaps.put(label, listOf(spaceActionMap))
+            }
+
+            return KeyboardLayout(keys, flickMaps, 5, 4)
+        }
+    }
+
+    private fun createSymbolToggleLayout(
+        inputStyle: String
     ): KeyboardLayout {
         val keys = listOf(
             KeyData(
                 "PasteActionKey",
                 0,
                 0,
-                false,
+                true,
                 KeyAction.Paste,
                 isSpecialKey = true,
                 drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px,
@@ -4271,11 +3673,11 @@ object KeyboardDefaultLayouts {
                 "CursorMoveLeft",
                 1,
                 0,
-                false,
+                true,
                 KeyAction.MoveCursorLeft,
                 isSpecialKey = true,
                 drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24,
-                keyType = KeyType.CROSS_FLICK,
+                keyType = KeyType.CROSS_FLICK
             ),
             KeyData(
                 "モード",
@@ -4284,7 +3686,7 @@ object KeyboardDefaultLayouts {
                 false,
                 KeyAction.ChangeInputMode,
                 isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom
             ),
             KeyData(
                 "",
@@ -4296,92 +3698,139 @@ object KeyboardDefaultLayouts {
                 drawableResId = com.kazumaproject.core.R.drawable.language_24dp
             ),
             KeyData(
-                "あ",
+                "1\n☆♪→",
                 0,
                 1,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "か",
+                "2\n￥$€",
                 0,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "さ",
+                "3\n%°#",
                 0,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "た",
+                "4\n○*・",
                 1,
                 1,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "な",
+                "5\n+x÷",
                 1,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "は",
+                "6\n< = >",
                 1,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "ま",
+                "7\n「」:",
                 2,
                 1,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "や",
+                "8\n〒々〆",
                 2,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "ら",
+                "9\n^|\\",
                 2,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                dakutenToggleStates[0].label ?: "",
+                "0\n〜…",
+                3,
+                2,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "( ) [ ]",
                 3,
                 1,
-                false,
-                dakutenToggleStates[0].action,
-                dynamicStates = dakutenToggleStates,
-                keyId = "dakuten_toggle_key",
-                keyType = KeyType.CROSS_FLICK
-            ),
-            KeyData(
-                "わ",
-                3,
-                2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                isSpecialKey = false,
+                colSpan = 1,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
-                "、。?!",
+                ".,-/",
                 3,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
-            ), // Label fixed to match map key
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
             KeyData(
                 "Del",
                 0,
@@ -4418,443 +3867,1899 @@ object KeyboardDefaultLayouts {
             )
         )
 
-        val pasteActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Paste,
-                drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.SelectAll,
-                drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.Copy,
-                drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+        if (inputStyle == "sumire") {
+            return createSymbolLayout()
+        } else {
+            val pasteActionMap = mapOf(
+                FlickDirection.TAP to FlickAction.Action(
+                    KeyAction.Paste,
+                    drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+                ),
+                FlickDirection.UP to FlickAction.Action(
+                    KeyAction.SelectAll,
+                    drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+                ),
+                FlickDirection.UP_RIGHT to FlickAction.Action(
+                    KeyAction.Copy,
+                    drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+                )
             )
-        )
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+            val cursorMoveActionMap = mapOf(
+                FlickDirection.TAP to FlickAction.Action(
+                    KeyAction.MoveCursorLeft,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                ),
+                FlickDirection.UP_RIGHT to FlickAction.Action(
+                    KeyAction.MoveCursorRight,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                )
             )
-        )
-
-        val spaceActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Space,
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.Space,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
-
+            val symbols3 = mapOf(
+                FlickDirection.TAP to FlickAction.Input("."),
+                FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
+                FlickDirection.UP to FlickAction.Input("-"),
+                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("/")
             )
-        )
 
-        val conversionActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.Convert,
-            ),
-        )
+            val spaceActionMap = mapOf(
+                FlickDirection.TAP to FlickAction.Action(
+                    KeyAction.Space,
+                ),
+                FlickDirection.UP_LEFT to FlickAction.Action(
+                    KeyAction.Space,
+                    drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
 
-        // 状態0 (^_^): タップ操作のみを持つマップ
-        val emojiStateFlickMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.InputText("^_^"),
-                label = "^_^"
+                )
             )
-            // この状態ではフリックアクションを定義しない
-        )
-        // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
-        val dakutenStateFlickMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
-                KeyAction.ToggleDakuten,
-                label = " 小゛゜"
-            ),
-            FlickDirection.UP to FlickAction.Action(
-                KeyAction.InputText("ひらがな小文字"),
-                label = "小"
-            ),
-            FlickDirection.UP_LEFT to FlickAction.Action(
-                KeyAction.InputText("濁点"),
-                label = "゛"
-            ),
-            FlickDirection.UP_RIGHT to FlickAction.Action(
-                KeyAction.InputText("半濁点"),
-                label = "゜"
-            )
-        )
 
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "PasteActionKey" to listOf(pasteActionMap),
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-        )
+            val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                mutableMapOf(
+                    "PasteActionKey" to listOf(pasteActionMap),
+                    "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                    "1\n☆♪→" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("1"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("☆"),
+                            FlickDirection.UP to FlickAction.Input("♪"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("→"),
+                        )
+                    ),
+                    "2\n￥$€" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("2"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("￥"),
+                            FlickDirection.UP to FlickAction.Input("$"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("€"),
+                        )
+                    ),
+                    "3\n%°#" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("3"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("%"),
+                            FlickDirection.UP to FlickAction.Input("°"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("#"),
+                        )
+                    ),
+                    "4\n○*・" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("4"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("○"),
+                            FlickDirection.UP to FlickAction.Input("*"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("・"),
 
-        dakutenToggleStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(emojiStateFlickMap))
+                            )
+                    ),
+                    "5\n+x÷" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("5"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("+"),
+                            FlickDirection.UP to FlickAction.Input("x"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("÷"),
+                        ),
+                    ),
+                    "6\n< = >" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("6"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("<"),
+                            FlickDirection.UP to FlickAction.Input("="),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(">"),
+                        )
+                    ),
+                    "7\n「」:" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("7"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("「"),
+                            FlickDirection.UP to FlickAction.Input("」"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(":"),
+                        )
+                    ),
+                    "8\n〒々〆" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("8"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("〒"), // Double quote
+                            FlickDirection.UP to FlickAction.Input("々"),   // Single quote
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〆"),
+                        )
+                    ),
+                    "9\n^|\\" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("9"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("^"),   // Square brackets
+                            FlickDirection.UP to FlickAction.Input("|"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("\\"),   // Curly braces
+                        )
+                    ),
+                    "0\n〜…" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("0"),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input("〜"),
+                            FlickDirection.UP to FlickAction.Input("…"),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("√"),
+                        )
+                    ),
+                    "( ) [ ]" to listOf(
+                        mapOf(
+                            FlickDirection.TAP to FlickAction.Input("("),
+                            FlickDirection.UP_LEFT_FAR to FlickAction.Input(")"),
+                            FlickDirection.UP to FlickAction.Input("["),
+                            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("]"),
+                        )
+                    ),
+                    ".,-/" to listOf(symbols3),
+                )
+
+            spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                flickMaps.put(label, listOf(spaceActionMap))
+            }
+
+            return KeyboardLayout(keys, flickMaps, 5, 4)
         }
-        dakutenToggleStates.getOrNull(1)?.label?.let { label ->
-            flickMaps.put(label, listOf(dakutenStateFlickMap))
-        }
-
-        spaceConvertStates.getOrNull(0)?.label?.let { label ->
-            flickMaps.put(label, listOf(spaceActionMap))
-        }
-
-        spaceConvertStates.getOrNull(1)?.label?.let { label ->
-            flickMaps.put(label, listOf(conversionActionMap))
-        }
-
-        // 2段階フリック用の文字マップ (isDefaultKey = true の場合に利用)
-        val twoStepFlickMaps = mapOf(
-            // あ行
-            "あ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.UP_RIGHT to "ぁ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.LEFT to "い",
-                    TfbiFlickDirection.DOWN_LEFT to "ぃ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.UP to "う",
-                    TfbiFlickDirection.UP_LEFT to "ぅ"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.RIGHT to "え",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぇ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.DOWN to "お",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぉ",
-                )
-            ),
-            // か行
-            "か" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.UP_RIGHT to "が",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.LEFT to "き",
-                    TfbiFlickDirection.DOWN_LEFT to "ぎ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.UP to "く",
-                    TfbiFlickDirection.UP_LEFT to "ぐ"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.RIGHT to "け",
-                    TfbiFlickDirection.DOWN_RIGHT to "げ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.DOWN to "こ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ご",
-                )
-            ),
-            // さ行
-            "さ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.UP_RIGHT to "ざ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.LEFT to "し",
-                    TfbiFlickDirection.DOWN_LEFT to "じ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.UP to "す",
-                    TfbiFlickDirection.UP_LEFT to "ず"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.RIGHT to "せ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぜ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.DOWN to "そ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぞ",
-                )
-            ),
-            // た行
-            "た" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.UP_RIGHT to "だ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.LEFT to "ち",
-                    TfbiFlickDirection.DOWN_LEFT to "ぢ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.UP to "つ",
-                    TfbiFlickDirection.UP_LEFT to "づ",
-                    TfbiFlickDirection.UP_RIGHT to "っ"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.RIGHT to "て",
-                    TfbiFlickDirection.DOWN_RIGHT to "で"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.DOWN to "と",
-                    TfbiFlickDirection.DOWN_RIGHT to "ど",
-                )
-            ),
-            // な行
-            "な" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.LEFT to "に",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.UP to "ぬ",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.RIGHT to "ね",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.DOWN to "の",
-                )
-            ),
-            // は行
-            "は" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.UP_RIGHT to "ば",
-                ),
-                TfbiFlickDirection.UP_LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.UP_LEFT to "ぱ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.LEFT to "ひ",
-                    TfbiFlickDirection.DOWN_LEFT to "び",
-                    TfbiFlickDirection.UP_LEFT to "ぴ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.UP to "ふ",
-                    TfbiFlickDirection.UP_RIGHT to "ぷ",
-                    TfbiFlickDirection.UP_LEFT to "ぶ",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.RIGHT to "へ",
-                    TfbiFlickDirection.DOWN_RIGHT to "べ",
-                    TfbiFlickDirection.UP_RIGHT to "ぺ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.DOWN to "ほ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぼ",
-                    TfbiFlickDirection.DOWN_LEFT to "ぽ",
-                )
-            ),
-            // ま行
-            "ま" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.LEFT to "み",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.UP to "む",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.RIGHT to "め",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.DOWN to "も",
-                )
-            ),
-            // や行
-            "や" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.UP_RIGHT to "ゃ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.LEFT to "(",
-                    TfbiFlickDirection.DOWN_LEFT to "「",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.UP to "ゆ",
-                    TfbiFlickDirection.UP_LEFT to "ゅ",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.RIGHT to ")",
-                    TfbiFlickDirection.DOWN_RIGHT to "」",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.DOWN to "よ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ょ",
-                )
-            ),
-            // ら行
-            "ら" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.LEFT to "り",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.UP to "る",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.RIGHT to "れ",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.DOWN to "ろ",
-                )
-            ),
-            // わ行
-            "わ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.UP_RIGHT to "ゎ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.LEFT to "を",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.UP to "ん",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.RIGHT to "ー",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.DOWN to "〜",
-                )
-            ),
-            // 記号
-            "、。?!" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.LEFT to "。",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.UP to "？",
-                    TfbiFlickDirection.UP_LEFT to "：",
-                    TfbiFlickDirection.UP_RIGHT to "・",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.RIGHT to "！",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.DOWN to "…",
-                )
-            )
-        )
-
-        return KeyboardLayout(keys, flickMaps, 5, 4, twoStepFlickKeyMaps = twoStepFlickMaps)
     }
 
-    private fun createTwoStepFlickFlickLayout(
-        isDefaultKey: Boolean
+    private fun createHiraganaFlickLayout(
+        inputStyle: String
+    ): KeyboardLayout {
+        when (inputStyle) {
+            "second-flick" -> {
+                val keys = listOf(
+                    KeyData(
+                        "SwitchToNumber",
+                        0,
+                        0,
+                        false,
+                        KeyAction.SwitchToNumberLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
+                    ),
+                    KeyData(
+                        "SwitchToEnglish",
+                        1,
+                        0,
+                        false,
+                        KeyAction.SwitchToEnglishLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                    ),
+                    KeyData(
+                        "SwitchToKana",
+                        2,
+                        0,
+                        false,
+                        KeyAction.SwitchToKanaLayout,
+                        isSpecialKey = true,
+                        isHiLighted = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+                    ),
+                    KeyData(
+                        "",
+                        3,
+                        0,
+                        false,
+                        KeyAction.SwitchToNextIme,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                    ),
+                    KeyData(
+                        "あ",
+                        0,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "か",
+                        0,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "さ",
+                        0,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "た",
+                        1,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "な",
+                        1,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "は",
+                        1,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ま",
+                        2,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "や",
+                        2,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ら",
+                        2,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        dakutenToggleStates[0].label ?: "",
+                        3,
+                        1,
+                        false,
+                        dakutenToggleStates[0].action,
+                        dynamicStates = dakutenToggleStates,
+                        keyId = "dakuten_toggle_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "わ",
+                        3,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "、。?!",
+                        3,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            "second-flick" -> KeyType.TWO_STEP_FLICK
+                            "sumire" -> KeyType.CIRCULAR_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ), // Label fixed to match map key
+                    KeyData(
+                        "Del",
+                        0,
+                        4,
+                        false,
+                        KeyAction.Delete,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                    ),
+                    KeyData(
+                        spaceConvertStates[0].label ?: "",
+                        1,
+                        4,
+                        true,
+                        spaceConvertStates[0].action,
+                        dynamicStates = spaceConvertStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        keyId = "space_convert_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "CursorMoveLeft",
+                        2,
+                        4,
+                        false,
+                        KeyAction.MoveCursorRight,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
+                        keyType = KeyType.CROSS_FLICK,
+                    ),
+                    KeyData(
+                        enterKeyStates[0].label ?: "",
+                        3,
+                        4,
+                        false,
+                        enterKeyStates[0].action,
+                        dynamicStates = enterKeyStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = enterKeyStates[0].drawableResId,
+                        keyId = "enter_key"
+                    )
+                )
+                val pasteActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Paste,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.SelectAll,
+                        drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.Copy,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+                    )
+                )
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    )
+                )
+
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+
+                val conversionActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Convert,
+                    ),
+                )
+
+                // 状態0 (^_^): タップ操作のみを持つマップ
+                val emojiStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.InputText("^_^"),
+                        label = "^_^"
+                    )
+                    // この状態ではフリックアクションを定義しない
+                )
+                // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+                val dakutenStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.ToggleDakuten,
+                        label = " 小゛゜"
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.InputText("ひらがな小文字"),
+                        label = "小"
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.InputText("濁点"),
+                        label = "゛"
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.InputText("半濁点"),
+                        label = "゜"
+                    )
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "PasteActionKey" to listOf(pasteActionMap),
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                    )
+
+                dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(emojiStateFlickMap))
+                }
+                dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(dakutenStateFlickMap))
+                }
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                spaceConvertStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(conversionActionMap))
+                }
+
+                // 2段階フリック用の文字マップ (isDefaultKey = true の場合に利用)
+                val twoStepFlickMaps = mapOf(
+                    // あ行
+                    "あ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.UP_RIGHT to "ぁ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.LEFT to "い",
+                            TfbiFlickDirection.DOWN_LEFT to "ぃ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.UP to "う",
+                            TfbiFlickDirection.UP_LEFT to "ぅ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.RIGHT to "え",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぇ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.DOWN to "お",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぉ",
+                        )
+                    ),
+                    // か行
+                    "か" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.UP_RIGHT to "が",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.LEFT to "き",
+                            TfbiFlickDirection.DOWN_LEFT to "ぎ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.UP to "く",
+                            TfbiFlickDirection.UP_LEFT to "ぐ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.RIGHT to "け",
+                            TfbiFlickDirection.DOWN_RIGHT to "げ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.DOWN to "こ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ご",
+                        )
+                    ),
+                    // さ行
+                    "さ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.UP_RIGHT to "ざ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.LEFT to "し",
+                            TfbiFlickDirection.DOWN_LEFT to "じ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.UP to "す",
+                            TfbiFlickDirection.UP_LEFT to "ず"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.RIGHT to "せ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぜ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.DOWN to "そ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぞ",
+                        )
+                    ),
+                    // た行
+                    "た" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.UP_RIGHT to "だ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.LEFT to "ち",
+                            TfbiFlickDirection.DOWN_LEFT to "ぢ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.UP to "つ",
+                            TfbiFlickDirection.UP_LEFT to "づ",
+                            TfbiFlickDirection.UP_RIGHT to "っ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.RIGHT to "て",
+                            TfbiFlickDirection.DOWN_RIGHT to "で"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.DOWN to "と",
+                            TfbiFlickDirection.DOWN_RIGHT to "ど",
+                        )
+                    ),
+                    // な行
+                    "な" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.LEFT to "に",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.UP to "ぬ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.RIGHT to "ね",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.DOWN to "の",
+                        )
+                    ),
+                    // は行
+                    "は" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP_RIGHT to "ば",
+                        ),
+                        TfbiFlickDirection.UP_LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP_LEFT to "ぱ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.LEFT to "ひ",
+                            TfbiFlickDirection.DOWN_LEFT to "び",
+                            TfbiFlickDirection.UP_LEFT to "ぴ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP to "ふ",
+                            TfbiFlickDirection.UP_RIGHT to "ぷ",
+                            TfbiFlickDirection.UP_LEFT to "ぶ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.RIGHT to "へ",
+                            TfbiFlickDirection.DOWN_RIGHT to "べ",
+                            TfbiFlickDirection.UP_RIGHT to "ぺ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.DOWN to "ほ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぼ",
+                            TfbiFlickDirection.DOWN_LEFT to "ぽ",
+                        )
+                    ),
+                    // ま行
+                    "ま" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.LEFT to "み",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.UP to "む",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.RIGHT to "め",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.DOWN to "も",
+                        )
+                    ),
+                    // や行
+                    "や" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.UP_RIGHT to "ゃ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.LEFT to "(",
+                            TfbiFlickDirection.DOWN_LEFT to "「",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.UP to "ゆ",
+                            TfbiFlickDirection.UP_LEFT to "ゅ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.RIGHT to ")",
+                            TfbiFlickDirection.DOWN_RIGHT to "」",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.DOWN to "よ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ょ",
+                        )
+                    ),
+                    // ら行
+                    "ら" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.LEFT to "り",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.UP to "る",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.RIGHT to "れ",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.DOWN to "ろ",
+                        )
+                    ),
+                    // わ行
+                    "わ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.UP_RIGHT to "ゎ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.LEFT to "を",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.UP to "ん",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.RIGHT to "ー",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.DOWN to "〜",
+                        )
+                    ),
+                    // 記号
+                    "、。?!" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.LEFT to "。",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.UP to "？",
+                            TfbiFlickDirection.UP_LEFT to "：",
+                            TfbiFlickDirection.UP_RIGHT to "・",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.RIGHT to "！",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.DOWN to "…",
+                        )
+                    )
+                )
+
+                return KeyboardLayout(keys, flickMaps, 5, 4, twoStepFlickKeyMaps = twoStepFlickMaps)
+            }
+
+            "sumire" -> {
+                return createHiraganaLayout()
+            }
+
+            else -> {
+                val keys = listOf(
+                    KeyData(
+                        "SwitchToNumber",
+                        0,
+                        0,
+                        false,
+                        KeyAction.SwitchToNumberLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
+                    ),
+                    KeyData(
+                        "SwitchToEnglish",
+                        1,
+                        0,
+                        false,
+                        KeyAction.SwitchToEnglishLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                    ),
+                    KeyData(
+                        "SwitchToKana",
+                        2,
+                        0,
+                        false,
+                        KeyAction.SwitchToKanaLayout,
+                        isSpecialKey = true,
+                        isHiLighted = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+                    ),
+                    KeyData(
+                        "",
+                        3,
+                        0,
+                        false,
+                        KeyAction.SwitchToNextIme,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                    ),
+                    KeyData(
+                        "あ",
+                        0,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "か",
+                        0,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "さ",
+                        0,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "た",
+                        1,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "な",
+                        1,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "は",
+                        1,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ま",
+                        2,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "や",
+                        2,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ら",
+                        2,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        dakutenToggleStates[0].label ?: "",
+                        3,
+                        1,
+                        false,
+                        dakutenToggleStates[0].action,
+                        dynamicStates = dakutenToggleStates,
+                        keyId = "dakuten_toggle_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "わ",
+                        3,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "、。?!",
+                        3,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "Del",
+                        0,
+                        4,
+                        false,
+                        KeyAction.Delete,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                    ),
+                    KeyData(
+                        spaceConvertStates[0].label ?: "",
+                        1,
+                        4,
+                        true,
+                        spaceConvertStates[0].action,
+                        dynamicStates = spaceConvertStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        keyId = "space_convert_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "CursorMoveLeft",
+                        2,
+                        4,
+                        false,
+                        KeyAction.MoveCursorRight,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
+                        keyType = KeyType.CROSS_FLICK,
+                    ),
+                    KeyData(
+                        enterKeyStates[0].label ?: "",
+                        3,
+                        4,
+                        false,
+                        enterKeyStates[0].action,
+                        dynamicStates = enterKeyStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = enterKeyStates[0].drawableResId,
+                        keyId = "enter_key"
+                    )
+                )
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    )
+                )
+
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+
+                val conversionActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Convert,
+                    ),
+                )
+
+                // 状態0 (^_^): タップ操作のみを持つマップ
+                val emojiStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.InputText("^_^"),
+                        label = "^_^"
+                    )
+                    // この状態ではフリックアクションを定義しない
+                )
+
+                // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+                val dakutenStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.ToggleDakuten,
+                        label = " 小゛゜"
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.InputText("ひらがな小文字"),
+                        label = "小"
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.InputText("濁点"),
+                        label = "゛"
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.InputText("半濁点"),
+                        label = "゜"
+                    )
+                )
+
+                val a = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("あ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("い"),
+                    FlickDirection.UP to FlickAction.Input("う"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え"),
+                    FlickDirection.DOWN to FlickAction.Input("お")
+                )
+                val ka = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("か"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("き"),
+                    FlickDirection.UP to FlickAction.Input("く"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("け"),
+                    FlickDirection.DOWN to FlickAction.Input("こ")
+                )
+                val sa = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("さ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("し"),
+                    FlickDirection.UP to FlickAction.Input("す"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("せ"),
+                    FlickDirection.DOWN to FlickAction.Input("そ")
+                )
+                val ta = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("た"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("ち"),
+                    FlickDirection.UP to FlickAction.Input("つ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("て"),
+                    FlickDirection.DOWN to FlickAction.Input("と")
+                )
+                val na = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("な"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("に"),
+                    FlickDirection.UP to FlickAction.Input("ぬ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ね"),
+                    FlickDirection.DOWN to FlickAction.Input("の")
+                )
+                val ha = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("は"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("ひ"),
+                    FlickDirection.UP to FlickAction.Input("ふ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("へ"),
+                    FlickDirection.DOWN to FlickAction.Input("ほ")
+                )
+                val ma = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("ま"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("み"),
+                    FlickDirection.UP to FlickAction.Input("む"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("め"),
+                    FlickDirection.DOWN to FlickAction.Input("も")
+                )
+                val ya = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("や"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
+                    FlickDirection.UP to FlickAction.Input("ゆ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+                    FlickDirection.DOWN to FlickAction.Input("よ")
+                )
+                val ra = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("ら"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("り"),
+                    FlickDirection.UP to FlickAction.Input("る"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("れ"),
+                    FlickDirection.DOWN to FlickAction.Input("ろ")
+                )
+                val wa = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("わ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("を"),
+                    FlickDirection.UP to FlickAction.Input("ん"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー")
+                )
+                val symbols = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("、"),
+                    FlickDirection.UP to FlickAction.Input("？"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
+                    FlickDirection.DOWN to FlickAction.Input("…")
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                        "あ" to listOf(a),
+                        "か" to listOf(ka),
+                        "さ" to listOf(sa),
+                        "た" to listOf(ta),
+                        "な" to listOf(na),
+                        "は" to listOf(ha),
+                        "ま" to listOf(ma),
+                        "や" to listOf(ya),
+                        "ら" to listOf(ra),
+                        "わ" to listOf(wa),
+                        "、。?!" to listOf(symbols),
+                    )
+
+                dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(emojiStateFlickMap))
+                }
+                dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(dakutenStateFlickMap))
+                }
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                spaceConvertStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(conversionActionMap))
+                }
+
+                return KeyboardLayout(keys, flickMaps, 5, 4)
+            }
+        }
+    }
+
+    private fun createEnglishFlickLayout(
+        inputStyle: String,
+        isUpperCase: Boolean,
+    ): KeyboardLayout {
+        when (inputStyle) {
+            "sumire" -> {
+                return createEnglishLayout(isUpperCase)
+            }
+
+            else -> {
+                val keys = listOf(
+                    KeyData(
+                        "SwitchToNumber",
+                        0,
+                        0,
+                        false,
+                        KeyAction.SwitchToNumberLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
+                    ),
+                    KeyData(
+                        "SwitchToEnglish",
+                        1,
+                        0,
+                        false,
+                        KeyAction.SwitchToEnglishLayout,
+                        isSpecialKey = true,
+                        isHiLighted = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                    ),
+                    KeyData(
+                        "SwitchToKana",
+                        2,
+                        0,
+                        false,
+                        KeyAction.SwitchToKanaLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+                    ),
+                    KeyData(
+                        "",
+                        3,
+                        0,
+                        false,
+                        KeyAction.SwitchToNextIme,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                    ),
+                    KeyData(
+                        "@#/_",
+                        0,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "ABC",
+                        0,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "DEF",
+                        0,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "GHI",
+                        1,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "JKL",
+                        1,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "MNO",
+                        1,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "PQRS",
+                        2,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "TUV",
+                        2,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "WXYZ",
+                        2,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "a/A",
+                        3,
+                        1,
+                        false,
+                        action = KeyAction.ToggleCase,
+                        isSpecialKey = false
+                    ),
+                    KeyData(
+                        "' \" ( )",
+                        3,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        ". , ? !",
+                        3,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "Del",
+                        0,
+                        4,
+                        false,
+                        KeyAction.Delete,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                    ),
+                    KeyData(
+                        spaceConvertStates[0].label ?: "",
+                        1,
+                        4,
+                        true,
+                        spaceConvertStates[0].action,
+                        dynamicStates = spaceConvertStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        keyId = "space_convert_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "CursorMoveLeft",
+                        2,
+                        4,
+                        false,
+                        KeyAction.MoveCursorRight,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
+                        keyType = KeyType.CROSS_FLICK,
+                    ),
+                    KeyData(
+                        enterKeyStates[0].label ?: "",
+                        3,
+                        4,
+                        false,
+                        enterKeyStates[0].action,
+                        dynamicStates = enterKeyStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = enterKeyStates[0].drawableResId,
+                        keyId = "enter_key"
+                    )
+                )
+
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    )
+                )
+
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+
+                fun getCase(c: Char) = if (isUpperCase) c.uppercaseChar() else c
+                val symbols1 = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("@"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("#"),
+                    FlickDirection.UP to FlickAction.Input("/"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("_"),
+                    FlickDirection.DOWN to FlickAction.Input("1")
+                )
+                val abc = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('a').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('b').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('c').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("2")
+                )
+                val def = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('d').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('e').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('f').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("3")
+                )
+                val ghi = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('g').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('h').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('i').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("4")
+                )
+                val jkl = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('j').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('k').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('l').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("5")
+                )
+                val mno = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('m').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('n').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('o').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("6")
+                )
+                val pqrs = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('p').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('q').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('r').toString()),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('s').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("7")
+                )
+                val tuv = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('t').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('u').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('v').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("8")
+                )
+                val wxyz = mapOf(
+                    FlickDirection.TAP to FlickAction.Input(getCase('w').toString()),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('x').toString()),
+                    FlickDirection.UP to FlickAction.Input(getCase('y').toString()),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('z').toString()),
+                    FlickDirection.DOWN to FlickAction.Input("9")
+                )
+                val symbols2 = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("'"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("\""),
+                    FlickDirection.UP to FlickAction.Input("("),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+                    FlickDirection.DOWN to FlickAction.Input("0")
+                )
+                val symbols3 = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("."),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
+                    FlickDirection.UP to FlickAction.Input("?"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("!"),
+                    FlickDirection.DOWN to FlickAction.Input("-")
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                        "@#/_" to listOf(symbols1),
+                        "ABC" to listOf(abc),
+                        "DEF" to listOf(def),
+                        "GHI" to listOf(ghi),
+                        "JKL" to listOf(jkl),
+                        "MNO" to listOf(mno),
+                        "PQRS" to listOf(pqrs),
+                        "TUV" to listOf(tuv),
+                        "WXYZ" to listOf(wxyz),
+                        "' \" ( )" to listOf(symbols2),
+                        ". , ? !" to listOf(symbols3)
+                    )
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                return KeyboardLayout(keys, flickMaps, 5, 4)
+            }
+        }
+    }
+
+    private fun createSymbolFlickLayout(
+        inputStyle: String,
+    ): KeyboardLayout {
+
+        when (inputStyle) {
+            "sumire" -> {
+                return createSymbolLayout()
+            }
+
+            else -> {
+                val keys = listOf(
+                    KeyData(
+                        "SwitchToNumber",
+                        0,
+                        0,
+                        false,
+                        KeyAction.SwitchToNumberLayout,
+                        isSpecialKey = true,
+                        isHiLighted = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
+                    ),
+                    KeyData(
+                        "SwitchToEnglish",
+                        1,
+                        0,
+                        false,
+                        KeyAction.SwitchToEnglishLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+                    ),
+                    KeyData(
+                        "SwitchToKana",
+                        2,
+                        0,
+                        false,
+                        KeyAction.SwitchToKanaLayout,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+                    ),
+                    KeyData(
+                        "",
+                        3,
+                        0,
+                        false,
+                        KeyAction.SwitchToNextIme,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+                    ),
+                    KeyData(
+                        "1\n☆♪→",
+                        0,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "2\n￥$€",
+                        0,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "3\n%°#",
+                        0,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "4\n○*・",
+                        1,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "5\n+x÷",
+                        1,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "6\n< = >",
+                        1,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "7\n「」:",
+                        2,
+                        1,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "8\n〒々〆",
+                        2,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "9\n^|\\",
+                        2,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "0\n〜…",
+                        3,
+                        2,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "( ) [ ]",
+                        3,
+                        1,
+                        true,
+                        isSpecialKey = false,
+                        colSpan = 1,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        ".,-/",
+                        3,
+                        3,
+                        true,
+                        keyType = when (inputStyle) {
+                            "default" -> KeyType.PETAL_FLICK
+                            "circle" -> KeyType.STANDARD_FLICK
+                            else -> KeyType.PETAL_FLICK
+                        }
+                    ),
+                    KeyData(
+                        "Del",
+                        0,
+                        4,
+                        false,
+                        KeyAction.Delete,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+                    ),
+                    KeyData(
+                        spaceConvertStates[0].label ?: "",
+                        1,
+                        4,
+                        true,
+                        spaceConvertStates[0].action,
+                        dynamicStates = spaceConvertStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        keyId = "space_convert_key",
+                        keyType = KeyType.CROSS_FLICK
+                    ),
+                    KeyData(
+                        "CursorMoveLeft",
+                        2,
+                        4,
+                        false,
+                        KeyAction.MoveCursorRight,
+                        isSpecialKey = true,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
+                        keyType = KeyType.CROSS_FLICK,
+                    ),
+                    KeyData(
+                        enterKeyStates[0].label ?: "",
+                        3,
+                        4,
+                        false,
+                        enterKeyStates[0].action,
+                        dynamicStates = enterKeyStates,
+                        isSpecialKey = true,
+                        rowSpan = 1,
+                        drawableResId = enterKeyStates[0].drawableResId,
+                        keyId = "enter_key"
+                    )
+                )
+
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    )
+                )
+
+                val symbols3 = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("."),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
+                    FlickDirection.UP to FlickAction.Input("-"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("/")
+                )
+
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                        "1\n☆♪→" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("1"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("☆"),
+                                FlickDirection.UP to FlickAction.Input("♪"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("→"),
+                            )
+                        ),
+                        "2\n￥$€" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("2"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("￥"),
+                                FlickDirection.UP to FlickAction.Input("$"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("€"),
+                            )
+                        ),
+                        "3\n%°#" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("3"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("%"),
+                                FlickDirection.UP to FlickAction.Input("°"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("#"),
+                            )
+                        ),
+                        "4\n○*・" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("4"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("○"),
+                                FlickDirection.UP to FlickAction.Input("*"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("・"),
+
+                                )
+                        ),
+                        "5\n+x÷" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("5"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("+"),
+                                FlickDirection.UP to FlickAction.Input("x"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("÷"),
+                            ),
+                        ),
+                        "6\n< = >" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("6"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("<"),
+                                FlickDirection.UP to FlickAction.Input("="),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input(">"),
+                            )
+                        ),
+                        "7\n「」:" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("7"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("「"),
+                                FlickDirection.UP to FlickAction.Input("」"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input(":"),
+                            )
+                        ),
+                        "8\n〒々〆" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("8"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("〒"), // Double quote
+                                FlickDirection.UP to FlickAction.Input("々"),   // Single quote
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("〆"),
+                            )
+                        ),
+                        "9\n^|\\" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("9"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("^"),   // Square brackets
+                                FlickDirection.UP to FlickAction.Input("|"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("\\"),   // Curly braces
+                            )
+                        ),
+                        "0\n〜…" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("0"),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input("〜"),
+                                FlickDirection.UP to FlickAction.Input("…"),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("√"),
+                            )
+                        ),
+                        "( ) [ ]" to listOf(
+                            mapOf(
+                                FlickDirection.TAP to FlickAction.Input("("),
+                                FlickDirection.UP_LEFT_FAR to FlickAction.Input(")"),
+                                FlickDirection.UP to FlickAction.Input("["),
+                                FlickDirection.UP_RIGHT_FAR to FlickAction.Input("]"),
+                            )
+                        ),
+                        ".,-/" to listOf(symbols3),
+                    )
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                return KeyboardLayout(keys, flickMaps, 5, 4)
+            }
+        }
+    }
+
+    private fun createHiraganaEffectiveLayout(
+        inputStyle: String
     ): KeyboardLayout {
         val keys = listOf(
             KeyData(
-                "SwitchToNumber",
-                0,
-                0,
-                false,
-                KeyAction.SwitchToNumberLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom,
-            ),
-            KeyData(
-                "SwitchToEnglish",
-                1,
-                0,
-                false,
-                KeyAction.SwitchToEnglishLayout,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
-            ),
-            KeyData(
-                "SwitchToKana",
-                2,
-                0,
-                false,
-                KeyAction.SwitchToKanaLayout,
-                isSpecialKey = true,
-                isHiLighted = true,
-                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
-            ),
-            KeyData(
                 "",
-                3,
+                0,
                 0,
                 false,
                 KeyAction.SwitchToNextIme,
@@ -4862,67 +5767,149 @@ object KeyboardDefaultLayouts {
                 drawableResId = com.kazumaproject.core.R.drawable.language_24dp
             ),
             KeyData(
+                "CursorMoveLeft",
+                1,
+                0,
+                false,
+                KeyAction.MoveCursorLeft,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.outline_arrow_left_alt_24
+            ),
+            KeyData(
+                katakanaToggleStates[0].label ?: "",
+                2,
+                0,
+                false,
+                katakanaToggleStates[0].action,
+                isSpecialKey = true,
+                dynamicStates = katakanaToggleStates,
+                keyId = "katakana_toggle_key",
+            ),
+            KeyData(
+                "SwitchToEnglish",
+                3,
+                0,
+                false,
+                KeyAction.SwitchToEnglishLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+            ),
+            KeyData(
                 "あ",
                 0,
                 1,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "か",
                 0,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "さ",
                 0,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "た",
                 1,
                 1,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "な",
                 1,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "は",
                 1,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "ま",
                 2,
                 1,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "や",
                 2,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "ら",
                 2,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 dakutenToggleStates[0].label ?: "",
@@ -4939,14 +5926,26 @@ object KeyboardDefaultLayouts {
                 3,
                 2,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ),
             KeyData(
                 "、。?!",
                 3,
                 3,
                 true,
-                keyType = if (isDefaultKey) KeyType.TWO_STEP_FLICK else KeyType.STANDARD_FLICK
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    "second-flick" -> KeyType.TWO_STEP_FLICK
+                    "sumire" -> KeyType.CIRCULAR_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
             ), // Label fixed to match map key
             KeyData(
                 "Del",
@@ -4959,49 +5958,1064 @@ object KeyboardDefaultLayouts {
                 drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
             ),
             KeyData(
-                spaceConvertStates[0].label ?: "",
+                "CursorMoveRight",
                 1,
                 4,
+                false,
+                KeyAction.MoveCursorRight,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.outline_arrow_right_alt_24,
+            ),
+            KeyData(
+                spaceConvertStatesCursor[0].label ?: "",
+                2,
+                4,
                 true,
-                spaceConvertStates[0].action,
-                dynamicStates = spaceConvertStates,
+                spaceConvertStatesCursor[0].action,
+                dynamicStates = spaceConvertStatesCursor,
                 isSpecialKey = true,
                 rowSpan = 1,
                 keyId = "space_convert_key",
                 keyType = KeyType.CROSS_FLICK
             ),
             KeyData(
-                "CursorMoveLeft",
-                2,
-                4,
-                false,
-                KeyAction.MoveCursorRight,
-                isSpecialKey = true,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24,
-                keyType = KeyType.CROSS_FLICK,
-            ),
-            KeyData(
-                enterKeyStates[0].label ?: "",
+                enterKeyStatesCursor[0].label ?: "",
                 3,
                 4,
                 false,
-                enterKeyStates[0].action,
-                dynamicStates = enterKeyStates,
+                enterKeyStatesCursor[0].action,
+                dynamicStates = enterKeyStatesCursor,
                 isSpecialKey = true,
                 rowSpan = 1,
-                drawableResId = enterKeyStates[0].drawableResId,
+                drawableResId = enterKeyStatesCursor[0].drawableResId,
                 keyId = "enter_key"
             )
         )
 
-        val cursorMoveActionMap = mapOf(
-            FlickDirection.TAP to FlickAction.Action(
+        when (inputStyle) {
+            "second-flick" -> {
+                val pasteActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Paste,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_paste_24px
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.SelectAll,
+                        drawableResId = com.kazumaproject.core.R.drawable.text_select_start_24dp
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.Copy,
+                        drawableResId = com.kazumaproject.core.R.drawable.content_copy_24dp
+                    )
+                )
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    )
+                )
+
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+
+                val conversionActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Convert,
+                    ),
+                )
+
+                // 状態0 (^_^): タップ操作のみを持つマップ
+                val emojiStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.InputText("^_^"),
+                        label = "^_^"
+                    )
+                    // この状態ではフリックアクションを定義しない
+                )
+                // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+                val dakutenStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.ToggleDakuten,
+                        label = " 小゛゜"
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.InputText("ひらがな小文字"),
+                        label = "小"
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.InputText("濁点"),
+                        label = "゛"
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.InputText("半濁点"),
+                        label = "゜"
+                    )
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "PasteActionKey" to listOf(pasteActionMap),
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                    )
+
+                dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(emojiStateFlickMap))
+                }
+                dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(dakutenStateFlickMap))
+                }
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                spaceConvertStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(conversionActionMap))
+                }
+
+                // 2段階フリック用の文字マップ (isDefaultKey = true の場合に利用)
+                val twoStepFlickMaps = mapOf(
+                    // あ行
+                    "あ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.UP_RIGHT to "ぁ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.LEFT to "い",
+                            TfbiFlickDirection.DOWN_LEFT to "ぃ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.UP to "う",
+                            TfbiFlickDirection.UP_LEFT to "ぅ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.RIGHT to "え",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぇ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "あ",
+                            TfbiFlickDirection.DOWN to "お",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぉ",
+                        )
+                    ),
+                    // か行
+                    "か" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.UP_RIGHT to "が",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.LEFT to "き",
+                            TfbiFlickDirection.DOWN_LEFT to "ぎ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.UP to "く",
+                            TfbiFlickDirection.UP_LEFT to "ぐ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.RIGHT to "け",
+                            TfbiFlickDirection.DOWN_RIGHT to "げ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "か",
+                            TfbiFlickDirection.DOWN to "こ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ご",
+                        )
+                    ),
+                    // さ行
+                    "さ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.UP_RIGHT to "ざ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.LEFT to "し",
+                            TfbiFlickDirection.DOWN_LEFT to "じ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.UP to "す",
+                            TfbiFlickDirection.UP_LEFT to "ず"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.RIGHT to "せ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぜ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "さ",
+                            TfbiFlickDirection.DOWN to "そ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぞ",
+                        )
+                    ),
+                    // た行
+                    "た" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.UP_RIGHT to "だ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.LEFT to "ち",
+                            TfbiFlickDirection.DOWN_LEFT to "ぢ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.UP to "つ",
+                            TfbiFlickDirection.UP_LEFT to "づ",
+                            TfbiFlickDirection.UP_RIGHT to "っ"
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.RIGHT to "て",
+                            TfbiFlickDirection.DOWN_RIGHT to "で"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "た",
+                            TfbiFlickDirection.DOWN to "と",
+                            TfbiFlickDirection.DOWN_RIGHT to "ど",
+                        )
+                    ),
+                    // な行
+                    "な" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.LEFT to "に",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.UP to "ぬ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.RIGHT to "ね",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "な",
+                            TfbiFlickDirection.DOWN to "の",
+                        )
+                    ),
+                    // は行
+                    "は" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP_RIGHT to "ば",
+                        ),
+                        TfbiFlickDirection.UP_LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP_LEFT to "ぱ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.LEFT to "ひ",
+                            TfbiFlickDirection.DOWN_LEFT to "び",
+                            TfbiFlickDirection.UP_LEFT to "ぴ",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.UP to "ふ",
+                            TfbiFlickDirection.UP_RIGHT to "ぷ",
+                            TfbiFlickDirection.UP_LEFT to "ぶ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.RIGHT to "へ",
+                            TfbiFlickDirection.DOWN_RIGHT to "べ",
+                            TfbiFlickDirection.UP_RIGHT to "ぺ"
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "は",
+                            TfbiFlickDirection.DOWN to "ほ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ぼ",
+                            TfbiFlickDirection.DOWN_LEFT to "ぽ",
+                        )
+                    ),
+                    // ま行
+                    "ま" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.LEFT to "み",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.UP to "む",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.RIGHT to "め",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "ま",
+                            TfbiFlickDirection.DOWN to "も",
+                        )
+                    ),
+                    // や行
+                    "や" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.UP_RIGHT to "ゃ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.LEFT to "(",
+                            TfbiFlickDirection.DOWN_LEFT to "「",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.UP to "ゆ",
+                            TfbiFlickDirection.UP_LEFT to "ゅ",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.RIGHT to ")",
+                            TfbiFlickDirection.DOWN_RIGHT to "」",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "や",
+                            TfbiFlickDirection.DOWN to "よ",
+                            TfbiFlickDirection.DOWN_RIGHT to "ょ",
+                        )
+                    ),
+                    // ら行
+                    "ら" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.LEFT to "り",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.UP to "る",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.RIGHT to "れ",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "ら",
+                            TfbiFlickDirection.DOWN to "ろ",
+                        )
+                    ),
+                    // わ行
+                    "わ" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                        ),
+                        TfbiFlickDirection.UP_RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.UP_RIGHT to "ゎ",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.LEFT to "を",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.UP to "ん",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.RIGHT to "ー",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "わ",
+                            TfbiFlickDirection.DOWN to "〜",
+                        )
+                    ),
+                    // 記号
+                    "、。?!" to mapOf(
+                        TfbiFlickDirection.TAP to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                        ),
+                        TfbiFlickDirection.LEFT to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.LEFT to "。",
+                        ),
+                        TfbiFlickDirection.UP to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.UP to "？",
+                            TfbiFlickDirection.UP_LEFT to "：",
+                            TfbiFlickDirection.UP_RIGHT to "・",
+                        ),
+                        TfbiFlickDirection.RIGHT to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.RIGHT to "！",
+                        ),
+                        TfbiFlickDirection.DOWN to mapOf(
+                            TfbiFlickDirection.TAP to "、",
+                            TfbiFlickDirection.DOWN to "…",
+                        )
+                    )
+                )
+
+                return KeyboardLayout(keys, flickMaps, 5, 4, twoStepFlickKeyMaps = twoStepFlickMaps)
+            }
+
+            "sumire" -> {
+                return createHiraganaLayout()
+            }
+
+            else -> {
+                val cursorMoveActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.MoveCursorRight,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.MoveCursorLeft,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                    )
+                )
+
+                val spaceActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Space,
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.Space,
+                        drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+                    )
+                )
+
+                val conversionActionMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.Convert,
+                    ),
+                )
+
+                // 状態0 (^_^): タップ操作のみを持つマップ
+                val emojiStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.InputText("^_^"),
+                        label = "^_^"
+                    )
+                    // この状態ではフリックアクションを定義しない
+                )
+
+                // 状態1 ( 小゛゜): タップとフリック操作を持つマップ
+                val dakutenStateFlickMap = mapOf(
+                    FlickDirection.TAP to FlickAction.Action(
+                        KeyAction.ToggleDakuten,
+                        label = " 小゛゜"
+                    ),
+                    FlickDirection.UP to FlickAction.Action(
+                        KeyAction.InputText("ひらがな小文字"),
+                        label = "小"
+                    ),
+                    FlickDirection.UP_LEFT to FlickAction.Action(
+                        KeyAction.InputText("濁点"),
+                        label = "゛"
+                    ),
+                    FlickDirection.UP_RIGHT to FlickAction.Action(
+                        KeyAction.InputText("半濁点"),
+                        label = "゜"
+                    )
+                )
+
+                val a = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("あ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("い"),
+                    FlickDirection.UP to FlickAction.Input("う"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え"),
+                    FlickDirection.DOWN to FlickAction.Input("お")
+                )
+                val ka = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("か"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("き"),
+                    FlickDirection.UP to FlickAction.Input("く"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("け"),
+                    FlickDirection.DOWN to FlickAction.Input("こ")
+                )
+                val sa = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("さ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("し"),
+                    FlickDirection.UP to FlickAction.Input("す"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("せ"),
+                    FlickDirection.DOWN to FlickAction.Input("そ")
+                )
+                val ta = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("た"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("ち"),
+                    FlickDirection.UP to FlickAction.Input("つ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("て"),
+                    FlickDirection.DOWN to FlickAction.Input("と")
+                )
+                val na = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("な"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("に"),
+                    FlickDirection.UP to FlickAction.Input("ぬ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ね"),
+                    FlickDirection.DOWN to FlickAction.Input("の")
+                )
+                val ha = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("は"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("ひ"),
+                    FlickDirection.UP to FlickAction.Input("ふ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("へ"),
+                    FlickDirection.DOWN to FlickAction.Input("ほ")
+                )
+                val ma = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("ま"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("み"),
+                    FlickDirection.UP to FlickAction.Input("む"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("め"),
+                    FlickDirection.DOWN to FlickAction.Input("も")
+                )
+                val ya = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("や"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
+                    FlickDirection.UP to FlickAction.Input("ゆ"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+                    FlickDirection.DOWN to FlickAction.Input("よ")
+                )
+                val ra = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("ら"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("り"),
+                    FlickDirection.UP to FlickAction.Input("る"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("れ"),
+                    FlickDirection.DOWN to FlickAction.Input("ろ")
+                )
+                val wa = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("わ"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("を"),
+                    FlickDirection.UP to FlickAction.Input("ん"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("ー")
+                )
+                val symbols = mapOf(
+                    FlickDirection.TAP to FlickAction.Input("、"),
+                    FlickDirection.UP to FlickAction.Input("？"),
+                    FlickDirection.UP_LEFT_FAR to FlickAction.Input("。"),
+                    FlickDirection.UP_RIGHT_FAR to FlickAction.Input("！"),
+                    FlickDirection.DOWN to FlickAction.Input("…")
+                )
+
+                val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+                    mutableMapOf(
+                        "CursorMoveLeft" to listOf(cursorMoveActionMap),
+                        "あ" to listOf(a),
+                        "か" to listOf(ka),
+                        "さ" to listOf(sa),
+                        "た" to listOf(ta),
+                        "な" to listOf(na),
+                        "は" to listOf(ha),
+                        "ま" to listOf(ma),
+                        "や" to listOf(ya),
+                        "ら" to listOf(ra),
+                        "わ" to listOf(wa),
+                        "、。?!" to listOf(symbols),
+                    )
+
+                dakutenToggleStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(emojiStateFlickMap))
+                }
+                dakutenToggleStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(dakutenStateFlickMap))
+                }
+
+                spaceConvertStates.getOrNull(0)?.label?.let { label ->
+                    flickMaps.put(label, listOf(spaceActionMap))
+                }
+
+                spaceConvertStates.getOrNull(1)?.label?.let { label ->
+                    flickMaps.put(label, listOf(conversionActionMap))
+                }
+
+                return KeyboardLayout(keys, flickMaps, 5, 4)
+            }
+        }
+    }
+
+    private fun createEnglishEffectiveLayout(
+        isUpperCase: Boolean,
+        inputStyle: String
+    ): KeyboardLayout {
+        val keys = listOf(
+            KeyData(
+                "",
+                0,
+                0,
+                false,
+                KeyAction.SwitchToNextIme,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+            ),
+            KeyData(
+                "CursorMoveLeft",
+                1,
+                0,
+                false,
+                KeyAction.MoveCursorLeft,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.outline_arrow_left_alt_24
+            ),
+            KeyData(
+                "SwitchToNumber",
+                2,
+                0,
+                false,
+                KeyAction.SwitchToNumberLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_number_select_custom
+            ),
+            KeyData(
+                "SwitchToKana",
+                3,
+                0,
+                false,
+                KeyAction.SwitchToKanaLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+            ),
+            KeyData(
+                "@#/_",
+                0,
+                1,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "ABC",
+                0,
+                2,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "DEF",
+                0,
+                3,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "GHI",
+                1,
+                1,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "JKL",
+                1,
+                2,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "MNO",
+                1,
+                3,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "PQRS",
+                2,
+                1,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "TUV",
+                2,
+                2,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "WXYZ",
+                2,
+                3,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "a/A",
+                3,
+                1,
+                false,
+                action = KeyAction.ToggleCase,
+                isSpecialKey = false
+            ),
+            KeyData(
+                "' \" ( )",
+                3,
+                2,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                ". , ? !",
+                3,
+                3,
+                true,
+                keyType = when (inputStyle) {
+                    "default" -> KeyType.PETAL_FLICK
+                    "circle" -> KeyType.STANDARD_FLICK
+                    else -> KeyType.PETAL_FLICK
+                }
+            ),
+            KeyData(
+                "Del",
+                0,
+                4,
+                false,
+                KeyAction.Delete,
+                isSpecialKey = true,
+                rowSpan = 1,
+                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+            ),
+            KeyData(
+                "CursorMoveRight",
+                1,
+                4,
+                false,
                 KeyAction.MoveCursorRight,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_24
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.outline_arrow_right_alt_24,
+            ),
+            KeyData(
+                spaceConvertStatesCursor[0].label ?: "",
+                2,
+                4,
+                true,
+                spaceConvertStatesCursor[0].action,
+                dynamicStates = spaceConvertStatesCursor,
+                isSpecialKey = true,
+                rowSpan = 1,
+                keyId = "space_convert_key",
+                keyType = KeyType.CROSS_FLICK
+            ),
+            KeyData(
+                enterKeyStatesCursor[0].label ?: "",
+                3,
+                4,
+                false,
+                enterKeyStatesCursor[0].action,
+                dynamicStates = enterKeyStatesCursor,
+                isSpecialKey = true,
+                rowSpan = 1,
+                drawableResId = enterKeyStatesCursor[0].drawableResId,
+                keyId = "enter_key"
+            )
+        )
+        val spaceActionMap = mapOf(
+            FlickDirection.TAP to FlickAction.Action(
+                KeyAction.Space,
             ),
             FlickDirection.UP_LEFT to FlickAction.Action(
+                KeyAction.Space,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_space_bar_24
+
+            )
+        )
+
+        fun getCase(c: Char) = if (isUpperCase) c.uppercaseChar() else c
+        val symbols1 = mapOf(
+            FlickDirection.TAP to FlickAction.Input("@"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("#"),
+            FlickDirection.UP to FlickAction.Input("/"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("_"),
+            FlickDirection.DOWN to FlickAction.Input("1")
+        )
+        val abc = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('a').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('b').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('c').toString()),
+            FlickDirection.DOWN to FlickAction.Input("2")
+        )
+        val def = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('d').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('e').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('f').toString()),
+            FlickDirection.DOWN to FlickAction.Input("3")
+        )
+        val ghi = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('g').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('h').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('i').toString()),
+            FlickDirection.DOWN to FlickAction.Input("4")
+        )
+        val jkl = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('j').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('k').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('l').toString()),
+            FlickDirection.DOWN to FlickAction.Input("5")
+        )
+        val mno = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('m').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('n').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('o').toString()),
+            FlickDirection.DOWN to FlickAction.Input("6")
+        )
+        val pqrs = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('p').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('q').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('r').toString()),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('s').toString()),
+            FlickDirection.DOWN to FlickAction.Input("7")
+        )
+        val tuv = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('t').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('u').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('v').toString()),
+            FlickDirection.DOWN to FlickAction.Input("8")
+        )
+        val wxyz = mapOf(
+            FlickDirection.TAP to FlickAction.Input(getCase('w').toString()),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(getCase('x').toString()),
+            FlickDirection.UP to FlickAction.Input(getCase('y').toString()),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(getCase('z').toString()),
+            FlickDirection.DOWN to FlickAction.Input("9")
+        )
+        val symbols2 = mapOf(
+            FlickDirection.TAP to FlickAction.Input("'"),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input("\""),
+            FlickDirection.UP to FlickAction.Input("("),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+            FlickDirection.DOWN to FlickAction.Input("0")
+        )
+        val symbols3 = mapOf(
+            FlickDirection.TAP to FlickAction.Input("."),
+            FlickDirection.UP_LEFT_FAR to FlickAction.Input(","),
+            FlickDirection.UP to FlickAction.Input("?"),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input("!"),
+            FlickDirection.DOWN to FlickAction.Input("-")
+        )
+
+        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+            mutableMapOf(
+                "@#/_" to listOf(symbols1),
+                "ABC" to listOf(abc),
+                "DEF" to listOf(def),
+                "GHI" to listOf(ghi),
+                "JKL" to listOf(jkl),
+                "MNO" to listOf(mno),
+                "PQRS" to listOf(pqrs),
+                "TUV" to listOf(tuv),
+                "WXYZ" to listOf(wxyz),
+                "' \" ( )" to listOf(symbols2),
+                ". , ? !" to listOf(symbols3)
+            )
+
+        spaceConvertStates.getOrNull(0)?.label?.let { label ->
+            flickMaps.put(label, listOf(spaceActionMap))
+        }
+
+        return KeyboardLayout(keys, flickMaps, 5, 4)
+    }
+
+    private fun createNumberEffectiveLayout(): KeyboardLayout {
+        val keys = listOf(
+            KeyData(
+                "",
+                0,
+                0,
+                false,
+                KeyAction.SwitchToNextIme,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.language_24dp
+            ),
+            KeyData(
+                "CursorMoveLeft",
+                1,
+                0,
+                false,
                 KeyAction.MoveCursorLeft,
-                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_left_24
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.outline_arrow_left_alt_24
+            ),
+            KeyData(
+                "SwitchToKana",
+                2,
+                0,
+                false,
+                KeyAction.SwitchToKanaLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_japanese_select_custom,
+            ),
+            KeyData(
+                "SwitchToEnglish",
+                3,
+                0,
+                false,
+                KeyAction.SwitchToEnglishLayout,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.input_mode_english_custom
+            ),
+            KeyData(
+                label = "1",
+                row = 0,
+                column = 1,
+                isFlickable = false,
+                keyType = KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                label = "4",
+                row = 1,
+                column = 1,
+                isFlickable = false,
+                keyType = KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                label = "7",
+                row = 2,
+                column = 1,
+                isFlickable = false,
+                keyType = KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                label = ",",
+                row = 3,
+                column = 1,
+                isFlickable = false,
+                keyType = KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "2", 0, 2,
+                false,
+                keyType = KeyType.STANDARD_FLICK
+            ),
+            KeyData(
+                "3", 0, 3,
+                false,
+                keyType = KeyType.STANDARD_FLICK
+            ),
+            KeyData("5", 1, 2, false, keyType = KeyType.STANDARD_FLICK),
+            KeyData("6", 1, 3, false, keyType = KeyType.STANDARD_FLICK),
+            KeyData("8", 2, 2, false, keyType = KeyType.STANDARD_FLICK),
+            KeyData("9", 2, 3, false, keyType = KeyType.STANDARD_FLICK),
+            KeyData("0", 3, 2, false, keyType = KeyType.STANDARD_FLICK),
+            KeyData(".", 3, 3, false, keyType = KeyType.STANDARD_FLICK),
+            KeyData(
+                "Del",
+                0,
+                4,
+                false,
+                KeyAction.Delete,
+                isSpecialKey = true,
+                rowSpan = 1,
+                drawableResId = com.kazumaproject.core.R.drawable.backspace_24px
+            ),
+            KeyData(
+                "CursorMoveRight",
+                1,
+                4,
+                false,
+                KeyAction.MoveCursorRight,
+                isSpecialKey = true,
+                drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_alt_24,
+            ),
+            KeyData(
+                spaceConvertStatesCursor[0].label ?: "",
+                2,
+                4,
+                true,
+                spaceConvertStatesCursor[0].action,
+                dynamicStates = spaceConvertStatesCursor,
+                isSpecialKey = true,
+                rowSpan = 1,
+                keyId = "space_convert_key",
+                keyType = KeyType.CROSS_FLICK
+            ),
+            KeyData(
+                enterKeyStatesCursor[0].label ?: "",
+                3,
+                4,
+                false,
+                enterKeyStatesCursor[0].action,
+                dynamicStates = enterKeyStatesCursor,
+                isSpecialKey = true,
+                rowSpan = 1,
+                drawableResId = enterKeyStatesCursor[0].drawableResId,
+                keyId = "enter_key"
             )
         )
 
@@ -5051,317 +7065,37 @@ object KeyboardDefaultLayouts {
             )
         )
 
-        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> = mutableMapOf(
-            "CursorMoveLeft" to listOf(cursorMoveActionMap),
-        )
-
-        val twoStepFlickMaps = mapOf(
-            // あ行
-            "あ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
+        val flickMaps: MutableMap<String, List<Map<FlickDirection, FlickAction>>> =
+            mutableMapOf(
+                "1" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("1"))),
+                "2" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("2"))),
+                "3" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("3"))),
+                "4" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("4"))),
+                "5" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("5"))),
+                "6" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("6"))),
+                "7" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("7"))),
+                "8" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("8"))),
+                "9" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("9"))),
+                "0" to listOf(mapOf(FlickDirection.TAP to FlickAction.Input("0"))),
+                "," to listOf(
+                    mapOf(
+                        FlickDirection.TAP to FlickAction.Input(","),
+                        FlickDirection.UP_LEFT_FAR to FlickAction.Input("+"),
+                        FlickDirection.UP to FlickAction.Input("-"),
+                        FlickDirection.UP_RIGHT_FAR to FlickAction.Input("*"),
+                        FlickDirection.DOWN to FlickAction.Input("/"),
+                    )
                 ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.UP_RIGHT to "ぁ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.LEFT to "い",
-                    TfbiFlickDirection.DOWN_LEFT to "ぃ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.UP to "う",
-                    TfbiFlickDirection.UP_LEFT to "ぅ"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.RIGHT to "え",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぇ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "あ",
-                    TfbiFlickDirection.DOWN to "お",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぉ",
-                )
-            ),
-            // か行
-            "か" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.UP_RIGHT to "が",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.LEFT to "き",
-                    TfbiFlickDirection.DOWN_LEFT to "ぎ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.UP to "く",
-                    TfbiFlickDirection.UP_LEFT to "ぐ"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.RIGHT to "け",
-                    TfbiFlickDirection.DOWN_RIGHT to "げ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "か",
-                    TfbiFlickDirection.DOWN to "こ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ご",
-                )
-            ),
-            // さ行
-            "さ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.UP_RIGHT to "ざ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.LEFT to "し",
-                    TfbiFlickDirection.DOWN_LEFT to "じ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.UP to "す",
-                    TfbiFlickDirection.UP_LEFT to "ず"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.RIGHT to "せ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぜ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "さ",
-                    TfbiFlickDirection.DOWN to "そ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぞ",
-                )
-            ),
-            // た行
-            "た" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.UP_RIGHT to "だ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.LEFT to "ち",
-                    TfbiFlickDirection.DOWN_LEFT to "ぢ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.UP to "つ",
-                    TfbiFlickDirection.UP_LEFT to "づ",
-                    TfbiFlickDirection.UP_RIGHT to "っ"
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.RIGHT to "て",
-                    TfbiFlickDirection.DOWN_RIGHT to "で"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "た",
-                    TfbiFlickDirection.DOWN to "と",
-                    TfbiFlickDirection.DOWN_RIGHT to "ど",
-                )
-            ),
-            // な行
-            "な" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.LEFT to "に",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.UP to "ぬ",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.RIGHT to "ね",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "な",
-                    TfbiFlickDirection.DOWN to "の",
-                )
-            ),
-            // は行
-            "は" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.UP_RIGHT to "ば",
-                ),
-                TfbiFlickDirection.UP_LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.UP_LEFT to "ぱ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.LEFT to "ひ",
-                    TfbiFlickDirection.DOWN_LEFT to "び",
-                    TfbiFlickDirection.UP_LEFT to "ぴ",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.UP to "ふ",
-                    TfbiFlickDirection.UP_RIGHT to "ぷ",
-                    TfbiFlickDirection.UP_LEFT to "ぶ",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.RIGHT to "へ",
-                    TfbiFlickDirection.DOWN_RIGHT to "べ",
-                    TfbiFlickDirection.UP_RIGHT to "ぺ"
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "は",
-                    TfbiFlickDirection.DOWN to "ほ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ぼ",
-                    TfbiFlickDirection.DOWN_LEFT to "ぽ",
-                )
-            ),
-            // ま行
-            "ま" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.LEFT to "み",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.UP to "む",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.RIGHT to "め",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "ま",
-                    TfbiFlickDirection.DOWN to "も",
-                )
-            ),
-            // や行
-            "や" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.UP_RIGHT to "ゃ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.LEFT to "(",
-                    TfbiFlickDirection.DOWN_LEFT to "「",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.UP to "ゆ",
-                    TfbiFlickDirection.UP_LEFT to "ゅ",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.RIGHT to ")",
-                    TfbiFlickDirection.DOWN_RIGHT to "」",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "や",
-                    TfbiFlickDirection.DOWN to "よ",
-                    TfbiFlickDirection.DOWN_RIGHT to "ょ",
-                )
-            ),
-            // ら行
-            "ら" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.LEFT to "り",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.UP to "る",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.RIGHT to "れ",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "ら",
-                    TfbiFlickDirection.DOWN to "ろ",
-                )
-            ),
-            // わ行
-            "わ" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                ),
-                TfbiFlickDirection.UP_RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.UP_RIGHT to "ゎ",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.LEFT to "を",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.UP to "ん",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.RIGHT to "ー",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "わ",
-                    TfbiFlickDirection.DOWN to "〜",
-                )
-            ),
-            // 記号
-            "、。?!" to mapOf(
-                TfbiFlickDirection.TAP to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                ),
-                TfbiFlickDirection.LEFT to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.LEFT to "。",
-                ),
-                TfbiFlickDirection.UP to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.UP to "？",
-                    TfbiFlickDirection.UP_LEFT to "：",
-                    TfbiFlickDirection.UP_RIGHT to "・",
-                ),
-                TfbiFlickDirection.RIGHT to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.RIGHT to "！",
-                ),
-                TfbiFlickDirection.DOWN to mapOf(
-                    TfbiFlickDirection.TAP to "、",
-                    TfbiFlickDirection.DOWN to "…",
+                "." to listOf(
+                    mapOf(
+                        FlickDirection.TAP to FlickAction.Input("."),
+                        FlickDirection.UP_LEFT_FAR to FlickAction.Input("("),
+                        FlickDirection.UP to FlickAction.Input("%"),
+                        FlickDirection.UP_RIGHT_FAR to FlickAction.Input(")"),
+                        FlickDirection.DOWN to FlickAction.Input("="),
+                    )
                 )
             )
-        )
 
         dakutenToggleStates.getOrNull(0)?.label?.let { label ->
             flickMaps.put(label, listOf(emojiStateFlickMap))
@@ -5378,7 +7112,7 @@ object KeyboardDefaultLayouts {
             flickMaps.put(label, listOf(conversionActionMap))
         }
 
-        return KeyboardLayout(keys, flickMaps, 5, 4, twoStepFlickKeyMaps = twoStepFlickMaps)
+        return KeyboardLayout(keys, flickMaps, 5, 4)
     }
 
 }

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -4,7 +4,12 @@ import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.Configuration
 import android.graphics.Rect
+import android.graphics.Typeface
 import android.os.SystemClock
+import android.text.Spannable
+import android.text.SpannableString
+import android.text.style.RelativeSizeSpan
+import android.text.style.StyleSpan
 import android.util.AttributeSet
 import android.util.Log
 import android.util.SparseArray
@@ -103,6 +108,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     private val qwertyMode: StateFlow<QWERTYMode> = _qwertyMode.asStateFlow()
 
     private var isTablet = false
+    private var showPopupView = true
 
     private var isDynamicColorsEnable = false
 
@@ -360,6 +366,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         }
     }
 
+    fun setPopUpViewState(state: Boolean) {
+        this.showPopupView = state
+    }
+
     private fun setMaterialYouTheme(
         isDarkMode: Boolean, isDynamicColorEnable: Boolean
     ) {
@@ -411,6 +421,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
 
             cursorLeft.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
             cursorRight.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
+            switchRomajiEnglish.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
         }
     }
 
@@ -462,7 +473,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             binding.cursorLeft to QWERTYKey.QWERTYKeyCursorLeft,
             binding.cursorRight to QWERTYKey.QWERTYKeyCursorRight,
             binding.keyTouten to QWERTYKey.QWERTYKeyTouten,
-            binding.keyKuten to QWERTYKey.QWERTYKeyKuten
+            binding.keyKuten to QWERTYKey.QWERTYKeyKuten,
+            binding.switchRomajiEnglish to QWERTYKey.QWERTYKeySwitchRomajiEnglish
         )
     }
 
@@ -771,7 +783,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                     } else {
                         val qwertyKey = qwertyButtonMap[it] ?: QWERTYKey.QWERTYKeyNotSelect
                         when (qwertyKey) {
-                            QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight -> {
+                            QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight, QWERTYKey.QWERTYKeySwitchRomajiEnglish -> {
                                 qwertyKeyListener?.onReleasedQWERTYKey(qwertyKey, null, null)
                             }
 
@@ -831,7 +843,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                                     val qwertyKey =
                                         qwertyButtonMap[it] ?: QWERTYKey.QWERTYKeyNotSelect
                                     when (qwertyKey) {
-                                        QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight -> {
+                                        QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight, QWERTYKey.QWERTYKeySwitchRomajiEnglish -> {
                                             qwertyKeyListener?.onReleasedQWERTYKey(
                                                 qwertyKey,
                                                 null,
@@ -1025,6 +1037,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
      */
     private fun showKeyPreview(view: View) {
         if (isTablet) return
+        if (!showPopupView) return
         dismissKeyPreview()
         val previewHeight = dpToPx(view.height)
         val layoutRes = R.layout.key_preview_large
@@ -1323,6 +1336,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         _capsLockState.value = CapsLockState()
     }
 
+    fun getRomajiMode(): Boolean {
+        return romajiModeState.value
+    }
+
     fun setRomajiMode(state: Boolean) {
         _romajiModeState.update { state }
     }
@@ -1409,6 +1426,53 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         binding.keySwitchDefault.isVisible = showSwitchKey
         binding.keyKuten.isVisible = showKutouten
         binding.keyTouten.isVisible = showKutouten
+    }
+
+    fun setRomajiEnglishSwitchKeyVisibility(
+        showRomajiEnglishKey: Boolean
+    ) {
+        binding.switchRomajiEnglish.isVisible = showRomajiEnglishKey
+    }
+
+    fun setRomajiEnglishSwitchKeyTextWithStyle(showRomajiEnglishKey: Boolean) {
+        val text = "あa"
+        val spannableString = SpannableString(text)
+
+        if (showRomajiEnglishKey) {
+            spannableString.setSpan(
+                StyleSpan(Typeface.BOLD),
+                0,
+                1,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
+            spannableString.setSpan(
+                StyleSpan(Typeface.NORMAL),
+                1,
+                2,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
+        } else {
+            spannableString.setSpan(
+                StyleSpan(Typeface.NORMAL),
+                0,
+                1,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
+            spannableString.setSpan(
+                StyleSpan(Typeface.BOLD),
+                1,
+                2,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
+            spannableString.setSpan(
+                RelativeSizeSpan(1.7f),
+                1,
+                2,
+                Spannable.SPAN_INCLUSIVE_INCLUSIVE
+            )
+        }
+
+        binding.switchRomajiEnglish.text = spannableString
     }
 
 }

--- a/qwerty_keyboard/src/main/res/layout-land/qwerty_layout.xml
+++ b/qwerty_keyboard/src/main/res/layout-land/qwerty_layout.xml
@@ -588,6 +588,25 @@
 
     <!-- ─── Fourth Row: 123, (new extra button), SPACE, RETURN ─── -->
     <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/switch_romaji_english"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:layout_marginEnd="4dp"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:gravity="center"
+        android:text="あa"
+        android:textAllCaps="false"
+        android:textColor="@color/keyboard_icon_color"
+        android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key_123"
+        app:layout_constraintHorizontal_weight="0.75"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/key_123"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -601,8 +620,8 @@
         android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/key_switch_default"
-        app:layout_constraintHorizontal_weight="0.5"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintHorizontal_weight="0.75"
+        app:layout_constraintStart_toEndOf="@id/switch_romaji_english"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
 
     <androidx.appcompat.widget.AppCompatImageButton

--- a/qwerty_keyboard/src/main/res/layout/qwerty_layout.xml
+++ b/qwerty_keyboard/src/main/res/layout/qwerty_layout.xml
@@ -588,6 +588,26 @@
 
     <!-- ─── Fourth Row: 123, (new extra button), SPACE, RETURN ─── -->
     <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/switch_romaji_english"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:layout_marginStart="2dp"
+        android:layout_marginEnd="4dp"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:gravity="center"
+        android:text="あa"
+        android:textAllCaps="false"
+        android:textColor="@color/keyboard_icon_color"
+        android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key_123"
+        app:layout_constraintHorizontal_weight="0.75"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
+
+    <androidx.appcompat.widget.AppCompatButton
         android:id="@+id/key_123"
         android:layout_width="0dp"
         android:layout_height="0dp"
@@ -602,7 +622,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/key_switch_default"
         app:layout_constraintHorizontal_weight="0.75"
-        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintStart_toEndOf="@id/switch_romaji_english"
         app:layout_constraintTop_toBottomOf="@id/guideline_row3" />
 
     <androidx.appcompat.widget.AppCompatImageButton

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -512,6 +512,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
     }
 
     fun setCurrentMode(inputMode: InputMode) {
+        Log.d("setCurrentMode", "$inputMode")
         _currentInputMode.update { inputMode }
     }
 


### PR DESCRIPTION
## 概要

- スミレキーボードにカーソル入力のレイアウトを追加
- QWERTY のローマ字入力キーボードにローマ字と英語の切り替えキーの追加
- リスタート時にキーボードをリセットしないように修正
- EditText のタイプの検知の修正