### PR TITLE
変換候補の View の高さの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 524
-        versionName "1.4.403"
+        versionCode 525
+        versionName "1.4.404"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## 概要

- 特定のデバイスで変換候補を ２、３段にすると高さが余分に設定されるので修正。
- QWERTY キーボードにて、エンターとスペースキーの文字の修正