### PR TITLE
FlexboxLayoutManager から LinearLayoutManager に変更した際に、クラッシュするバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 527
-        versionName "1.4.406"
+        versionCode 528
+        versionName "1.4.407"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -516,8 +516,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private var countToggleKatakana = 0
 
-    private lateinit var linearLayoutManager: LinearLayoutManager
-
     override fun onCreate() {
         super.onCreate()
         Timber.d("onCreate")
@@ -552,7 +550,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         listAdapter.onPagerClicked = {
             goToNextPageForFloatingCandidate()
         }
-        linearLayoutManager = LinearLayoutManager(this, RecyclerView.HORIZONTAL, false)
     }
 
     override fun onCreateInputView(): View? {
@@ -6790,7 +6787,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
         when (columnNum) {
             "1" -> {
-                mainView.suggestionRecyclerView.layoutManager = linearLayoutManager
+                mainView.suggestionRecyclerView.layoutManager =
+                    LinearLayoutManager(this, LinearLayoutManager.HORIZONTAL, false)
             }
 
             "2", "3" -> {


### PR DESCRIPTION
## 概要
FlexboxLayoutManager から LinearLayoutManager に変更したが、 onCreate で LinearLayoutManager を宣言していたのを onStartInputView に移動させた。