### PR TITLE
サムスンのデバイスにおけるキーボードの高さの修正とローマ字入力で子音字を2つ連続して入力すると、子音字+子音字が「っ」になり子音が残らないの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 530
-        versionName "1.4.409"
+        versionCode 531
+        versionName "1.4.410"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -75,6 +75,9 @@ object AppPreference {
     private val KEYBOARD_FLOATING_POSITION_X = Pair("keyboard_floating_position_x", -1)
     private val KEYBOARD_FLOATING_POSITION_Y = Pair("keyboard_floating_position_y", -1)
 
+    private val KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE =
+        Pair("keyboard_height_fix_enable_preference", false)
+
     private val defaultKeyboardOrderJson = gson.toJson(
         listOf(
             KeyboardType.TENKEY,
@@ -386,6 +389,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(CUSTOM_KEYBOARD_SUGGESTION_PREFERENCE.first, value ?: true)
+        }
+
+    var keyboard_height_fix_for_specific_device_preference: Boolean?
+        get() = preferences.getBoolean(
+            KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE.first,
+            KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE.first, value ?: false)
         }
 
     var sumire_input_selection_preference: String?

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -15,6 +15,13 @@
             android:summary="キーボードの位置とサイズの設定を変更できます"
             android:title="位置とサイズの設定" />
 
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="keyboard_height_fix_enable_preference"
+            android:summaryOff="一部端末向けの高さ補正は無効です。"
+            android:summaryOn="一部端末向けの高さ補正は有効です（例：Galaxy）。"
+            android:title="端末別の高さ補正" />
+
         <PreferenceCategory android:title="変換候補">
             <SeekBarPreference
                 android:defaultValue="4"
@@ -64,6 +71,7 @@
                 android:summaryOff="削除キータップ：ハイライト解除"
                 android:summaryOn="削除キー長押し：ハイライト解除\n削除キータップ：選択位置を1つ前に戻す"
                 android:title="候補ハイライト時の削除キー動作" />
+
         </PreferenceCategory>
 
         <PreferenceCategory android:title="機能">

--- a/core/src/main/java/com/kazumaproject/core/domain/extensions/DpPx.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/extensions/DpPx.kt
@@ -1,6 +1,7 @@
 package com.kazumaproject.core.domain.extensions
 
 import android.content.Context
+import android.os.Build
 
 /**
  * Context 拡張: dp → px（Int 版）
@@ -65,3 +66,7 @@ fun android.view.View.dpToPx(dp: Int): Int =
  */
 fun android.view.View.pxToDp(px: Int): Int =
     context.pxToDp(px)
+
+fun isGalaxyDevice(): Boolean {
+    return Build.MANUFACTURER.equals("samsung", ignoreCase = true)
+}


### PR DESCRIPTION
## Issue
#305 #309 

## 概要
- ローマ字入力で子音字を2つ連続して入力した際に、「っ」の後に子音を残すように修正

- かなりアドホック的な対応になるが Galaxy の端末の場合 + Preference が ON の場合、高さの値を低くする。