### PR TITLE
パスワード入力を検知した際に QWERTY に切り替える設定の追加

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -30,6 +30,8 @@ object AppPreference {
     private val MOZCUT_NEOLOGD = Pair("mozc_ut_neologd_preference", false)
     private val MOZCUT_WEB = Pair("mozc_ut_web_preference", false)
 
+    private val SWITCH_QWERTY_PASSWORD = Pair("switch_qwerty_keyboard_password_preference", false)
+
     private val CUSTOM_KEYBOARD_TWO_WORDS_OUTPUTS =
         Pair("custom_keyboard_two_words_preference", true)
 
@@ -138,6 +140,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(QWERTY_SHOW_CURSOR_BUTTONS.first, value ?: false)
+        }
+
+    var switch_qwerty_password: Boolean?
+        get() = preferences.getBoolean(
+            SWITCH_QWERTY_PASSWORD.first,
+            SWITCH_QWERTY_PASSWORD.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(SWITCH_QWERTY_PASSWORD.first, value ?: false)
         }
 
     var qwerty_show_popup_window: Boolean?

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -6,9 +6,9 @@
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="app_setting_language_preference"
-            android:title="@string/language_display_title"
             android:summaryOff="@string/app_language_summary_off"
-            android:summaryOn="@string/app_language_summary_on"/>
+            android:summaryOn="@string/app_language_summary_on"
+            android:title="@string/language_display_title" />
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/category_title_keyboard">
@@ -30,6 +30,14 @@
             android:summaryOff="@string/keyboard_height_fix_specific_device_summary_off"
             android:summaryOn="@string/keyboard_height_fix_specific_device_summary_on"
             android:title="@string/keyboard_height_fix_specific_device_title" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="switch_qwerty_keyboard_password_preference"
+            android:summaryOff="パスワード入力の場合、テンキーで固定"
+            android:summaryOn="パスワード入力の場合、QWERTY キーボードに切り替えます。"
+            android:title="キーボード切り替え"
+            app:defaultValue="false" />
 
         <PreferenceCategory android:title="@string/conversion_preference_title">
             <SeekBarPreference


### PR DESCRIPTION
## Issue
#321 

## 概要
Gboard ではパスワード入力の際にテンキーから QWERTY に切り替わる。
設定からパスワード入力の際に QWERTY に切り替える設定の追加