### PR TITLE
かな入力の英語モードをQWERTYにする設定の追加、英語キーボードで長押し時、記号と大文字を入力するように修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 536
-        versionName "1.4.415"
+        versionCode 537
+        versionName "1.4.416"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -3031,10 +3031,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     KeyboardType.ROMAJI -> {
                         mainView.keyboardView.setCurrentMode(InputMode.ModeJapanese)
+                        mainView.qwertyView.setSwitchNumberLayoutKeyVisibility(false)
                     }
 
                     KeyboardType.QWERTY -> {
                         mainView.keyboardView.setCurrentMode(InputMode.ModeEnglish)
+                        mainView.qwertyView.setSwitchNumberLayoutKeyVisibility(false)
                     }
 
                     KeyboardType.CUSTOM -> {}
@@ -7298,6 +7300,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 _inputString.update { "" }
                                 finishComposingText()
                                 setComposingText("", 0)
+                                mainView.qwertyView.setSwitchNumberLayoutKeyVisibility(false)
                             }
                         }
 
@@ -8010,6 +8013,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         if (tenkeyQWERTYSwitchNumber == true) {
                             _tenKeyQWERTYMode.update { TenKeyQWERTYMode.TenKeyQWERTY }
                             mainView.qwertyView.setSwitchNumberLayoutKeyVisibility(true)
+                            mainView.qwertyView.setRomajiMode(false)
                         } else {
                             setSideKeySpaceDrawable(
                                 cachedSpaceDrawable

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -239,6 +239,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var isClipboardHistoryFeatureEnabled: Boolean = false
     private val clipboardMutex = Mutex()
     private var isCustomKeyboardTwoWordsOutputEnable: Boolean? = false
+    private var tenkeyQWERTYSwitchNumber: Boolean? = false
 
     private var floatingCandidateWindow: PopupWindow? = null
     private lateinit var floatingCandidateView: View
@@ -665,6 +666,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             candidateViewHeight = candidate_view_height_preference
             symbolKeyboardFirstItem = symbol_mode_preference
             isCustomKeyboardTwoWordsOutputEnable = custom_keyboard_two_words_output ?: true
+            tenkeyQWERTYSwitchNumber = tenkey_qwerty_switch_number_layout ?: false
             isKeyboardFloatingMode = is_floating_mode ?: false
             _keyboardFloatingMode.update { is_floating_mode ?: false }
             switchQWERTYPassword = switch_qwerty_password ?: false
@@ -861,6 +863,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 qwertyView.updateSymbolKeymapState(qwertyShowKeymapSymbolsPreference ?: false)
                 qwertyView.updateNumberKeyState(qwertyShowNumberButtonsPreference ?: false)
                 qwertyView.setPopUpViewState(qwertyShowPopupWindowPreference ?: true)
+                qwertyView.setNumberSwitchKeyTextStyle()
+                qwertyView.setSwitchNumberLayoutKeyVisibility(false)
                 if (isKeyboardFloatingMode == true) {
                     suggestionRecyclerView.adapter = null
                     candidatesRowView.adapter = null
@@ -1016,6 +1020,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         symbolKeyboardFirstItem = null
         userDictionaryPrefixMatchNumber = null
         isCustomKeyboardTwoWordsOutputEnable = null
+        tenkeyQWERTYSwitchNumber = null
         isKeyboardFloatingMode = null
         inputManager.unregisterInputDeviceListener(this)
         actionInDestroy()
@@ -7381,6 +7386,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             }
                         }
 
+                        QWERTYKey.QWERTYKeySwitchNumberKey -> {
+                            _tenKeyQWERTYMode.update { TenKeyQWERTYMode.Default }
+                            mainView.keyboardView.setCurrentMode(InputMode.ModeNumber)
+                        }
+
                         else -> {
                             if (mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                                 if (insertString.isNotEmpty()) {
@@ -7997,26 +8007,31 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             mainView.keyboardView.apply {
                 when (currentInputMode.value) {
                     is InputMode.ModeJapanese -> {
-                        setSideKeySpaceDrawable(
-                            cachedSpaceDrawable
-                        )
-                        setSideKeyPreviousState(true)
-                        if (insertString.isNotEmpty()) {
-                            if (insertString.isNotEmpty() && insertString.last()
-                                    .isLatinAlphabet()
-                            ) {
-                                setBackgroundSmallLetterKey(
-                                    cachedEnglishDrawable
-                                )
+                        if (tenkeyQWERTYSwitchNumber == true) {
+                            _tenKeyQWERTYMode.update { TenKeyQWERTYMode.TenKeyQWERTY }
+                            mainView.qwertyView.setSwitchNumberLayoutKeyVisibility(true)
+                        } else {
+                            setSideKeySpaceDrawable(
+                                cachedSpaceDrawable
+                            )
+                            setSideKeyPreviousState(true)
+                            if (insertString.isNotEmpty()) {
+                                if (insertString.isNotEmpty() && insertString.last()
+                                        .isLatinAlphabet()
+                                ) {
+                                    setBackgroundSmallLetterKey(
+                                        cachedEnglishDrawable
+                                    )
+                                } else {
+                                    setBackgroundSmallLetterKey(
+                                        cachedLogoDrawable
+                                    )
+                                }
                             } else {
                                 setBackgroundSmallLetterKey(
                                     cachedLogoDrawable
                                 )
                             }
-                        } else {
-                            setBackgroundSmallLetterKey(
-                                cachedLogoDrawable
-                            )
                         }
                     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -32,6 +32,9 @@ object AppPreference {
 
     private val SWITCH_QWERTY_PASSWORD = Pair("switch_qwerty_keyboard_password_preference", false)
 
+    private val TENKEY_SWITCH_QWERTY_PREFERENCE =
+        Pair("tenkey_kana_english_qwerty_preference", false)
+
     private val CUSTOM_KEYBOARD_TWO_WORDS_OUTPUTS =
         Pair("custom_keyboard_two_words_preference", true)
 
@@ -128,6 +131,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(CUSTOM_KEYBOARD_TWO_WORDS_OUTPUTS.first, value ?: false)
+        }
+
+    var tenkey_qwerty_switch_number_layout: Boolean?
+        get() = preferences.getBoolean(
+            TENKEY_SWITCH_QWERTY_PREFERENCE.first,
+            TENKEY_SWITCH_QWERTY_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(TENKEY_SWITCH_QWERTY_PREFERENCE.first, value ?: false)
         }
 
     var qwerty_show_ime_button: Boolean?

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -188,5 +188,8 @@
     <string name="switch_qwerty_preference_title">パスワード入力時</string>
     <string name="switch_qwerty_password_summary_on">パスワード入力の場合、QWERTY キーボードに切り替えます。</string>
     <string name="switch_qwerty_password_summary_off">パスワード入力の場合、テンキーで固定</string>
+    <string name="kana_layout_category_preference_title">かな入力 レイアウトの設定</string>
+    <string name="kana_input_qwerty_preference_title">英字入力は QWERTY</string>
+    <string name="kana_input_qwerty_preference_summary">英字入力時は QWERTY レイアウトを使用する</string>
 
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -183,8 +183,8 @@
     <string name="qwerty_number_keys_summary_on">数字キーを表示します</string>
     <string name="qwerty_number_keys_summary_off">数字キーを表示しません</string>
     <string name="qwerty_keymap_symbol_preference">記号キーマップの表示</string>
-    <string name="qwerty_keymap_preference_summary_on">ローマ字キーボードで長押し時に記号のキーマップを表示します。</string>
-    <string name="qwerty_keymap_preference_summary_off">ローマ字キーボードで長押し時に記号のキーマップを表示しません。</string>
+    <string name="qwerty_keymap_preference_summary_on">QWERTYキーボードのキーマップを表示します。</string>
+    <string name="qwerty_keymap_preference_summary_off">QWERTYキーボードのキーマップを表示しません。</string>
     <string name="switch_qwerty_preference_title">パスワード入力時</string>
     <string name="switch_qwerty_password_summary_on">パスワード入力の場合、QWERTY キーボードに切り替えます。</string>
     <string name="switch_qwerty_password_summary_off">パスワード入力の場合、テンキーで固定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -187,4 +187,7 @@
     <string name="switch_qwerty_preference_title">Input Password</string>
     <string name="switch_qwerty_password_summary_on">Switch to QWERTY keyboard when entering a password.</string>
     <string name="switch_qwerty_password_summary_off">Keep using the ten key when entering a password.</string>
+    <string name="kana_layout_category_preference_title">Kana input layout setting</string>
+    <string name="kana_input_qwerty_preference_title">QWERTY for alphabet</string>
+    <string name="kana_input_qwerty_preference_summary">Use QWERTY layout for alphabet input mode</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -182,8 +182,8 @@
     <string name="qwerty_number_keys_summary_on">Display number keys</string>
     <string name="qwerty_number_keys_summary_off">Do not display number keys</string>
     <string name="qwerty_keymap_symbol_preference">Show Symbol Keymap</string>
-    <string name="qwerty_keymap_preference_summary_on">Show the symbol keymap on long press in the Romaji keyboard.</string>
-    <string name="qwerty_keymap_preference_summary_off">Do not show the symbol keymap on long press in the Romaji keyboard.</string>
+    <string name="qwerty_keymap_preference_summary_on">Show the symbol keymap on long press in the QWERTY keyboard.</string>
+    <string name="qwerty_keymap_preference_summary_off">Do not show the symbol keymap on long press in the QWERTY keyboard.</string>
     <string name="switch_qwerty_preference_title">Input Password</string>
     <string name="switch_qwerty_password_summary_on">Switch to QWERTY keyboard when entering a password.</string>
     <string name="switch_qwerty_password_summary_off">Keep using the ten key when entering a password.</string>

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -143,6 +143,14 @@
                 app:summary="@string/custom_romaji_summary" />
         </PreferenceCategory>
 
+        <PreferenceCategory android:title="@string/kana_layout_category_preference_title">
+            <SwitchPreferenceCompat
+                android:key="tenkey_kana_english_qwerty_preference"
+                android:title="@string/kana_input_qwerty_preference_title"
+                app:defaultValue="false"
+                app:summary="@string/kana_input_qwerty_preference_summary" />
+        </PreferenceCategory>
+
         <PreferenceCategory android:title="@string/category_qwerty_keyboard_title">
             <SwitchPreferenceCompat
                 android:defaultValue="true"

--- a/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKey.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKey.kt
@@ -46,6 +46,8 @@ sealed class QWERTYKey {
 
     data object QWERTYKeySwitchRomajiEnglish : QWERTYKey()
 
+    data object QWERTYKeySwitchNumberKey : QWERTYKey()
+
     data object QWERTYKey1 : QWERTYKey()
     data object QWERTYKey2 : QWERTYKey()
     data object QWERTYKey3 : QWERTYKey()

--- a/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKeyInfo.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKeyInfo.kt
@@ -13,32 +13,58 @@ sealed class QWERTYKeyInfo {
     object KeyA : QWERTYVariation() {
         override val tap: Char get() = 'a'
         override val capChar: Char get() = 'A'
-        override val variations: List<Char> get() = listOf('a', 'à', 'á', 'â', 'æ', 'ã', 'å', 'ā')
+        override val variations: List<Char>
+            get() = listOf(
+                '@',
+                'a',
+                'à',
+                'á',
+                'â',
+                'æ',
+                'ã',
+                'å',
+                'ā',
+                'A',
+            )
         override val capVariations: List<Char>
             get() = listOf(
-                'A', 'À', 'Á', 'Â', 'Æ', 'Ã', 'Å', 'Ā'
+                '@', 'A', 'À', 'Á', 'Â', 'Æ', 'Ã', 'Å', 'Ā'
             )
     }
 
     object KeyB : QWERTYVariation() {
         override val tap: Char get() = 'b'
         override val capChar: Char get() = 'B'
-        override val variations: List<Char> = listOf('b', 'ƀ', 'ɓ')
-        override val capVariations: List<Char> = listOf('B', 'Ɓ', 'Ƀ')
+        override val variations: List<Char> = listOf('¡', '!', 'b', 'ƀ', 'ɓ', 'B')
+        override val capVariations: List<Char> = listOf('¡', '!', 'B', 'Ɓ', 'Ƀ')
     }
 
     object KeyC : QWERTYVariation() {
         override val tap: Char get() = 'c'
         override val capChar: Char get() = 'C'
-        override val variations: List<Char> get() = listOf('c', 'ç', 'ć', 'č', 'ĉ', 'ċ')
-        override val capVariations: List<Char> get() = listOf('C', 'Ç', 'Ć', 'Č', 'Ĉ', 'Ċ')
+        override val variations: List<Char>
+            get() = listOf(
+                'ç',
+                '\"',
+                'c',
+                'ç',
+                'ć',
+                'č',
+                'ĉ',
+                'ċ',
+                'C'
+            )
+        override val capVariations: List<Char>
+            get() = listOf(
+                'ç', '\"', 'C', 'Ç', 'Ć', 'Č', 'Ĉ', 'Ċ'
+            )
     }
 
     object KeyD : QWERTYVariation() {
         override val tap: Char get() = 'd'
         override val capChar: Char get() = 'D'
-        override val variations: List<Char> get() = listOf('d', 'ď', 'đ')
-        override val capVariations: List<Char> get() = listOf('D', 'Ď', 'Đ')
+        override val variations: List<Char> get() = listOf('+', 'd', 'ď', 'đ', 'D')
+        override val capVariations: List<Char> get() = listOf('+', 'D', 'Ď', 'Đ')
     }
 
     object KeyE : QWERTYVariation() {
@@ -56,6 +82,7 @@ sealed class QWERTYKeyInfo {
                 'ę',
                 'ě',
                 '3',
+                'E'
             )
         override val capVariations: List<Char>
             get() = listOf(
@@ -75,22 +102,22 @@ sealed class QWERTYKeyInfo {
     object KeyF : QWERTYVariation() {
         override val tap: Char get() = 'f'
         override val capChar: Char get() = 'F'
-        override val variations: List<Char>? get() = null
-        override val capVariations: List<Char>? get() = null
+        override val variations: List<Char> get() = listOf('-', 'f', 'ｆ', 'F')
+        override val capVariations: List<Char> get() = listOf('-', 'F', 'Ｆ')
     }
 
     object KeyG : QWERTYVariation() {
         override val tap: Char get() = 'g'
         override val capChar: Char get() = 'G'
-        override val variations: List<Char> get() = listOf('g', 'ĝ', 'ğ', 'ġ', 'ģ')
-        override val capVariations: List<Char> get() = listOf('G', 'Ĝ', 'Ğ', 'Ġ', 'Ģ')
+        override val variations: List<Char> get() = listOf('=', 'g', 'ĝ', 'ğ', 'ġ', 'ģ', 'G')
+        override val capVariations: List<Char> get() = listOf('=', 'G', 'Ĝ', 'Ğ', 'Ġ', 'Ģ')
     }
 
     object KeyH : QWERTYVariation() {
         override val tap: Char get() = 'h'
         override val capChar: Char get() = 'H'
-        override val variations: List<Char> get() = listOf('h', 'ĥ', 'ħ')
-        override val capVariations: List<Char> get() = listOf('H', 'Ĥ', 'Ħ')
+        override val variations: List<Char> get() = listOf('/', 'h', 'ĥ', 'ħ', 'H')
+        override val capVariations: List<Char> get() = listOf('/', 'H', 'Ĥ', 'Ħ')
     }
 
     object KeyI : QWERTYVariation() {
@@ -98,7 +125,7 @@ sealed class QWERTYKeyInfo {
         override val capChar: Char get() = 'I'
         override val variations: List<Char>
             get() = listOf(
-                'i', 'ì', 'í', 'î', 'ï', 'ī', 'į', 'ǐ', 'ı', '8'
+                'i', 'ì', 'í', 'î', 'ï', 'ī', 'į', 'ǐ', 'ı', '8', 'I'
             )
         override val capVariations: List<Char>
             get() = listOf(
@@ -109,36 +136,36 @@ sealed class QWERTYKeyInfo {
     object KeyJ : QWERTYVariation() {
         override val tap: Char get() = 'j'
         override val capChar: Char get() = 'J'
-        override val variations: List<Char> get() = listOf('j', 'ĵ')
-        override val capVariations: List<Char> get() = listOf('J', 'Ĵ')
+        override val variations: List<Char> get() = listOf('#', 'j', 'ĵ', 'J')
+        override val capVariations: List<Char> get() = listOf('#', 'J', 'Ĵ')
     }
 
     object KeyK : QWERTYVariation() {
         override val tap: Char get() = 'k'
         override val capChar: Char get() = 'K'
-        override val variations: List<Char> get() = listOf('k', 'ķ')
-        override val capVariations: List<Char> get() = listOf('K', 'Ķ')
+        override val variations: List<Char> get() = listOf('(', 'k', 'ķ', 'K')
+        override val capVariations: List<Char> get() = listOf('(', 'K', 'Ķ')
     }
 
     object KeyL : QWERTYVariation() {
         override val tap: Char get() = 'l'
         override val capChar: Char get() = 'L'
-        override val variations: List<Char> get() = listOf('l', 'ĺ', 'ļ', 'ľ', 'ł')
-        override val capVariations: List<Char> get() = listOf('L', 'Ĺ', 'Ļ', 'Ľ', 'Ł')
+        override val variations: List<Char> get() = listOf(')', 'l', 'ĺ', 'ļ', 'ľ', 'ł', 'L')
+        override val capVariations: List<Char> get() = listOf(')', 'L', 'Ĺ', 'Ļ', 'Ľ', 'Ł')
     }
 
     object KeyM : QWERTYVariation() {
         override val tap: Char get() = 'm'
         override val capChar: Char get() = 'M'
-        override val variations: List<Char>? get() = null
-        override val capVariations: List<Char>? get() = null
+        override val variations: List<Char> get() = listOf('_', '…', 'm', 'ｍ', 'M')
+        override val capVariations: List<Char> get() = listOf('_', '…', 'M', 'Ｍ')
     }
 
     object KeyN : QWERTYVariation() {
         override val tap: Char get() = 'n'
         override val capChar: Char get() = 'N'
-        override val variations: List<Char> get() = listOf('n', 'ñ', 'ń', 'ņ', 'ň')
-        override val capVariations: List<Char> get() = listOf('N', 'Ñ', 'Ń', 'Ņ', 'Ň')
+        override val variations: List<Char> get() = listOf('~', 'n', 'ñ', 'ń', 'ņ', 'ň', 'N')
+        override val capVariations: List<Char> get() = listOf('~', 'N', 'Ñ', 'Ń', 'Ņ', 'Ň')
     }
 
     object KeyO : QWERTYVariation() {
@@ -146,7 +173,7 @@ sealed class QWERTYKeyInfo {
         override val capChar: Char get() = 'O'
         override val variations: List<Char>
             get() = listOf(
-                'o', 'ò', 'ó', 'ô', 'õ', 'ö', 'ø', 'ō', 'ő', '9'
+                'o', 'ò', 'ó', 'ô', 'õ', 'ö', 'ø', 'ō', 'ő', '9', 'O'
             )
         override val capVariations: List<Char>
             get() = listOf(
@@ -157,35 +184,35 @@ sealed class QWERTYKeyInfo {
     object KeyP : QWERTYVariation() {
         override val tap: Char get() = 'p'
         override val capChar: Char get() = 'P'
-        override val variations: List<Char> get() = listOf('p', '0')
+        override val variations: List<Char> get() = listOf('p', '0', 'P')
         override val capVariations: List<Char> get() = listOf('P', '0')
     }
 
     object KeyQ : QWERTYVariation() {
         override val tap: Char get() = 'q'
         override val capChar: Char get() = 'Q'
-        override val variations: List<Char> get() = listOf('q', '1')
+        override val variations: List<Char> get() = listOf('q', '1', 'Q')
         override val capVariations: List<Char> get() = listOf('Q', '1')
     }
 
     object KeyR : QWERTYVariation() {
         override val tap: Char get() = 'r'
         override val capChar: Char get() = 'R'
-        override val variations: List<Char> get() = listOf('r', 'ŕ', 'ř', '4')
+        override val variations: List<Char> get() = listOf('r', 'ŕ', 'ř', '4', 'R')
         override val capVariations: List<Char> get() = listOf('R', 'Ŕ', 'Ř', '4')
     }
 
     object KeyS : QWERTYVariation() {
         override val tap: Char get() = 's'
         override val capChar: Char get() = 'S'
-        override val variations: List<Char> get() = listOf('s', 'ś', 'š', 'ş', 'ș')
-        override val capVariations: List<Char> get() = listOf('S', 'Ś', 'Š', 'Ş', 'Ș')
+        override val variations: List<Char> get() = listOf('β', '*', 's', 'ś', 'š', 'ş', 'ș', 'S')
+        override val capVariations: List<Char> get() = listOf('β', '*', 'S', 'Ś', 'Š', 'Ş', 'Ș')
     }
 
     object KeyT : QWERTYVariation() {
         override val tap: Char get() = 't'
         override val capChar: Char get() = 'T'
-        override val variations: List<Char> get() = listOf('t', 'ţ', 'ť', 'ț', '5')
+        override val variations: List<Char> get() = listOf('t', 'ţ', 'ť', 'ț', '5', 'T')
         override val capVariations: List<Char> get() = listOf('T', 'Ţ', 'Ť', 'Ț', '5')
     }
 
@@ -194,7 +221,7 @@ sealed class QWERTYKeyInfo {
         override val capChar: Char get() = 'U'
         override val variations: List<Char>
             get() = listOf(
-                'u', 'ù', 'ú', 'û', 'ü', 'ũ', 'ū', 'ů', 'ű', '7'
+                'u', 'ù', 'ú', 'û', 'ü', 'ũ', 'ū', 'ů', 'ű', '7', 'U'
             )
         override val capVariations: List<Char>
             get() = listOf(
@@ -205,36 +232,36 @@ sealed class QWERTYKeyInfo {
     object KeyV : QWERTYVariation() {
         override val tap: Char get() = 'v'
         override val capChar: Char get() = 'V'
-        override val variations: List<Char>? get() = null
-        override val capVariations: List<Char>? get() = null
+        override val variations: List<Char> get() = listOf('¿', '?', 'v', 'ｖ', 'V')
+        override val capVariations: List<Char> get() = listOf('¿', '?', 'V', 'Ｖ')
     }
 
     object KeyW : QWERTYVariation() {
         override val tap: Char get() = 'w'
         override val capChar: Char get() = 'W'
-        override val variations: List<Char> get() = listOf('w', 'ŵ', '2')
+        override val variations: List<Char> get() = listOf('w', 'ŵ', '2', 'W')
         override val capVariations: List<Char> get() = listOf('W', 'Ŵ', '2')
     }
 
     object KeyX : QWERTYVariation() {
         override val tap: Char get() = 'x'
         override val capChar: Char get() = 'X'
-        override val variations: List<Char>? get() = null
-        override val capVariations: List<Char>? get() = null
+        override val variations: List<Char> get() = listOf(':', 'x', 'ｘ', 'X')
+        override val capVariations: List<Char> get() = listOf(':', 'X', 'Ｘ')
     }
 
     object KeyY : QWERTYVariation() {
         override val tap: Char get() = 'y'
         override val capChar: Char get() = 'Y'
-        override val variations: List<Char> get() = listOf('y', 'ý', 'ÿ', 'ŷ', '6')
+        override val variations: List<Char> get() = listOf('y', 'ý', 'ÿ', 'ŷ', '6', 'Y')
         override val capVariations: List<Char> get() = listOf('Y', 'Ý', 'Ÿ', 'Ŷ', '6')
     }
 
     object KeyZ : QWERTYVariation() {
         override val tap: Char get() = 'z'
         override val capChar: Char get() = 'Z'
-        override val variations: List<Char> get() = listOf('z', 'ź', 'ž', 'ż')
-        override val capVariations: List<Char> get() = listOf('Z', 'Ź', 'Ž', 'Ż')
+        override val variations: List<Char> get() = listOf(',', '\'', 'z', 'ź', 'ž', 'ż', 'Z')
+        override val capVariations: List<Char> get() = listOf(',', '\'', 'Z', 'Ź', 'Ž', 'Ż')
     }
 
     object Key1 : QWERTYVariation() {
@@ -854,7 +881,7 @@ sealed class QWERTYKeyInfo {
         override val tap: Char get() = 'x'
         override val capChar: Char get() = 'X'
         override val variations: List<Char> get() = listOf(':', 'x', 'ｘ', 'X')
-        override val capVariations: List<Char> get() = listOf('X', 'Ｘ')
+        override val capVariations: List<Char> get() = listOf(':', 'X', 'Ｘ')
     }
 
     object KeyYJP : QWERTYVariation() {
@@ -867,7 +894,7 @@ sealed class QWERTYKeyInfo {
     object KeyZJP : QWERTYVariation() {
         override val tap: Char get() = 'z'
         override val capChar: Char get() = 'Z'
-        override val variations: List<Char> get() = listOf(',', '\'', 'z', 'ｚ','Z')
+        override val variations: List<Char> get() = listOf(',', '\'', 'z', 'ｚ', 'Z')
         override val capVariations: List<Char> get() = listOf(',', '\'', 'Z', 'Ｚ')
     }
 

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -234,6 +234,115 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                                     defaultQWERTYButtonsRoman.forEach {
                                         it.topRightChar = null
                                     }
+                                    if (isSymbolKeymapShow) {
+                                        defaultQWERTYButtons.forEach {
+                                            when (it.id) {
+                                                R.id.key_a -> {
+                                                    it.topRightChar = '@'
+                                                }
+
+                                                R.id.key_b -> {
+                                                    it.topRightChar = '!'
+                                                }
+
+                                                R.id.key_c -> {
+                                                    it.topRightChar = '\"'
+                                                }
+
+                                                R.id.key_d -> {
+                                                    it.topRightChar = '+'
+                                                }
+
+                                                R.id.key_e -> {
+                                                    it.topRightChar = '3'
+                                                }
+
+                                                R.id.key_f -> {
+                                                    it.topRightChar = '-'
+                                                }
+
+                                                R.id.key_g -> {
+                                                    it.topRightChar = '='
+                                                }
+
+                                                R.id.key_h -> {
+                                                    it.topRightChar = '/'
+                                                }
+
+                                                R.id.key_i -> {
+                                                    it.topRightChar = '8'
+                                                }
+
+                                                R.id.key_j -> {
+                                                    it.topRightChar = '#'
+                                                }
+
+                                                R.id.key_k -> {
+                                                    it.topRightChar = '('
+                                                }
+
+                                                R.id.key_l -> {
+                                                    it.topRightChar = ')'
+                                                }
+
+                                                R.id.key_m -> {
+                                                    it.topRightChar = '…'
+                                                }
+
+                                                R.id.key_n -> {
+                                                    it.topRightChar = '~'
+                                                }
+
+                                                R.id.key_o -> {
+                                                    it.topRightChar = '9'
+                                                }
+
+                                                R.id.key_p -> {
+                                                    it.topRightChar = '1'
+                                                }
+
+                                                R.id.key_q -> {
+                                                    it.topRightChar = '1'
+                                                }
+
+                                                R.id.key_r -> {
+                                                    it.topRightChar = '4'
+                                                }
+
+                                                R.id.key_s -> {
+                                                    it.topRightChar = '*'
+                                                }
+
+                                                R.id.key_t -> {
+                                                    it.topRightChar = '5'
+                                                }
+
+                                                R.id.key_u -> {
+                                                    it.topRightChar = '7'
+                                                }
+
+                                                R.id.key_v -> {
+                                                    it.topRightChar = '?'
+                                                }
+
+                                                R.id.key_w -> {
+                                                    it.topRightChar = '2'
+                                                }
+
+                                                R.id.key_x -> {
+                                                    it.topRightChar = ':'
+                                                }
+
+                                                R.id.key_y -> {
+                                                    it.topRightChar = '6'
+                                                }
+
+                                                R.id.key_z -> {
+                                                    it.topRightChar = '\''
+                                                }
+                                            }
+                                        }
+                                    }
                                 } else {
                                     if (isSymbolKeymapShow) {
                                         defaultQWERTYButtonsRoman.forEach {
@@ -284,6 +393,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
 
                                                 R.id.key_at_mark -> {
                                                     it.topRightChar = ')'
+                                                }
+
+                                                R.id.key_l -> {
+                                                    it.topRightChar = null
                                                 }
 
                                                 R.id.key_m -> {
@@ -512,6 +625,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                                         it.topRightChar = '('
                                     }
 
+                                    R.id.key_l -> {
+                                        it.topRightChar = null
+                                    }
+
                                     R.id.key_at_mark -> {
                                         it.topRightChar = ')'
                                     }
@@ -596,6 +713,115 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                         }
                         defaultQWERTYButtonsRoman.forEach {
                             it.topRightChar = null
+                        }
+                        if (isSymbolKeymapShow) {
+                            defaultQWERTYButtons.forEach {
+                                when (it.id) {
+                                    R.id.key_a -> {
+                                        it.topRightChar = '@'
+                                    }
+
+                                    R.id.key_b -> {
+                                        it.topRightChar = '!'
+                                    }
+
+                                    R.id.key_c -> {
+                                        it.topRightChar = '\"'
+                                    }
+
+                                    R.id.key_d -> {
+                                        it.topRightChar = '+'
+                                    }
+
+                                    R.id.key_e -> {
+                                        it.topRightChar = '3'
+                                    }
+
+                                    R.id.key_f -> {
+                                        it.topRightChar = '-'
+                                    }
+
+                                    R.id.key_g -> {
+                                        it.topRightChar = '='
+                                    }
+
+                                    R.id.key_h -> {
+                                        it.topRightChar = '/'
+                                    }
+
+                                    R.id.key_i -> {
+                                        it.topRightChar = '8'
+                                    }
+
+                                    R.id.key_j -> {
+                                        it.topRightChar = '#'
+                                    }
+
+                                    R.id.key_k -> {
+                                        it.topRightChar = '('
+                                    }
+
+                                    R.id.key_l -> {
+                                        it.topRightChar = ')'
+                                    }
+
+                                    R.id.key_m -> {
+                                        it.topRightChar = '…'
+                                    }
+
+                                    R.id.key_n -> {
+                                        it.topRightChar = '~'
+                                    }
+
+                                    R.id.key_o -> {
+                                        it.topRightChar = '9'
+                                    }
+
+                                    R.id.key_p -> {
+                                        it.topRightChar = '0'
+                                    }
+
+                                    R.id.key_q -> {
+                                        it.topRightChar = '1'
+                                    }
+
+                                    R.id.key_r -> {
+                                        it.topRightChar = '4'
+                                    }
+
+                                    R.id.key_s -> {
+                                        it.topRightChar = '*'
+                                    }
+
+                                    R.id.key_t -> {
+                                        it.topRightChar = '5'
+                                    }
+
+                                    R.id.key_u -> {
+                                        it.topRightChar = '7'
+                                    }
+
+                                    R.id.key_v -> {
+                                        it.topRightChar = '?'
+                                    }
+
+                                    R.id.key_w -> {
+                                        it.topRightChar = '2'
+                                    }
+
+                                    R.id.key_x -> {
+                                        it.topRightChar = ':'
+                                    }
+
+                                    R.id.key_y -> {
+                                        it.topRightChar = '6'
+                                    }
+
+                                    R.id.key_z -> {
+                                        it.topRightChar = '\''
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -655,6 +655,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             keySwitchDefault.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
             keyReturn.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
             key123.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
+            switchNumberLayout.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
 
             cursorLeft.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
             cursorRight.setBackgroundDrawable(ContextCompat.getDrawable(context, bgSideRes))
@@ -712,6 +713,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             binding.keyTouten to QWERTYKey.QWERTYKeyTouten,
             binding.keyKuten to QWERTYKey.QWERTYKeyKuten,
             binding.switchRomajiEnglish to QWERTYKey.QWERTYKeySwitchRomajiEnglish,
+            binding.switchNumberLayout to QWERTYKey.QWERTYKeySwitchNumberKey,
 
             binding.key1 to QWERTYKey.QWERTYKey1,
             binding.key2 to QWERTYKey.QWERTYKey2,
@@ -1031,7 +1033,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                     } else {
                         val qwertyKey = qwertyButtonMap[it] ?: QWERTYKey.QWERTYKeyNotSelect
                         when (qwertyKey) {
-                            QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight, QWERTYKey.QWERTYKeySwitchRomajiEnglish -> {
+                            QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight, QWERTYKey.QWERTYKeySwitchRomajiEnglish, QWERTYKey.QWERTYKeySwitchNumberKey -> {
                                 qwertyKeyListener?.onReleasedQWERTYKey(qwertyKey, null, null)
                             }
 
@@ -1091,7 +1093,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                                     val qwertyKey =
                                         qwertyButtonMap[it] ?: QWERTYKey.QWERTYKeyNotSelect
                                     when (qwertyKey) {
-                                        QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight, QWERTYKey.QWERTYKeySwitchRomajiEnglish -> {
+                                        QWERTYKey.QWERTYKeyCursorLeft, QWERTYKey.QWERTYKeyCursorRight, QWERTYKey.QWERTYKeySwitchRomajiEnglish, QWERTYKey.QWERTYKeySwitchNumberKey -> {
                                             qwertyKeyListener?.onReleasedQWERTYKey(
                                                 qwertyKey,
                                                 null,
@@ -1221,7 +1223,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                 it.id != binding.keySwitchDefault.id &&
                 it.id != binding.cursorLeft.id &&
                 it.id != binding.cursorRight.id &&
-                it.id != binding.switchRomajiEnglish.id
+                it.id != binding.switchRomajiEnglish.id &&
+                it.id != binding.switchNumberLayout.id
             ) {
                 showKeyPreview(it)
             }
@@ -1734,6 +1737,51 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         binding.switchRomajiEnglish.text = spannableString
     }
 
+    /**
+     * Sets the style for the text in the number switch key ("あa1").
+     *
+     * This function makes the 'a' character bold and slightly larger,
+     * while keeping the other characters in a normal style.
+     */
+    fun setNumberSwitchKeyTextStyle() {
+        // The text to be displayed on the button.
+        val text = "あa1"
+        val spannableString = SpannableString(text)
+
+        // Apply NORMAL style to the first character "あ" (index 0).
+        spannableString.setSpan(
+            StyleSpan(Typeface.NORMAL),
+            0, // Start index (inclusive)
+            1, // End index (exclusive)
+            Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+        )
+
+        // Apply BOLD style to the second character "a" (index 1).
+        spannableString.setSpan(
+            StyleSpan(Typeface.BOLD),
+            1, // Start index (inclusive)
+            2, // End index (exclusive)
+            Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+        )
+
+        // You could also increase the size of 'a' like in your other function.
+        spannableString.setSpan(
+            RelativeSizeSpan(1.5f), // Makes 'a' 20% larger
+            1, // Start index
+            2, // End index
+            Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+        )
+
+        // Apply NORMAL style to the third character "1" (index 2).
+        spannableString.setSpan(
+            StyleSpan(Typeface.NORMAL),
+            2, // Start index (inclusive)
+            3, // End index (exclusive)
+            Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+        )
+        binding.switchNumberLayout.text = spannableString
+    }
+
     fun updateNumberKeyState(state: Boolean) {
         this.isNumberKeysShow = state
         displayOrHideNumberKeys(state)
@@ -1887,7 +1935,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             qRowKeys.forEach { key ->
                 constraintSet.connect(
                     key.id,
-                    ConstraintLayout.LayoutParams.TOP,
+                    LayoutParams.TOP,
                     R.id.guideline_number_row,
                     ConstraintLayout.LayoutParams.BOTTOM
                 )
@@ -1918,15 +1966,19 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             qRowKeys.forEach { key ->
                 constraintSet.connect(
                     key.id,
-                    ConstraintLayout.LayoutParams.TOP,
-                    ConstraintLayout.LayoutParams.PARENT_ID,
-                    ConstraintLayout.LayoutParams.TOP
+                    LayoutParams.TOP,
+                    LayoutParams.PARENT_ID,
+                    LayoutParams.TOP
                 )
             }
         }
 
         // Apply the new constraints to the layout
         constraintSet.applyTo(this)
+    }
+
+    fun setSwitchNumberLayoutKeyVisibility(state: Boolean) {
+        binding.switchNumberLayout.isVisible = state
     }
 
 }

--- a/qwerty_keyboard/src/main/res/layout-land/qwerty_layout.xml
+++ b/qwerty_keyboard/src/main/res/layout-land/qwerty_layout.xml
@@ -785,6 +785,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:layout_marginStart="2dp"
         android:layout_marginEnd="4dp"
         android:background="@drawable/qwerty_key_side_bg"
         android:elevation="@dimen/qwerty_side_key_elevation_size"
@@ -794,9 +795,30 @@
         android:textColor="@color/keyboard_icon_color"
         android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/key_123"
+        app:layout_constraintEnd_toStartOf="@+id/switch_number_layout"
         app:layout_constraintHorizontal_weight="0.75"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/guideline_z_row" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/switch_number_layout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:gravity="center"
+        android:text="あa1"
+        android:textAllCaps="false"
+        android:textColor="@color/keyboard_icon_color"
+        android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key_123"
+        app:layout_constraintHorizontal_weight="0.75"
+        app:layout_constraintStart_toEndOf="@id/switch_romaji_english"
         app:layout_constraintTop_toBottomOf="@id/guideline_z_row" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -814,7 +836,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/key_switch_default"
         app:layout_constraintHorizontal_weight="0.75"
-        app:layout_constraintStart_toEndOf="@id/switch_romaji_english"
+        app:layout_constraintStart_toEndOf="@id/switch_number_layout"
         app:layout_constraintTop_toBottomOf="@id/guideline_z_row" />
 
     <androidx.appcompat.widget.AppCompatImageButton

--- a/qwerty_keyboard/src/main/res/layout/qwerty_layout.xml
+++ b/qwerty_keyboard/src/main/res/layout/qwerty_layout.xml
@@ -797,9 +797,30 @@
         android:textColor="@color/keyboard_icon_color"
         android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
         app:layout_constraintBottom_toBottomOf="parent"
-        app:layout_constraintEnd_toStartOf="@+id/key_123"
+        app:layout_constraintEnd_toStartOf="@+id/switch_number_layout"
         app:layout_constraintHorizontal_weight="0.75"
         app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/guideline_z_row" />
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/switch_number_layout"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginVertical="@dimen/qwerty_key_vertical_margin"
+        android:layout_marginStart="4dp"
+        android:layout_marginEnd="4dp"
+        android:background="@drawable/qwerty_key_side_bg"
+        android:elevation="@dimen/qwerty_side_key_elevation_size"
+        android:gravity="center"
+        android:text="あa1"
+        android:textAllCaps="false"
+        android:textColor="@color/keyboard_icon_color"
+        android:textSize="@dimen/qwerty_side_key_switch_mode_text_size"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@+id/key_123"
+        app:layout_constraintHorizontal_weight="0.75"
+        app:layout_constraintStart_toEndOf="@id/switch_romaji_english"
         app:layout_constraintTop_toBottomOf="@id/guideline_z_row" />
 
     <androidx.appcompat.widget.AppCompatButton
@@ -817,7 +838,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/key_switch_default"
         app:layout_constraintHorizontal_weight="0.75"
-        app:layout_constraintStart_toEndOf="@id/switch_romaji_english"
+        app:layout_constraintStart_toEndOf="@id/switch_number_layout"
         app:layout_constraintTop_toBottomOf="@id/guideline_z_row" />
 
     <androidx.appcompat.widget.AppCompatImageButton

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/extensions/MaterialTextExtension.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/extensions/MaterialTextExtension.kt
@@ -420,7 +420,7 @@ fun MaterialTextView.setTextFlickTopEnglish(
             text = ENGLISH_SMALL_CHAR[11].toString()
         }
         R.id.key_6 -> {
-            text = ENGLISH_SMALL_CHAR[15].toString()
+            text = ENGLISH_SMALL_CHAR[14].toString()
         }
         R.id.key_7 -> {
             text = ENGLISH_SMALL_CHAR[17].toString()


### PR DESCRIPTION
## Issue
#326 #327 

## 概要
- かな入力キーボードにて英語モードの場合、QWERTY に切り替えるキーと設定の追加
- QWERTY キーボードの英語の場合にもキーマップの表示と記号、大文字を長押しで出力できるように修正