### PR TITLE
create new reset flags without reset layout in onFinish

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 542
-        versionName "1.4.421"
+        versionCode 543
+        versionName "1.4.422"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -940,10 +940,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
     }
 
+    override fun onFinishInput() {
+        super.onFinishInput()
+        Timber.d("onUpdate onFinishInput")
+        resetAllFlagsWithoutResetLayout()
+    }
 
     override fun onFinishInputView(finishingInput: Boolean) {
         super.onFinishInputView(finishingInput)
-        resetAllFlags()
         Timber.d("onUpdate onFinishInputView")
         if (isTablet == true) {
             mainLayoutBinding?.tabletView?.isVisible = true
@@ -8129,6 +8133,46 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         Timber.d("onUpdate resetAllFlags called")
         _inputString.update { "" }
         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.Default }
+        suggestionAdapter?.suggestions = emptyList()
+        stringInTail.set("")
+        suggestionClickNum = 0
+        currentCustomKeyboardPosition = 0
+        isHenkan.set(false)
+        isContinuousTapInputEnabled.set(false)
+        leftCursorKeyLongKeyPressed.set(false)
+        rightCursorKeyLongKeyPressed.set(false)
+        _dakutenPressed.value = false
+        englishSpaceKeyPressed.set(false)
+        lastFlickConvertedNextHiragana.set(false)
+        onDeleteLongPressUp.set(false)
+        isSpaceKeyLongPressed = false
+        onKeyboardSwitchLongPressUp = false
+        suggestionAdapter?.updateHighlightPosition(RecyclerView.NO_POSITION)
+        isFirstClickHasStringTail = false
+        resetKeyboard()
+        _keyboardSymbolViewState.update { false }
+        learnMultiple.stop()
+        stopDeleteLongPress()
+        clearDeletedBuffer()
+        suggestionAdapter?.setUndoEnabled(false)
+        updateClipboardPreview()
+        _selectMode.update { false }
+        hasConvertedKatakana = false
+        romajiConverter?.clear()
+        hardKeyboardShiftPressd = false
+        resetSumireKeyboardDakutenMode()
+        initialCursorDetectInFloatingCandidateView = false
+        initialCursorXPosition = 0
+        countToggleKatakana = 0
+        currentEnterKeyIndex = 0
+        currentSpaceKeyIndex = 0
+        currentKatakanaKeyIndex = 0
+        currentDakutenKeyIndex = 0
+    }
+
+    private fun resetAllFlagsWithoutResetLayout() {
+        Timber.d("onUpdate resetAllFlags called")
+        _inputString.update { "" }
         suggestionAdapter?.suggestions = emptyList()
         stringInTail.set("")
         suggestionClickNum = 0


### PR DESCRIPTION
## Issue
#342 

## Issue
Sony 系のスマホで onFinish 時にレイアウトをリセットするとチラつきが出るようなので修正を試みた。