### PR TITLE
Aquos のデバイスで onFinish が呼ばれた際のチラつきを無くす試み

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 543
-        versionName "1.4.422"
+        versionCode 544
+        versionName "1.4.423"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -869,6 +869,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         keyboardSelectionPopupWindow?.dismiss()
         mainLayoutBinding?.let { mainView ->
             mainView.apply {
+                suggestionRecyclerView.isVisible = true
                 keyboardView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 tabletView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 customLayoutDefault.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
@@ -943,35 +944,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     override fun onFinishInput() {
         super.onFinishInput()
         Timber.d("onUpdate onFinishInput")
-        resetAllFlagsWithoutResetLayout()
+        resetAllFlags()
     }
 
     override fun onFinishInputView(finishingInput: Boolean) {
         super.onFinishInputView(finishingInput)
         Timber.d("onUpdate onFinishInputView")
-        if (isTablet == true) {
-            mainLayoutBinding?.tabletView?.isVisible = true
-            mainLayoutBinding?.keyboardView?.isVisible = false
-        } else {
-            if (qwertyMode.value == TenKeyQWERTYMode.Default) {
-                mainLayoutBinding?.apply {
-                    qwertyView.isVisible = false
-                    keyboardView.isVisible = true
-                    tabletView.isVisible = false
-                }
-            } else {
-                mainLayoutBinding?.apply {
-                    qwertyView.isVisible = true
-                    keyboardView.isVisible = false
-                    tabletView.isVisible = false
-                }
-            }
-        }
         floatingCandidateWindow?.dismiss()
         floatingDockWindow?.dismiss()
         floatingModeSwitchWindow?.dismiss()
         floatingKeyboardView?.dismiss()
-        mainLayoutBinding?.suggestionRecyclerView?.isVisible = true
     }
 
     override fun onDestroy() {
@@ -8133,46 +8115,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         Timber.d("onUpdate resetAllFlags called")
         _inputString.update { "" }
         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.Default }
-        suggestionAdapter?.suggestions = emptyList()
-        stringInTail.set("")
-        suggestionClickNum = 0
-        currentCustomKeyboardPosition = 0
-        isHenkan.set(false)
-        isContinuousTapInputEnabled.set(false)
-        leftCursorKeyLongKeyPressed.set(false)
-        rightCursorKeyLongKeyPressed.set(false)
-        _dakutenPressed.value = false
-        englishSpaceKeyPressed.set(false)
-        lastFlickConvertedNextHiragana.set(false)
-        onDeleteLongPressUp.set(false)
-        isSpaceKeyLongPressed = false
-        onKeyboardSwitchLongPressUp = false
-        suggestionAdapter?.updateHighlightPosition(RecyclerView.NO_POSITION)
-        isFirstClickHasStringTail = false
-        resetKeyboard()
-        _keyboardSymbolViewState.update { false }
-        learnMultiple.stop()
-        stopDeleteLongPress()
-        clearDeletedBuffer()
-        suggestionAdapter?.setUndoEnabled(false)
-        updateClipboardPreview()
-        _selectMode.update { false }
-        hasConvertedKatakana = false
-        romajiConverter?.clear()
-        hardKeyboardShiftPressd = false
-        resetSumireKeyboardDakutenMode()
-        initialCursorDetectInFloatingCandidateView = false
-        initialCursorXPosition = 0
-        countToggleKatakana = 0
-        currentEnterKeyIndex = 0
-        currentSpaceKeyIndex = 0
-        currentKatakanaKeyIndex = 0
-        currentDakutenKeyIndex = 0
-    }
-
-    private fun resetAllFlagsWithoutResetLayout() {
-        Timber.d("onUpdate resetAllFlags called")
-        _inputString.update { "" }
         suggestionAdapter?.suggestions = emptyList()
         stringInTail.set("")
         suggestionClickNum = 0


### PR DESCRIPTION
## Issue
#342 

## 概要
`onFinishInputView` で該当しそうな箇所を修正した。
実機がないため、わからないがこの問題が修正されることを願う🤞