### PR TITLE
変換欄の高さをユーザーが変更できるようにする設定の追加、変換候補とかなキーボードの文字の大きさを変更できる設定の追加

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,9 +1,10 @@
 name: Android Release CI
 
+# Run this workflow when a new tag like 'v1.0.0' is pushed
 on:
   push:
     tags:
-      - 'v*'  # v1.0.0 のようにタグをプッシュしたときに実行
+      - 'v*'
 
 jobs:
   build:
@@ -11,25 +12,28 @@ jobs:
 
     strategy:
       matrix:
-        # 必要に応じて matrix を使って複数 API Level / ビルドツールを並列に回せますが、
-        # 今回は単一のセットで大丈夫なら省略しても OK です。
+        # Although we only have one configuration, the matrix is kept for future flexibility
         api-level: [ 35 ]
         build-tools: [ '35.0.0' ]
         target: [ 'android-35' ]
 
     steps:
-      # 1. コードチェックアウト
+      # 1. Checkout code with full history
+      # fetch-depth: 0 is required to get all tags and commit history
+      # for the automatic release note generation.
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      # 2. JDK 17 セットアップ
+      # 2. Set up JDK 17
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
           java-version: '17'
           distribution: 'temurin'
 
-      # 3. Android SDK セットアップ
+      # 3. Set up Android SDK
       - name: Set up Android SDK
         uses: android-actions/setup-android@v2
         with:
@@ -37,7 +41,7 @@ jobs:
           build-tools: ${{ matrix.build-tools }}
           target: ${{ matrix.target }}
 
-      # 4. Gradle キャッシュ
+      # 4. Cache Gradle dependencies
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -48,15 +52,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
 
-      # 5. JKS を Secrets から復号して my-release-key.jks に出力
+      # 5. Decode JKS keystore from GitHub Secrets
       - name: Decode JKS from Base64
         run: |
           echo "${{ secrets.KEYSTORE_BASE64 }}" | base64 -d > my-release-key.jks
 
-      # 6. local.properties に署名情報を追記
+      # 6. Create local.properties with signing information
       - name: Add signing info to local.properties
         run: |
-          # local.properties が存在しなければ新規作成
+          # Create the file if it doesn't exist
           if [ ! -f local.properties ]; then
             touch local.properties
           fi
@@ -66,37 +70,21 @@ jobs:
           echo "KEY_ALIAS=${{ secrets.KEY_ALIAS }}"   >> local.properties
           echo "KEY_PASSWORD=${{ secrets.KEY_PASSWORD }}" >> local.properties
 
-      # 7. リリース APK をビルド
+      # 7. Build the signed release APK
       - name: Build Signed Release APK
         run: ./gradlew clean assembleRelease
 
-      # ↓（あらためて）どのファイルがあるか確認しておく
-      - name: List APK directory
-        run: ls -R app/build/outputs/apk
-
-      # 8. リリース作成
-      - name: Create GitHub Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # 8. Create GitHub Release and upload APK
+      # This single step replaces the previous 'Create Release' and 'Upload Asset' steps.
+      # It automatically generates release notes from merged Pull Requests.
+      - name: Create Release and Upload APK
+        uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref_name }}
-          draft: false
-          prerelease: false
-          body: |
-            # ${{ github.ref_name }} リリースノート
-            • このリリースには署名済みのAPKが含まれます。
-            ## 変更・追加された機能
-
-      # 9. リネーム後のファイルをアップロード
-      - name: Upload APK to Release
-        uses: actions/upload-release-asset@v1
+          # This option tells the action to automatically create release notes
+          # based on the Pull Requests merged since the last tag.
+          generate_release_notes: true
+          # Specifies the file(s) to upload as release assets.
+          files: app/build/outputs/apk/release/app-release.apk
         env:
+          # The GITHUB_TOKEN is required to authorize the action to create a release.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: app/build/outputs/apk/release/app-release.apk
-          asset_name: app-release.apk
-          asset_content_type: application/vnd.android.package-archive

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -6135,6 +6135,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
         }
 
+        Timber.d("setKeyboardSizeForHeightForFloatingMode: $widthPref $qwertyWidthPref")
+
         val additionalHeightInDp = when {
             isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
                 when (candidateViewHeight) {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -682,8 +682,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             isNgWordEnable = ng_word_preference ?: true
             deleteKeyHighLight = delete_key_high_light_preference ?: true
             customKeyboardSuggestionPreference = custom_keyboard_suggestion_preference ?: true
-            keyboardHeightFixForSpecificDevicePreference =
-                keyboard_height_fix_for_specific_device_preference ?: false
             userDictionaryPrefixMatchNumber = user_dictionary_prefix_match_number_preference ?: 2
             isVibration = vibration_preference ?: true
             vibrationTimingStr = vibration_timing_preference ?: "both"
@@ -691,7 +689,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             sumireInputKeyLayoutType = sumire_input_method
             sumireInputStyle = sumire_keyboard_style
             candidateColumns = candidate_column_preference
-            candidateViewHeight = candidate_view_height_preference
             candidateTabVisibility = candidate_tab_preference
             symbolKeyboardFirstItem = symbol_mode_preference
             isCustomKeyboardTwoWordsOutputEnable = custom_keyboard_two_words_output ?: true

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -75,7 +75,6 @@ import com.kazumaproject.core.data.clipboard.ClipboardItem
 import com.kazumaproject.core.data.floating_candidate.CandidateItem
 import com.kazumaproject.core.domain.extensions.dpToPx
 import com.kazumaproject.core.domain.extensions.hiraganaToKatakana
-import com.kazumaproject.core.domain.extensions.isGalaxyDevice
 import com.kazumaproject.core.domain.extensions.toHankakuAlphabet
 import com.kazumaproject.core.domain.extensions.toHankakuKatakana
 import com.kazumaproject.core.domain.extensions.toHiragana
@@ -380,6 +379,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var tenkeyWidthPreferenceValue: Int? = 100
     private var qwertyHeightPreferenceValue: Int? = 280
     private var qwertyWidthPreferenceValue: Int? = 100
+    private var candidateViewHeightPreferenceValue: Int? = 110
+    private var candidateViewHeightEmptyPreferenceValue: Int? = 110
     private var tenkeyPositionPreferenceValue: Boolean? = true
     private var tenkeyBottomMarginPreferenceValue: Int? = 0
     private var qwertyPositionPreferenceValue: Boolean? = true
@@ -705,6 +706,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             tenkeyWidthPreferenceValue = keyboard_width ?: 100
             qwertyHeightPreferenceValue = qwerty_keyboard_height ?: 280
             qwertyWidthPreferenceValue = qwerty_keyboard_width ?: 100
+
+            candidateViewHeightPreferenceValue = candidate_view_height_dp ?: 110
+            candidateViewHeightEmptyPreferenceValue = candidate_view_empty_height_dp ?: 110
 
             tenkeyPositionPreferenceValue = keyboard_position ?: true
             tenkeyBottomMarginPreferenceValue = keyboard_vertical_margin_bottom ?: 0
@@ -1039,6 +1043,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         tenkeyHeightPreferenceValue = null
         tenkeyWidthPreferenceValue = null
         qwertyHeightPreferenceValue = null
+        candidateViewHeightPreferenceValue = null
+        candidateViewHeightEmptyPreferenceValue = null
         qwertyWidthPreferenceValue = null
         tenkeyPositionPreferenceValue = null
         tenkeyBottomMarginPreferenceValue = null
@@ -5851,59 +5857,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
         }
 
-        val defaultHeightSizeByDevice = when {
-            isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isTablet == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-
-            !isPortrait && isTablet == false -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
         val keyboardHeight = if (isPortrait) {
             if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
-                defaultHeightSizeByDevice
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         } else {
             if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                defaultHeightSizeByDevice
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         }
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true) {
@@ -6016,59 +5976,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
         }
 
-        val defaultHeightSizeByDevice = when {
-            isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isTablet == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-
-            !isPortrait && isTablet == false -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
         val keyboardHeight = if (isPortrait) {
             if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
-                defaultHeightSizeByDevice
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         } else {
             if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                defaultHeightSizeByDevice
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         }
 
@@ -6180,59 +6094,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
         Timber.d("setKeyboardSizeForHeightForFloatingMode: $widthPref $qwertyWidthPref")
 
-        val additionalHeightInDp = when {
-            isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isTablet == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-
-            !isPortrait && isTablet == false -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
         val keyboardHeight = if (isPortrait) {
             if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
-                additionalHeightInDp
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         } else {
             if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                additionalHeightInDp
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         }
 
@@ -6290,7 +6158,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun setKeyboardHeightWithAdditional(mainView: MainLayoutBinding) {
         Timber.d("Keyboard Height: setKeyboardHeightWithAdditional called")
         if (currentInputType.isPassword()) return
-        val columnNum = candidateColumns ?: "1"
 
         val heightPref = tenkeyHeightPreferenceValue ?: 280
         val widthPref = tenkeyWidthPreferenceValue ?: 100
@@ -6344,52 +6211,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
 
         // Determine additional height for suggestion bar in dp
-        val suggestionHeightInDp = when {
-            isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isTablet == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-
-            !isPortrait && isTablet == false -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
+        val suggestionHeightInDp = candidateViewHeightPreferenceValue ?: 110
 
         // Calculate the main keyboard height including suggestions, all in pixels
         val keyboardHeight = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
@@ -6408,50 +6230,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
         }
 
-        val additionalHeightForColumnsInDp =
-            when (candidateViewHeight) {
-                "1" -> {
-                    when (columnNum) {
-                        "2" -> 37
-                        "3" -> 75
-                        else -> 0
-                    }
-                }
-
-                "2" -> {
-                    when (columnNum) {
-                        "2" -> 50
-                        "3" -> 100
-                        else -> 0
-                    }
-                }
-
-                "3" -> {
-                    when (columnNum) {
-                        "2" -> 70
-                        "3" -> 140
-                        else -> 0
-                    }
-                }
-
-                else -> {
-                    when (columnNum) {
-                        "2" -> 70
-                        "3" -> 140
-                        else -> 0
-                    }
-                }
-            }
-        // 2. Convert the DP value to pixels.
-        val additionalKeyboardHeight = applicationContext.dpToPx(additionalHeightForColumnsInDp)
-
-        // Calculate the total height by adding the pixel values
-        val totalHeight = keyboardHeight + additionalKeyboardHeight
-
         val finalKeyboardHeight = if (candidateTabVisibility == true) {
-            totalHeight + mainView.candidateTabLayout.height
+            keyboardHeight + mainView.candidateTabLayout.height
         } else {
-            totalHeight
+            keyboardHeight
         }
 
         val finalKeyboardWidth =
@@ -6562,66 +6344,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
         }
 
-        val additionalHeightInDp = when {
-            isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            isTablet == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isTablet == false && !isPortrait -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
-        val keyboardHeight = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                additionalHeightInDp
+        val keyboardHeight = if (isPortrait) {
+            if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         } else {
-            if (isPortrait) {
-                if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
-                    additionalHeightInDp
-                )
-            } else {
-                if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                    additionalHeightInDp
-                )
-            }
+            if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
+                candidateViewHeightEmptyPreferenceValue ?: 110
+            )
         }
 
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true) {
@@ -6733,66 +6463,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
         }
 
-        val additionalHeightInDp = when {
-            isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            isTablet == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isTablet == false && !isPortrait -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
-        val keyboardHeight = if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                additionalHeightInDp
+        val keyboardHeight = if (isPortrait) {
+            if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
+                candidateViewHeightEmptyPreferenceValue ?: 110
             )
         } else {
-            if (isPortrait) {
-                if (keyboardSymbolViewState.value) heightPx + applicationContext.dpToPx(50) else heightPx + applicationContext.dpToPx(
-                    additionalHeightInDp
-                )
-            } else {
-                if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
-                    additionalHeightInDp
-                )
-            }
+            if (keyboardSymbolViewState.value) heightPx else heightPx + applicationContext.dpToPx(
+                candidateViewHeightEmptyPreferenceValue ?: 110
+            )
         }
 
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true) {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -7974,6 +7974,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 com.kazumaproject.core.R.drawable.content_copy_24dp -> {
                     copyAction()
                 }
+
+                com.kazumaproject.core.R.drawable.content_paste_24px -> {
+                    pasteAction()
+                }
             }
         }
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -5234,7 +5234,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     if (candidateTabVisibility == true) {
                         mainView.candidateTabLayout.isVisible = true
                     }
-                    mainView.shortcutToolbarRecyclerview.isVisible = false
+                    if (shortcutTollbarVisibility == true){
+                        mainView.shortcutToolbarRecyclerview.isInvisible = true
+                    }else{
+                        mainView.shortcutToolbarRecyclerview.isVisible = false
+                    }
                 }
                 when (currentFlag) {
                     CandidateShowFlag.Idle -> {
@@ -5433,11 +5437,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         mainView.candidateTabLayout.isVisible = false
                         val tab = mainView.candidateTabLayout.getTabAt(0)
                         mainView.candidateTabLayout.selectTab(tab)
-                        if (shortcutTollbarVisibility == true) {
-                            mainView.shortcutToolbarRecyclerview.isVisible = true
-                        } else {
-                            mainView.shortcutToolbarRecyclerview.isVisible = false
-                        }
+                        mainView.shortcutToolbarRecyclerview.isVisible = shortcutTollbarVisibility == true
                     }
 
                     CandidateShowFlag.Updating -> {
@@ -5826,11 +5826,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             )
         }
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true) {
-            if (isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true) {
-                keyboardHeight + 80
-            } else {
-                keyboardHeight + mainView.shortcutToolbarRecyclerview.height
-            }
+            keyboardHeight + mainView.shortcutToolbarRecyclerview.height
         } else {
             keyboardHeight
         }
@@ -5923,11 +5919,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
 
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true && !isSymbol) {
-            if (isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true) {
-                keyboardHeight + 80
-            } else {
-                keyboardHeight + mainView.shortcutToolbarRecyclerview.height
-            }
+            keyboardHeight + mainView.shortcutToolbarRecyclerview.height
         } else {
             keyboardHeight
         }
@@ -6016,11 +6008,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             )
         }
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true) {
-            if (isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true) {
-                keyboardHeight + 80
-            } else {
-                keyboardHeight + mainView.shortcutToolbarRecyclerview.height
-            }
+            keyboardHeight + mainView.shortcutToolbarRecyclerview.height
         } else {
             keyboardHeight
         }
@@ -6255,11 +6243,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
 
         val finalKeyboardHeight = if (shortcutTollbarVisibility == true) {
-            if (isGalaxyDevice() && keyboardHeightFixForSpecificDevicePreference == true) {
-                keyboardHeight + 80
-            } else {
-                keyboardHeight + mainView.shortcutToolbarRecyclerview.height
-            }
+            keyboardHeight + mainView.shortcutToolbarRecyclerview.height
         } else {
             keyboardHeight
         }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -70,6 +70,8 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private var incognitoIconDrawable: android.graphics.drawable.Drawable? = null
 
+    private var candidateTextSize: Float = 14f
+
     fun setOnItemClickListener(onItemClick: (Candidate, Int) -> Unit) {
         this.onItemClickListener = onItemClick
     }
@@ -362,6 +364,12 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         }
     }
 
+    fun setCandidateTextSize(size: Float) {
+        if (candidateTextSize == size) return
+        candidateTextSize = size
+        notifyItemRangeChanged(0, itemCount)
+    }
+
     private fun onBindSuggestionViewHolder(holder: SuggestionViewHolder, position: Int) {
         val suggestion = suggestions[position]
         val paddingLength = when {
@@ -381,6 +389,9 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             suggestion.string.padStart(suggestion.string.length + paddingLength)
                 .plus(" ".repeat(paddingLength))
         }
+
+        holder.text.textSize = candidateTextSize
+
         holder.typeText.text = when (suggestion.type) {
             (1).toByte() -> ""
             /** 予測 **/

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -240,7 +240,7 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             if (currentMode is TenKeyQWERTYMode.Custom && customLayouts.isNotEmpty()) {
                 customLayouts.size
             } else {
-                1
+                suggestions.size
             }
         }
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -90,9 +90,6 @@ object AppPreference {
     private val KEYBOARD_FLOATING_POSITION_X = Pair("keyboard_floating_position_x", -1)
     private val KEYBOARD_FLOATING_POSITION_Y = Pair("keyboard_floating_position_y", -1)
 
-    private val KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE =
-        Pair("keyboard_height_fix_enable_preference", false)
-
     private val defaultKeyboardOrderJson = gson.toJson(
         listOf(
             KeyboardType.TENKEY,
@@ -106,8 +103,6 @@ object AppPreference {
     private val SYMBOL_MODE_PREFERENCE = Pair("symbol_mode_preference", "EMOJI")
 
     private val CANDIDATE_COLUMN_PREFERENCE = Pair("candidate_column_preference", "1")
-
-    private val CANDIDATE_VIEW_HEIGHT_PREFERENCE = Pair("candidate_view_height_preference", "2")
 
     private val CANDIDATE_TAB_PREFERENCE = Pair("candidate_tab_visibility_preference", false)
 
@@ -486,15 +481,6 @@ object AppPreference {
             it.putBoolean(CUSTOM_KEYBOARD_SUGGESTION_PREFERENCE.first, value ?: true)
         }
 
-    var keyboard_height_fix_for_specific_device_preference: Boolean?
-        get() = preferences.getBoolean(
-            KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE.first,
-            KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE.second
-        )
-        set(value) = preferences.edit {
-            it.putBoolean(KEYBOARD_HEIGHT_FIX_FOR_SPECIFIC_DEVICE.first, value ?: false)
-        }
-
     var sumire_input_selection_preference: String?
         get() = preferences.getString(
             SUMIRE_INPUT_SELECTION_PREFERENCE.first, SUMIRE_INPUT_SELECTION_PREFERENCE.second
@@ -564,14 +550,6 @@ object AppPreference {
         ) ?: "1"
         set(value) = preferences.edit {
             it.putString(CANDIDATE_COLUMN_PREFERENCE.first, value)
-        }
-
-    var candidate_view_height_preference: String
-        get() = preferences.getString(
-            CANDIDATE_VIEW_HEIGHT_PREFERENCE.first, CANDIDATE_VIEW_HEIGHT_PREFERENCE.second
-        ) ?: "2"
-        set(value) = preferences.edit {
-            it.putString(CANDIDATE_VIEW_HEIGHT_PREFERENCE.first, value)
         }
 
     var candidate_tab_preference: Boolean

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -119,7 +119,9 @@ object AppPreference {
     private val DELETE_KEY_LEFT_FLICK_PREFERENCE = Pair("delete_key_flick_left_preference", true)
 
     private val KEY_LETTER_SIZE = Pair("key_letter_size_preference", 0.0f)
+    private val KEY_ICON_PADDING = Pair("key_icon_padding_preference", 24)
     private val CANDIDATE_LETTER_SIZE = Pair("candidate_letter_size_preference", 14.0f)
+    private val KEY_SWITCH_KEY_MODE_PADDING = Pair("key_switch_key_mode_padding_preference", 24)
 
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -590,10 +592,28 @@ object AppPreference {
             it.putFloat(KEY_LETTER_SIZE.first, value ?: KEY_LETTER_SIZE.second)
         }
 
+    var key_icon_padding: Int?
+        get() = preferences.getInt(KEY_ICON_PADDING.first, KEY_ICON_PADDING.second)
+        set(value) = preferences.edit {
+            it.putInt(KEY_ICON_PADDING.first, value ?: KEY_ICON_PADDING.second)
+        }
+
     var candidate_letter_size: Float?
         get() = preferences.getFloat(CANDIDATE_LETTER_SIZE.first, CANDIDATE_LETTER_SIZE.second)
         set(value) = preferences.edit {
             it.putFloat(CANDIDATE_LETTER_SIZE.first, value ?: CANDIDATE_LETTER_SIZE.second)
+        }
+
+    var key_switch_key_mode_padding: Int?
+        get() = preferences.getInt(
+            KEY_SWITCH_KEY_MODE_PADDING.first,
+            KEY_SWITCH_KEY_MODE_PADDING.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                KEY_SWITCH_KEY_MODE_PADDING.first,
+                value ?: KEY_SWITCH_KEY_MODE_PADDING.second
+            )
         }
 
     fun migrateSumirePreferenceIfNeeded() {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -67,6 +67,11 @@ object AppPreference {
     private val KEYBOARD_VERTICAL_MARGIN_BOTTOM =
         Pair("keyboard_vertical_margin_bottom_preference", 0)
     private val KEYBOARD_FLOATING_PREFERENCE = Pair("keyboard_floating_preference", false)
+    private val QWERTY_KEYBOARD_HEIGHT = Pair("qwerty_keyboard_height_preference", 220)
+    private val QWERTY_KEYBOARD_WIDTH = Pair("qwerty_keyboard_width_preference", 100)
+    private val QWERTY_KEYBOARD_VERTICAL_MARGIN_BOTTOM =
+        Pair("qwerty_keyboard_vertical_margin_bottom_preference", 0)
+    private val QWERTY_KEYBOARD_POSITION = Pair("qwerty_keyboard_position_preference", true)
     private val FLICK_INPUT_ONLY = Pair("flick_input_only_preference", false)
     private val OMISSION_SEARCH = Pair("omission_search_preference", false)
     private val UNDO_ENABLE = Pair("undo_enable_preference", false)
@@ -380,10 +385,44 @@ object AppPreference {
             it.putInt(KEYBOARD_WIDTH.first, value ?: 100)
         }
 
+    var qwerty_keyboard_height: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_HEIGHT.first, QWERTY_KEYBOARD_HEIGHT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(QWERTY_KEYBOARD_HEIGHT.first, value ?: 220)
+        }
+
+    var qwerty_keyboard_width: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_WIDTH.first, QWERTY_KEYBOARD_WIDTH.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(QWERTY_KEYBOARD_WIDTH.first, value ?: 100)
+        }
+
+    var qwerty_keyboard_vertical_margin_bottom: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_VERTICAL_MARGIN_BOTTOM.first,
+            QWERTY_KEYBOARD_VERTICAL_MARGIN_BOTTOM.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(QWERTY_KEYBOARD_VERTICAL_MARGIN_BOTTOM.first, value ?: 0)
+        }
+
     var keyboard_position: Boolean?
         get() = preferences.getBoolean(KEYBOARD_POSITION.first, KEYBOARD_POSITION.second)
         set(value) = preferences.edit {
             it.putBoolean(KEYBOARD_POSITION.first, value ?: true)
+        }
+
+    var qwerty_keyboard_position: Boolean?
+        get() = preferences.getBoolean(
+            QWERTY_KEYBOARD_POSITION.first,
+            QWERTY_KEYBOARD_POSITION.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(QWERTY_KEYBOARD_POSITION.first, value ?: true)
         }
 
     var keyboard_vertical_margin_bottom: Int?

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -118,6 +118,9 @@ object AppPreference {
 
     private val DELETE_KEY_LEFT_FLICK_PREFERENCE = Pair("delete_key_flick_left_preference", true)
 
+    private val KEY_LETTER_SIZE = Pair("key_letter_size_preference", 0.0f)
+    private val CANDIDATE_LETTER_SIZE = Pair("candidate_letter_size_preference", 14.0f)
+
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
     }
@@ -579,6 +582,18 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(DELETE_KEY_LEFT_FLICK_PREFERENCE.first, value)
+        }
+
+    var key_letter_size: Float?
+        get() = preferences.getFloat(KEY_LETTER_SIZE.first, KEY_LETTER_SIZE.second)
+        set(value) = preferences.edit {
+            it.putFloat(KEY_LETTER_SIZE.first, value ?: KEY_LETTER_SIZE.second)
+        }
+
+    var candidate_letter_size: Float?
+        get() = preferences.getFloat(CANDIDATE_LETTER_SIZE.first, CANDIDATE_LETTER_SIZE.second)
+        set(value) = preferences.edit {
+            it.putFloat(CANDIDATE_LETTER_SIZE.first, value ?: CANDIDATE_LETTER_SIZE.second)
         }
 
     fun migrateSumirePreferenceIfNeeded() {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -122,6 +122,9 @@ object AppPreference {
     private val KEY_ICON_PADDING = Pair("key_icon_padding_preference", 24)
     private val CANDIDATE_LETTER_SIZE = Pair("candidate_letter_size_preference", 14.0f)
     private val KEY_SWITCH_KEY_MODE_PADDING = Pair("key_switch_key_mode_padding_preference", 24)
+    private val CANDIDATE_VIEW_HEIGHT_DP = Pair("candidate_view_height_dp_preference", 110)
+    private val CANDIDATE_VIEW_EMPTY_HEIGHT_DP =
+        Pair("candidate_view_empty_height_dp_preference", 110)
 
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -534,6 +537,25 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putInt(KEYBOARD_FLOATING_POSITION_Y.first, value)
+        }
+
+    var candidate_view_height_dp: Int?
+        get() = preferences.getInt(
+            CANDIDATE_VIEW_HEIGHT_DP.first, CANDIDATE_VIEW_HEIGHT_DP.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(CANDIDATE_VIEW_HEIGHT_DP.first, value ?: CANDIDATE_VIEW_HEIGHT_DP.second)
+        }
+
+    var candidate_view_empty_height_dp: Int?
+        get() = preferences.getInt(
+            CANDIDATE_VIEW_EMPTY_HEIGHT_DP.first, CANDIDATE_VIEW_EMPTY_HEIGHT_DP.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                CANDIDATE_VIEW_EMPTY_HEIGHT_DP.first,
+                value ?: CANDIDATE_VIEW_EMPTY_HEIGHT_DP.second
+            )
         }
 
     var candidate_column_preference: String

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateViewHeightSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateViewHeightSettingFragment.kt
@@ -1,0 +1,269 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.candidate_view_height_setting
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.kazumaproject.markdownhelperkeyboard.R
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentCandidateViewHeightSettingBinding
+import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.GridSpacingItemDecoration
+import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionAdapter
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+import dagger.hilt.android.AndroidEntryPoint
+import timber.log.Timber
+import javax.inject.Inject
+import kotlin.math.roundToInt
+
+@AndroidEntryPoint
+class CandidateViewHeightSettingFragment : Fragment() {
+
+    @Inject
+    lateinit var appPreference: AppPreference
+
+    private lateinit var suggestionAdapter: SuggestionAdapter
+    private lateinit var candidateList: List<Candidate>
+
+    private var _binding: FragmentCandidateViewHeightSettingBinding? = null
+    private val binding get() = _binding!!
+
+    // State to track if the candidate list is visible. Set to false for empty by default.
+    private var isCandidateListVisible = false
+
+    private val minHeightDp = 30
+    private val maxHeightDp = 300
+    private val defaultHeightDp = 110
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        suggestionAdapter = SuggestionAdapter()
+        candidateList = (1..16).map { index ->
+            Candidate(
+                string = "候補 $index",
+                type = (index % 4).toByte(),
+                length = "候補 $index".length.toUByte(),
+                score = 100 - index,
+                leftId = (index * 10).toShort(),
+                rightId = (index * 10 + 1).toShort()
+            )
+        }
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentCandidateViewHeightSettingBinding.inflate(inflater, container, false)
+        setupMenu()
+        return binding.root
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupResizeHandle()
+        setSuggestionView()
+
+        suggestionAdapter.apply {
+            setUndoEnabled(false)
+            setPasteEnabled(false)
+
+            onListUpdated = {
+                applyCurrentDimensions()
+            }
+        }
+
+
+        binding.toggleCandidateListButton.setOnClickListener {
+            isCandidateListVisible = !isCandidateListVisible
+            updateCandidateListAndHeight()
+        }
+
+        binding.candidateHeightSettingTenkeyPreview.apply {
+            setOnTouchListener { _, _ ->
+                false
+            }
+        }
+        // Set initial state
+        updateCandidateListAndHeight()
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        isCandidateListVisible = false
+        _binding = null
+    }
+
+    private fun setupMenu() {
+        val menuHost: MenuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.fragment_reset_menu, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    R.id.action_reset -> {
+                        resetSettings()
+                        true
+                    }
+
+                    android.R.id.home -> {
+                        parentFragmentManager.popBackStack()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+
+    private fun resetSettings() {
+        // Reset height for when candidates are visible
+        if (!isCandidateListVisible) {
+            appPreference.candidate_view_height_dp = defaultHeightDp
+        } else {
+            when (appPreference.candidate_column_preference) {
+                "1" -> {
+                    appPreference.candidate_view_height_dp = defaultHeightDp
+                }
+
+                "2" -> {
+                    appPreference.candidate_view_height_dp = 165
+                }
+
+                "3" -> {
+                    appPreference.candidate_view_height_dp = 230
+                }
+            }
+        }
+        appPreference.candidate_view_empty_height_dp = defaultHeightDp
+        applyCurrentDimensions()
+    }
+
+    private fun updateCandidateListAndHeight() {
+        if (isCandidateListVisible) {
+            suggestionAdapter.suggestions = candidateList
+            binding.toggleCandidateListButton.text = "入力時"
+        } else {
+            suggestionAdapter.suggestions = emptyList()
+            binding.toggleCandidateListButton.text = "未入力時"
+        }
+    }
+
+    private fun setSuggestionView() {
+        when (val columnNum = appPreference.candidate_column_preference) {
+            "1" -> {
+                binding.candidateHeightSettingRecyclerview.layoutManager =
+                    LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+            }
+
+            "2", "3" -> {
+                val spanCount = columnNum.toInt()
+                val gridLayoutManager = GridLayoutManager(
+                    requireContext(), spanCount, GridLayoutManager.HORIZONTAL, false
+                )
+                val spacingInPixels =
+                    resources.getDimensionPixelSize(com.kazumaproject.core.R.dimen.grid_spacing)
+
+                binding.candidateHeightSettingRecyclerview.layoutManager =
+                    gridLayoutManager
+                binding.candidateHeightSettingRecyclerview.addItemDecoration(
+                    GridSpacingItemDecoration(
+                        spanCount, spacingInPixels, true
+                    )
+                )
+            }
+        }
+        binding.candidateHeightSettingRecyclerview.apply {
+            adapter = suggestionAdapter
+        }
+    }
+
+    /**
+     * 保存された高さ設定をビューに適用する
+     */
+    private fun applyCurrentDimensions() {
+        val heightPrefDp = if (isCandidateListVisible) {
+            appPreference.candidate_view_height_dp ?: defaultHeightDp
+        } else {
+            appPreference.candidate_view_empty_height_dp ?: defaultHeightDp
+        }
+
+        val density = resources.displayMetrics.density
+        val heightInPx = (heightPrefDp * density).toInt()
+
+        val layoutParams = binding.candidateHeightSettingRecyclerview.layoutParams
+        layoutParams.height = heightInPx
+        binding.candidateHeightSettingRecyclerview.layoutParams = layoutParams
+    }
+
+    /**
+     * 高さ変更ハンドルのタッチリスナーを設定する
+     */
+    @SuppressLint("ClickableViewAccessibility")
+    private fun setupResizeHandle() {
+        var initialY = 0f
+        var initialHeight = 0
+
+        val density = resources.displayMetrics.density
+        val minHeightPx = minHeightDp * density
+        val maxHeightPx = maxHeightDp * density
+
+        binding.handleTop.setOnTouchListener { _, event ->
+            when (event.action) {
+                MotionEvent.ACTION_DOWN -> {
+                    initialY = event.rawY
+                    initialHeight = binding.candidateHeightSettingRecyclerview.height
+                    true
+                }
+
+                MotionEvent.ACTION_MOVE -> {
+                    val deltaY = event.rawY - initialY
+                    val newHeight = (initialHeight - deltaY).coerceIn(minHeightPx, maxHeightPx)
+                    binding.candidateHeightSettingRecyclerview.layoutParams.height =
+                        newHeight.toInt()
+                    binding.candidateHeightSettingRecyclerview.requestLayout()
+                    true
+                }
+
+                MotionEvent.ACTION_UP -> {
+                    saveHeightPreference()
+                    true
+                }
+
+                else -> false
+            }
+        }
+    }
+
+    /**
+     * 現在のビューの高さを SharedPreferences に保存する
+     */
+    private fun saveHeightPreference() {
+        val density = resources.displayMetrics.density
+        val finalHeightDp =
+            (binding.candidateHeightSettingRecyclerview.height / density).roundToInt()
+
+        if (isCandidateListVisible) {
+            appPreference.candidate_view_height_dp = finalHeightDp
+            Timber.d("saveHeightPreference (with candidates): $finalHeightDp dp")
+        } else {
+            appPreference.candidate_view_empty_height_dp = finalHeightDp
+            Timber.d("saveHeightPreference (empty): $finalHeightDp dp")
+        }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/key_candidate_letter_size/KeyCandidateLetterSizeFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/key_candidate_letter_size/KeyCandidateLetterSizeFragment.kt
@@ -2,7 +2,6 @@ package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.key_candida
 
 import android.annotation.SuppressLint
 import android.content.res.Configuration
-import android.os.Build
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -17,7 +16,6 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.kazumaproject.core.domain.extensions.dpToPx
-import com.kazumaproject.core.domain.extensions.isGalaxyDevice
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
 import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentKeyCandidateLetterSizeBinding
@@ -87,13 +85,11 @@ class KeyCandidateLetterSizeFragment : Fragment() {
     private fun setKeyboardSize() {
         val heightPref = appPreference.keyboard_height ?: 280
         val widthPref = appPreference.keyboard_width ?: 280
-        val keyboardBottomMargin = appPreference.keyboard_vertical_margin_bottom ?: 0
         val density = resources.displayMetrics.density
         val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
         val screenWidth = resources.displayMetrics.widthPixels
         val positionPref = appPreference.keyboard_position ?: true
         val clampedHeight = heightPref.coerceIn(180, 420)
-        val candidateViewHeight = appPreference.candidate_view_height_preference
 
         val heightPx = (clampedHeight * density).toInt()
 
@@ -106,57 +102,17 @@ class KeyCandidateLetterSizeFragment : Fragment() {
                 (screenWidth * (widthPref / 100f)).toInt()
             }
         }
-
-        val defaultHeightSizeByDevice = when {
-            isGalaxyDevice() && appPreference.keyboard_height_fix_for_specific_device_preference == true -> {
-                when (candidateViewHeight) {
-                    "1" -> 48
-                    "2" -> 54
-                    "3" -> 60
-                    else -> 48
-                }
-            }
-
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.UPSIDE_DOWN_CAKE -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            isPortrait -> {
-                when (candidateViewHeight) {
-                    "1" -> 52
-                    "2" -> 58
-                    "3" -> 64
-                    else -> 52
-                }
-            }
-
-            else -> {
-                when (candidateViewHeight) {
-                    "1" -> 100
-                    "2" -> 110
-                    "3" -> 120
-                    else -> 100
-                }
-            }
-        }
         val keyboardHeight = if (isPortrait) {
             heightPx + requireContext().dpToPx(
-                defaultHeightSizeByDevice
+                appPreference.candidate_view_empty_height_dp ?: 110
             )
         } else {
             heightPx + requireContext().dpToPx(
-                defaultHeightSizeByDevice
+                appPreference.candidate_view_empty_height_dp ?: 110
             )
         }
 
-
         (binding.suggestionLetterSizeRecyclerview.layoutParams as? androidx.constraintlayout.widget.ConstraintLayout.LayoutParams)?.let { params ->
-
             params.width = widthPx
             if (positionPref) {
                 params.startToStart = -1

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/key_candidate_letter_size/KeyCandidateLetterSizeFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/key_candidate_letter_size/KeyCandidateLetterSizeFragment.kt
@@ -1,0 +1,210 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.key_candidate_letter_size
+
+import android.annotation.SuppressLint
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.SeekBar
+import androidx.core.view.MenuHost
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.kazumaproject.markdownhelperkeyboard.R
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentKeyCandidateLetterSizeBinding
+import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionAdapter
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class KeyCandidateLetterSizeFragment : Fragment() {
+
+    @Inject
+    lateinit var appPreference: AppPreference
+
+    private var _binding: FragmentKeyCandidateLetterSizeBinding? = null
+    private val binding get() = _binding!!
+    private lateinit var suggestionAdapter: SuggestionAdapter
+
+    private val minKeyTextSize = 12f
+    private val maxKeyTextSize = 40f
+    private val minCandidateTextSize = 10f
+    private val maxCandidateTextSize = 40f
+    private val defaultKeyTextSize = 17.0f
+    private val defaultCandidateTextSize = 14.0f
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        suggestionAdapter = SuggestionAdapter()
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentKeyCandidateLetterSizeBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    @SuppressLint("ClickableViewAccessibility")
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupRecyclerView()
+        setupPreviewData()
+        setupKeyLetterSizeSeekBar()
+        setupCandidateLetterSizeSeekBar()
+        setupMenu() // ★ Call the new menu setup function
+
+        binding.tenkeyLetterSizePreview.apply {
+            isClickable = false
+            isFocusable = false
+            setOnClickListener { }
+            setOnLongClickListener { false }
+            setOnTouchListener { _, _ -> true }
+        }
+    }
+
+    // ★ New function to set up the menu using the modern API
+    private fun setupMenu() {
+        val menuHost: MenuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                // Add menu items here
+                menuInflater.inflate(R.menu.fragment_reset_menu, menu)
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                // Handle the menu selection
+                return when (menuItem.itemId) {
+                    R.id.action_reset -> {
+                        resetSettings()
+                        true // Consume the event
+                    }
+
+                    else -> false // Let the system handle other items
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+
+    private fun resetSettings() {
+        // Reset key letter size
+        appPreference.key_letter_size = 0.0f
+        val keyProgress =
+            (100 * (defaultKeyTextSize - minKeyTextSize) / (maxKeyTextSize - minKeyTextSize)).toInt()
+        binding.keyLetterSizeSeekbar.progress = keyProgress
+        binding.tenkeyLetterSizePreview.setKeyLetterSize(defaultKeyTextSize)
+
+        // Reset candidate letter size
+        appPreference.candidate_letter_size = defaultCandidateTextSize
+        val candidateProgress =
+            (100 * (defaultCandidateTextSize - minCandidateTextSize) / (maxCandidateTextSize - minCandidateTextSize)).toInt()
+        binding.candidateLetterSizeSeekbar.progress = candidateProgress
+        suggestionAdapter.setCandidateTextSize(defaultCandidateTextSize)
+    }
+
+    private fun setupKeyLetterSizeSeekBar() {
+        binding.keyLetterSizeSeekbar.setOnSeekBarChangeListener(object :
+            SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                if (fromUser) {
+                    val newSize =
+                        minKeyTextSize + (progress.toFloat() / 100f) * (maxKeyTextSize - minKeyTextSize)
+                    binding.tenkeyLetterSizePreview.setKeyLetterSize(newSize)
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {
+                seekBar?.let {
+                    val newSize =
+                        minKeyTextSize + (it.progress.toFloat() / 100f) * (maxKeyTextSize - minKeyTextSize)
+                    val sizeDelta = newSize - defaultKeyTextSize
+                    appPreference.key_letter_size = sizeDelta
+                }
+            }
+        })
+
+        binding.keyLetterSizeSeekbar.max = 100
+        val savedDelta = appPreference.key_letter_size ?: 0.0f
+        val actualSize = defaultKeyTextSize + savedDelta
+        val keyProgress =
+            (100 * (actualSize - minKeyTextSize) / (maxKeyTextSize - minKeyTextSize)).toInt()
+        binding.keyLetterSizeSeekbar.progress = keyProgress
+        binding.tenkeyLetterSizePreview.post {
+            binding.tenkeyLetterSizePreview.setKeyLetterSize(actualSize)
+        }
+    }
+
+    private fun setupCandidateLetterSizeSeekBar() {
+        binding.candidateLetterSizeSeekbar.setOnSeekBarChangeListener(object :
+            SeekBar.OnSeekBarChangeListener {
+            override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+                if (fromUser) {
+                    val newSize =
+                        minCandidateTextSize + (progress.toFloat() / 100f) * (maxCandidateTextSize - minCandidateTextSize)
+                    suggestionAdapter.setCandidateTextSize(newSize)
+                }
+            }
+
+            override fun onStartTrackingTouch(seekBar: SeekBar?) {}
+
+            override fun onStopTrackingTouch(seekBar: SeekBar?) {
+                seekBar?.let {
+                    val newSize =
+                        minCandidateTextSize + (it.progress.toFloat() / 100f) * (maxCandidateTextSize - minCandidateTextSize)
+                    appPreference.candidate_letter_size = newSize
+                }
+            }
+        })
+
+        binding.candidateLetterSizeSeekbar.max = 100
+        val savedCandidateSize = appPreference.candidate_letter_size ?: defaultCandidateTextSize
+        val candidateProgress =
+            (100 * (savedCandidateSize - minCandidateTextSize) / (maxCandidateTextSize - minCandidateTextSize)).toInt()
+        binding.candidateLetterSizeSeekbar.progress = candidateProgress
+        suggestionAdapter.setCandidateTextSize(savedCandidateSize)
+    }
+
+    private fun setupRecyclerView() {
+        binding.suggestionLetterSizeRecyclerview.apply {
+            layoutManager =
+                LinearLayoutManager(requireContext(), LinearLayoutManager.HORIZONTAL, false)
+            adapter = suggestionAdapter
+            setHasFixedSize(true)
+        }
+    }
+
+    private fun setupPreviewData() {
+        val previewCandidates = listOf(
+            Candidate(
+                string = "プレビュー",
+                type = 1.toByte(),
+                length = (5).toUByte(),
+                score = 4000
+            ),
+            Candidate(
+                string = "文字サイズ",
+                type = 1.toByte(),
+                length = (5).toUByte(),
+                score = 4001
+            ),
+            Candidate(string = "候補", type = 1.toByte(), length = (2).toUByte(), score = 4002)
+        )
+        suggestionAdapter.suggestions = previewCandidates
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding.suggestionLetterSizeRecyclerview.adapter = null
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
@@ -231,13 +231,13 @@ class KeyboardSettingFragment : Fragment() {
         var initialWidth = 0
 
         val density = resources.displayMetrics.density
+        // ScreenWidth remains useful for min/max calculations in pixels
         val screenWidth = WindowMetricsCalculator.getOrCreate()
             .computeCurrentWindowMetrics(requireActivity()).bounds.width()
         val minHeightPx = minHeightDp * density
         val maxHeightPx = maxHeightDp * density
         val minWidthPx = screenWidth * (minWidthPercent / 100f)
 
-        // ▼▼▼ 保存ロジックを「高さ専用」と「幅専用」に分離 ▼▼▼
         fun saveHeightPreference() {
             val finalHeightDp = (binding.keyboardContainer.height / density).roundToInt()
             val currentPage = binding.keyboardViewPager.currentItem
@@ -250,8 +250,21 @@ class KeyboardSettingFragment : Fragment() {
         }
 
         fun saveWidthPreference() {
-            val finalWidthPercent =
-                ((binding.keyboardContainer.width.toFloat() / screenWidth) * 100).roundToInt()
+            // ▼▼▼ Correct calculation logic starts here ▼▼▼
+            // Get the parent view (the ConstraintLayout) to find the available width
+            val parentView = binding.keyboardSettingConstraint
+            // Calculate the actual available width by subtracting the horizontal padding
+            val availableWidth =
+                (parentView.width - parentView.paddingLeft - parentView.paddingRight).toFloat()
+
+            // Prevent division by zero if layout hasn't been measured yet
+            if (availableWidth <= 0) return
+
+            // Calculate the percentage based on the available width
+            val currentWidth = binding.keyboardContainer.width.toFloat()
+            val finalWidthPercent = ((currentWidth / availableWidth) * 100).roundToInt()
+            // ▲▲▲ Correct calculation logic ends here ▲▲▲
+
             val finalWidthValue = if (finalWidthPercent >= 98) 100 else finalWidthPercent
 
             val currentPage = binding.keyboardViewPager.currentItem
@@ -262,7 +275,6 @@ class KeyboardSettingFragment : Fragment() {
             }
             Timber.d("Saved Width for page $currentPage: $finalWidthValue %")
         }
-        // ▲▲▲ ここまで変更 ▲▲▲
 
         binding.handleTop.setOnTouchListener { _, event ->
             when (event.action) {
@@ -276,7 +288,7 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.height = newHeight.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-                // ▼▼▼ 高さ専用の保存関数を呼び出すように変更 ▼▼▼
+
                 MotionEvent.ACTION_UP -> saveHeightPreference()
             }
             true
@@ -294,7 +306,7 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.height = newHeight.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-                // ▼▼▼ 高さ専用の保存関数を呼び出すように変更 ▼▼▼
+
                 MotionEvent.ACTION_UP -> saveHeightPreference()
             }
             true
@@ -313,7 +325,7 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.width = newWidth.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-                // ▼▼▼ 幅専用の保存関数を呼び出すように変更 ▼▼▼
+
                 MotionEvent.ACTION_UP -> saveWidthPreference()
             }
             true
@@ -332,7 +344,7 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.width = newWidth.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-                // ▼▼▼ 幅専用の保存関数を呼び出すように変更 ▼▼▼
+
                 MotionEvent.ACTION_UP -> saveWidthPreference()
             }
             true

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
@@ -16,10 +16,12 @@ import androidx.core.content.ContextCompat
 import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
+import androidx.viewpager2.widget.ViewPager2
 import androidx.window.layout.WindowMetricsCalculator
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentKeyboardSettingBinding
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.keyboard_size_setting.adapter.KeyboardViewPagerAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import timber.log.Timber
 import javax.inject.Inject
@@ -35,9 +37,9 @@ class KeyboardSettingFragment : Fragment() {
     private val binding get() = _binding!!
 
     private var isRightAligned = true
-    private var isFloatingMode = false // フローティングモードの状態を管理する変数
+    private var isFloatingMode = false
+    private var areControlsVisible = true
 
-    // Define min/max dimensions for the keyboard
     private val minHeightDp = 100
     private val maxHeightDp = 420
     private val minWidthPercent = 32
@@ -55,74 +57,137 @@ class KeyboardSettingFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
 
         setupMenu()
-        // SharedPreferencesから状態を読み込む
         isRightAligned = appPreference.keyboard_position ?: true
         isFloatingMode = appPreference.is_floating_mode ?: false
 
-        // Set initial state and setup listeners
-        setInitialKeyboardView()
+        setupViewPager()
+        applyCurrentPageDimensions()
         setupKeyboardPositionButton()
-        setupFloatingButton() // フローティングボタンのリスナーをセットアップ
+        setupFloatingButton()
         setupResetButton()
         updateKeyboardAlignment()
-        updateFloatingModeUI() // UIの初期状態をセットアップ
+        updateFloatingModeUI()
+        // ▼▼▼ 正しい関数呼び出しに修正 ▼▼▼
         setupResizeHandles()
         setupMoveHandle()
+        // ▲▲▲ 正しい関数呼び出しに修正 ▲▲▲
+
+        updateControlsVisibility()
     }
 
-    /**
-     * Sets up the modern, lifecycle-aware MenuProvider to handle the "Up" button.
-     */
+    private fun setupViewPager() {
+        val adapter = KeyboardViewPagerAdapter()
+        binding.keyboardViewPager.adapter = adapter
+        binding.keyboardViewPager.isUserInputEnabled = false
+
+        binding.keyboardViewPager.registerOnPageChangeCallback(object :
+            ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                super.onPageSelected(position)
+                applyCurrentPageDimensions()
+                updateTooltipUI(position)
+
+                isRightAligned = if (position == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                    appPreference.keyboard_position ?: true
+                } else {
+                    appPreference.qwerty_keyboard_position ?: true
+                }
+                updateKeyboardAlignment()
+
+                binding.floatingKeyboardSettingBtn.visibility =
+                    if (position == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) View.VISIBLE else View.GONE
+            }
+        })
+
+        binding.tenkeyTooltipButton.setOnClickListener {
+            binding.keyboardViewPager.setCurrentItem(
+                KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION,
+                true
+            )
+        }
+        binding.qwertyTooltipButton.setOnClickListener {
+            binding.keyboardViewPager.setCurrentItem(
+                KeyboardViewPagerAdapter.QWERTY_PAGE_POSITION,
+                true
+            )
+        }
+
+        updateTooltipUI(binding.keyboardViewPager.currentItem)
+        binding.floatingKeyboardSettingBtn.visibility =
+            if (binding.keyboardViewPager.currentItem == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) View.VISIBLE else View.GONE
+    }
+
+    private fun applyCurrentPageDimensions() {
+        val position = binding.keyboardViewPager.currentItem
+        val heightPref: Int
+        val widthPref: Int
+        val marginBottomPref: Int
+        val positionPref: Boolean
+
+        if (position == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+            heightPref = appPreference.keyboard_height ?: 220
+            widthPref = appPreference.keyboard_width ?: 100
+            marginBottomPref = appPreference.keyboard_vertical_margin_bottom ?: 0
+            positionPref = appPreference.keyboard_position ?: true
+        } else { // QWERTY
+            heightPref = appPreference.qwerty_keyboard_height ?: 220
+            widthPref = appPreference.qwerty_keyboard_width ?: 100
+            marginBottomPref = appPreference.qwerty_keyboard_vertical_margin_bottom ?: 0
+            positionPref = appPreference.qwerty_keyboard_position ?: true
+        }
+        isRightAligned = positionPref
+
+        val density = resources.displayMetrics.density
+        val heightInPx = (heightPref * density).toInt()
+        val marginBottomInPx = (marginBottomPref * density).toInt()
+
+        val screenWidth = WindowMetricsCalculator.getOrCreate()
+            .computeCurrentWindowMetrics(requireActivity()).bounds.width()
+        val widthInPx = if (widthPref >= 98) {
+            ViewGroup.LayoutParams.MATCH_PARENT
+        } else {
+            (screenWidth * (widthPref / 100f)).toInt()
+        }
+
+        val layoutParams = binding.keyboardContainer.layoutParams as ConstraintLayout.LayoutParams
+        layoutParams.height = heightInPx
+        layoutParams.width = widthInPx
+        layoutParams.bottomMargin = marginBottomInPx
+        binding.keyboardContainer.layoutParams = layoutParams
+    }
+
     private fun setupMenu() {
         (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
         val menuHost = requireActivity()
         menuHost.addMenuProvider(object : MenuProvider {
-            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {}
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+                menuInflater.inflate(R.menu.menu_keyboard_settings, menu)
+            }
+
             override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
-                if (menuItem.itemId == android.R.id.home) {
-                    parentFragmentManager.popBackStack()
-                    return true
+                return when (menuItem.itemId) {
+                    android.R.id.home -> {
+                        parentFragmentManager.popBackStack()
+                        true
+                    }
+
+                    R.id.action_toggle_visibility -> {
+                        areControlsVisible = !areControlsVisible
+                        updateControlsVisibility()
+                        true
+                    }
+
+                    else -> false
                 }
-                return false
             }
         }, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
-    /**
-     * Applies the saved dimensions from preferences to the keyboard container on startup.
-     */
-    @SuppressLint("ClickableViewAccessibility")
-    private fun setInitialKeyboardView() {
-        val heightFromPreference = appPreference.keyboard_height ?: maxHeightDp
-        val widthFromPreference = appPreference.keyboard_width ?: maxWidthPercent
-        val marginBottomFromPreference = appPreference.keyboard_vertical_margin_bottom ?: 0
-
-        val density = resources.displayMetrics.density
-        val heightInPx = (heightFromPreference * density).toInt()
-        val marginBottomInPx = (marginBottomFromPreference * density).toInt()
-
-        val screenWidth = WindowMetricsCalculator.getOrCreate()
-            .computeCurrentWindowMetrics(requireActivity()).bounds.width()
-
-        val layoutParams = binding.keyboardContainer.layoutParams as ConstraintLayout.LayoutParams
-        layoutParams.height = heightInPx
-        layoutParams.width = if (widthFromPreference == maxWidthPercent) {
-            ViewGroup.LayoutParams.MATCH_PARENT
-        } else {
-            (screenWidth * (widthFromPreference / 100f)).toInt()
-        }
-        layoutParams.bottomMargin = marginBottomInPx
-        binding.keyboardContainer.layoutParams = layoutParams
-        binding.keyboardView.setOnTouchListener { _, _ ->
-            true
-        }
-    }
-
+    // ▼▼▼ 移動専用の関数を復活させ、中央の `handle_move` を対象にするように修正 ▼▼▼
     @SuppressLint("ClickableViewAccessibility")
     private fun setupMoveHandle() {
         var initialY = 0f
         var initialBottomMargin = 0
-
         val density = resources.displayMetrics.density
 
         binding.handleMove.setOnTouchListener { _, event ->
@@ -137,19 +202,22 @@ class KeyboardSettingFragment : Fragment() {
 
                 MotionEvent.ACTION_MOVE -> {
                     val deltaY = event.rawY - initialY
-                    // Yが小さい（上方向）にドラッグするとdeltaYは負になるため、マージンは増加する
                     val newBottomMargin = initialBottomMargin - deltaY
-                    // 画面外にドラッグできないようにマージンを制限（例: 0以上）
                     layoutParams.bottomMargin = newBottomMargin.toInt().coerceAtLeast(0)
                     binding.keyboardContainer.requestLayout()
                     true
                 }
 
                 MotionEvent.ACTION_UP -> {
-                    // dpに変換して設定を保存
                     val finalMarginDp = (layoutParams.bottomMargin / density).roundToInt()
-                    appPreference.keyboard_vertical_margin_bottom = finalMarginDp
-                    Timber.d("savePreferences: vertical margin bottom = $finalMarginDp dp")
+                    val currentPage = binding.keyboardViewPager.currentItem
+
+                    if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                        appPreference.keyboard_vertical_margin_bottom = finalMarginDp
+                    } else { // QWERTY
+                        appPreference.qwerty_keyboard_vertical_margin_bottom = finalMarginDp
+                    }
+                    Timber.d("Saved vertical margin for page $currentPage: $finalMarginDp dp")
                     true
                 }
 
@@ -157,10 +225,9 @@ class KeyboardSettingFragment : Fragment() {
             }
         }
     }
+    // ▲▲▲ 移動専用の関数を復活 ▲▲▲
 
-    /**
-     * Initializes touch listeners for all four resize handles.
-     */
+    // ▼▼▼ リサイズ専用の関数に修正 (`handle_top`の機能をリサイズに戻しました) ▼▼▼
     @SuppressLint("ClickableViewAccessibility")
     private fun setupResizeHandles() {
         var initialY = 0f
@@ -175,28 +242,27 @@ class KeyboardSettingFragment : Fragment() {
         val maxHeightPx = maxHeightDp * density
         val minWidthPx = screenWidth * (minWidthPercent / 100f)
 
-        // Common function to save preferences on ACTION_UP
         fun savePreferences() {
-            val finalHeightPx = (binding.keyboardContainer.height / density).roundToInt()
-            val finalWidthPx =
+            val finalHeightDp = (binding.keyboardContainer.height / density).roundToInt()
+            val finalWidthPercent =
                 ((binding.keyboardContainer.width.toFloat() / screenWidth) * 100).roundToInt()
+            val finalWidthValue = if (finalWidthPercent >= 98) 100 else finalWidthPercent
 
-            appPreference.keyboard_height = finalHeightPx
-            appPreference.keyboard_width = if (finalWidthPx >= 90) {
-                100
-            } else {
-                finalWidthPx
+            val currentPage = binding.keyboardViewPager.currentItem
+            if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                appPreference.keyboard_height = finalHeightDp
+                appPreference.keyboard_width = finalWidthValue
+            } else { // QWERTY
+                appPreference.qwerty_keyboard_height = finalHeightDp
+                appPreference.qwerty_keyboard_width = finalWidthValue
             }
-
-            Timber.d("savePreferences: $finalWidthPx $finalHeightPx")
+            Timber.d("Saved dimensions for page $currentPage: H=$finalHeightDp dp, W=$finalWidthValue %")
         }
 
-        // Top Handle
         binding.handleTop.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialY = event.rawY
-                    initialHeight = binding.keyboardContainer.height
+                    initialY = event.rawY; initialHeight = binding.keyboardContainer.height
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -211,12 +277,10 @@ class KeyboardSettingFragment : Fragment() {
             true
         }
 
-        // Bottom Handle
         binding.handleBottom.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialY = event.rawY
-                    initialHeight = binding.keyboardContainer.height
+                    initialY = event.rawY; initialHeight = binding.keyboardContainer.height
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -231,12 +295,10 @@ class KeyboardSettingFragment : Fragment() {
             true
         }
 
-        // Left Handle
         binding.handleLeft.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialX = event.rawX
-                    initialWidth = binding.keyboardContainer.width
+                    initialX = event.rawX; initialWidth = binding.keyboardContainer.width
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -252,12 +314,10 @@ class KeyboardSettingFragment : Fragment() {
             true
         }
 
-        // Right Handle
         binding.handleRight.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialX = event.rawX
-                    initialWidth = binding.keyboardContainer.width
+                    initialX = event.rawX; initialWidth = binding.keyboardContainer.width
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -273,6 +333,7 @@ class KeyboardSettingFragment : Fragment() {
             true
         }
     }
+    // ▲▲▲ リサイズ専用の関数に修正 ▲▲▲
 
     private fun setupKeyboardPositionButton() {
         binding.keyboardPositionButton.setOnClickListener {
@@ -281,47 +342,48 @@ class KeyboardSettingFragment : Fragment() {
         }
     }
 
-    /**
-     * フローティングボタンのクリックリスナーをセットアップ
-     */
     private fun setupFloatingButton() {
         binding.floatingKeyboardSettingBtn.setOnClickListener {
             isFloatingMode = !isFloatingMode
-            appPreference.is_floating_mode = isFloatingMode // 設定を保存
+            appPreference.is_floating_mode = isFloatingMode
             updateFloatingModeUI()
         }
     }
 
-    /**
-     * Sets up the listener for the new reset button.
-     */
     private fun setupResetButton() {
         binding.resetLayoutButton.setOnClickListener {
-            // Set preferences to default values
-            appPreference.keyboard_height = 220
-            appPreference.keyboard_width = maxWidthPercent
-            appPreference.keyboard_position = true // Default to right-aligned
-            appPreference.keyboard_vertical_margin_bottom = 0
-            appPreference.is_floating_mode = false // フローティングモードをOFFにリセット
+            val currentPage = binding.keyboardViewPager.currentItem
 
-            // Update local state and UI
-            isRightAligned = true
-            isFloatingMode = false // ローカルの状態もリセット
-            setInitialKeyboardView()
+            if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                appPreference.keyboard_height = 220
+                appPreference.keyboard_width = 100
+                appPreference.keyboard_vertical_margin_bottom = 0
+                appPreference.keyboard_position = true
+            } else {
+                appPreference.qwerty_keyboard_height = 220
+                appPreference.qwerty_keyboard_width = 100
+                appPreference.qwerty_keyboard_vertical_margin_bottom = 0
+                appPreference.qwerty_keyboard_position = true
+            }
+
+            applyCurrentPageDimensions()
             updateKeyboardAlignment()
-            updateFloatingModeUI() // フローティングボタンのUIを更新
         }
     }
 
     private fun updateKeyboardAlignment() {
-        appPreference.keyboard_position = isRightAligned
+        val currentPage = binding.keyboardViewPager.currentItem
+        if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+            appPreference.keyboard_position = isRightAligned
+        } else {
+            appPreference.qwerty_keyboard_position = isRightAligned
+        }
 
         val constraintLayout = binding.keyboardSettingConstraint
         val constraintSet = ConstraintSet()
         constraintSet.clone(constraintLayout)
 
         if (isRightAligned) {
-            // Align container to the right
             constraintSet.connect(
                 binding.keyboardContainer.id,
                 ConstraintSet.END,
@@ -330,15 +392,11 @@ class KeyboardSettingFragment : Fragment() {
             )
             constraintSet.clear(binding.keyboardContainer.id, ConstraintSet.START)
             binding.keyboardPositionButton.setBackgroundColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    com.kazumaproject.core.R.color.blue
-                )
+                ContextCompat.getColor(requireContext(), com.kazumaproject.core.R.color.blue)
             )
             binding.keyboardPositionButton.text =
                 getString(R.string.key_size_position_button_text_right)
         } else {
-            // Align container to the left
             constraintSet.connect(
                 binding.keyboardContainer.id,
                 ConstraintSet.START,
@@ -358,18 +416,12 @@ class KeyboardSettingFragment : Fragment() {
         constraintSet.applyTo(constraintLayout)
     }
 
-    /**
-     * フローティングモードの状態に基づいてUIを更新
-     */
     private fun updateFloatingModeUI() {
         if (isFloatingMode) {
             binding.floatingKeyboardSettingBtn.text =
                 getString(R.string.key_size_floating_button_text_on)
             binding.floatingKeyboardSettingBtn.setBackgroundColor(
-                ContextCompat.getColor(
-                    requireContext(),
-                    com.kazumaproject.core.R.color.blue
-                )
+                ContextCompat.getColor(requireContext(), com.kazumaproject.core.R.color.blue)
             )
         } else {
             binding.floatingKeyboardSettingBtn.text =
@@ -383,6 +435,36 @@ class KeyboardSettingFragment : Fragment() {
         }
     }
 
+    private fun updateTooltipUI(selectedPosition: Int) {
+        val selectedColor =
+            ContextCompat.getColor(requireContext(), com.kazumaproject.core.R.color.blue)
+        val defaultColor = ContextCompat.getColor(
+            requireContext(),
+            com.kazumaproject.core.R.color.qwety_key_bg_color
+        )
+
+        binding.tenkeyTooltipButton.setBackgroundColor(
+            if (selectedPosition == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) selectedColor else defaultColor
+        )
+        binding.qwertyTooltipButton.setBackgroundColor(
+            if (selectedPosition == KeyboardViewPagerAdapter.QWERTY_PAGE_POSITION) selectedColor else defaultColor
+        )
+    }
+
+    private fun updateControlsVisibility() {
+        val visibility = if (areControlsVisible) View.VISIBLE else View.GONE
+        binding.keyboardPositionTitle.visibility = visibility
+        binding.keyboardPositionButton.visibility = visibility
+        binding.resetLayoutButton.visibility = visibility
+        binding.tenkeyTooltipButton.visibility = visibility
+        binding.qwertyTooltipButton.visibility = visibility
+
+        if (areControlsVisible && binding.keyboardViewPager.currentItem == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+            binding.floatingKeyboardSettingBtn.visibility = View.VISIBLE
+        } else {
+            binding.floatingKeyboardSettingBtn.visibility = View.GONE
+        }
+    }
 
     override fun onDestroyView() {
         super.onDestroyView()

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
@@ -67,10 +67,8 @@ class KeyboardSettingFragment : Fragment() {
         setupResetButton()
         updateKeyboardAlignment()
         updateFloatingModeUI()
-        // ▼▼▼ 正しい関数呼び出しに修正 ▼▼▼
         setupResizeHandles()
         setupMoveHandle()
-        // ▲▲▲ 正しい関数呼び出しに修正 ▲▲▲
 
         updateControlsVisibility()
     }
@@ -183,7 +181,6 @@ class KeyboardSettingFragment : Fragment() {
         }, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
-    // ▼▼▼ 移動専用の関数を復活させ、中央の `handle_move` を対象にするように修正 ▼▼▼
     @SuppressLint("ClickableViewAccessibility")
     private fun setupMoveHandle() {
         var initialY = 0f
@@ -225,9 +222,7 @@ class KeyboardSettingFragment : Fragment() {
             }
         }
     }
-    // ▲▲▲ 移動専用の関数を復活 ▲▲▲
 
-    // ▼▼▼ リサイズ専用の関数に修正 (`handle_top`の機能をリサイズに戻しました) ▼▼▼
     @SuppressLint("ClickableViewAccessibility")
     private fun setupResizeHandles() {
         var initialY = 0f
@@ -242,22 +237,32 @@ class KeyboardSettingFragment : Fragment() {
         val maxHeightPx = maxHeightDp * density
         val minWidthPx = screenWidth * (minWidthPercent / 100f)
 
-        fun savePreferences() {
+        // ▼▼▼ 保存ロジックを「高さ専用」と「幅専用」に分離 ▼▼▼
+        fun saveHeightPreference() {
             val finalHeightDp = (binding.keyboardContainer.height / density).roundToInt()
+            val currentPage = binding.keyboardViewPager.currentItem
+            if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                appPreference.keyboard_height = finalHeightDp
+            } else { // QWERTY
+                appPreference.qwerty_keyboard_height = finalHeightDp
+            }
+            Timber.d("Saved Height for page $currentPage: $finalHeightDp dp")
+        }
+
+        fun saveWidthPreference() {
             val finalWidthPercent =
                 ((binding.keyboardContainer.width.toFloat() / screenWidth) * 100).roundToInt()
             val finalWidthValue = if (finalWidthPercent >= 98) 100 else finalWidthPercent
 
             val currentPage = binding.keyboardViewPager.currentItem
             if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
-                appPreference.keyboard_height = finalHeightDp
                 appPreference.keyboard_width = finalWidthValue
             } else { // QWERTY
-                appPreference.qwerty_keyboard_height = finalHeightDp
                 appPreference.qwerty_keyboard_width = finalWidthValue
             }
-            Timber.d("Saved dimensions for page $currentPage: H=$finalHeightDp dp, W=$finalWidthValue %")
+            Timber.d("Saved Width for page $currentPage: $finalWidthValue %")
         }
+        // ▲▲▲ ここまで変更 ▲▲▲
 
         binding.handleTop.setOnTouchListener { _, event ->
             when (event.action) {
@@ -271,8 +276,8 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.height = newHeight.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-
-                MotionEvent.ACTION_UP -> savePreferences()
+                // ▼▼▼ 高さ専用の保存関数を呼び出すように変更 ▼▼▼
+                MotionEvent.ACTION_UP -> saveHeightPreference()
             }
             true
         }
@@ -289,8 +294,8 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.height = newHeight.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-
-                MotionEvent.ACTION_UP -> savePreferences()
+                // ▼▼▼ 高さ専用の保存関数を呼び出すように変更 ▼▼▼
+                MotionEvent.ACTION_UP -> saveHeightPreference()
             }
             true
         }
@@ -308,8 +313,8 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.width = newWidth.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-
-                MotionEvent.ACTION_UP -> savePreferences()
+                // ▼▼▼ 幅専用の保存関数を呼び出すように変更 ▼▼▼
+                MotionEvent.ACTION_UP -> saveWidthPreference()
             }
             true
         }
@@ -327,13 +332,12 @@ class KeyboardSettingFragment : Fragment() {
                     binding.keyboardContainer.layoutParams.width = newWidth.toInt()
                     binding.keyboardContainer.requestLayout()
                 }
-
-                MotionEvent.ACTION_UP -> savePreferences()
+                // ▼▼▼ 幅専用の保存関数を呼び出すように変更 ▼▼▼
+                MotionEvent.ACTION_UP -> saveWidthPreference()
             }
             true
         }
     }
-    // ▲▲▲ リサイズ専用の関数に修正 ▲▲▲
 
     private fun setupKeyboardPositionButton() {
         binding.keyboardPositionButton.setOnClickListener {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/adapter/KeyboardViewPagerAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/adapter/KeyboardViewPagerAdapter.kt
@@ -1,0 +1,38 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.keyboard_size_setting.adapter
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.RecyclerView
+import com.kazumaproject.markdownhelperkeyboard.R
+
+class KeyboardViewPagerAdapter : RecyclerView.Adapter<KeyboardViewPagerAdapter.ViewHolder>() {
+
+    // 表示するページのレイアウトリスト
+    private val pageLayouts = listOf(
+        R.layout.page_tenkey,
+        R.layout.page_qwerty // QWERTYレイアウトを追加
+    )
+
+    companion object {
+        const val TEN_KEY_PAGE_POSITION = 0
+        const val QWERTY_PAGE_POSITION = 1
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        // 必要に応じて、各ページのビューに対する処理をここに記述
+    }
+
+    override fun getItemCount(): Int = pageLayouts.size
+
+    override fun getItemViewType(position: Int): Int {
+        return pageLayouts[position]
+    }
+
+    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
@@ -159,6 +159,29 @@ class SettingFragment : PreferenceFragmentCompat() {
             }
         }
 
+        val candidateColumnListPreference =
+            findPreference<ListPreference>("candidate_column_preference")
+        candidateColumnListPreference?.apply {
+            setOnPreferenceChangeListener { _, newValue ->
+                if (newValue is String) {
+                    when (newValue) {
+                        "1" -> {
+                            appPreference.candidate_view_height_dp = 110
+                        }
+
+                        "2" -> {
+                            appPreference.candidate_view_height_dp = 165
+                        }
+
+                        "3" -> {
+                            appPreference.candidate_view_height_dp = 230
+                        }
+                    }
+                }
+                true
+            }
+        }
+
         val appVersionPreference = findPreference<Preference>("app_version_preference")
         appVersionPreference?.apply {
             summary = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -190,6 +213,17 @@ class SettingFragment : PreferenceFragmentCompat() {
                 R.id.action_navigation_setting_to_keyCandidateLetterSizeFragment
             )
             true
+        }
+
+        val candidateHeightFragmentSetting =
+            findPreference<Preference>("candidate_view_height_setting_fragment_preference")
+        candidateHeightFragmentSetting?.apply {
+            setOnPreferenceClickListener {
+                findNavController().navigate(
+                    R.id.action_navigation_setting_to_candidateViewHeightSettingFragment
+                )
+                true
+            }
         }
 
         val clipBoardHistoryPreference =

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingFragment.kt
@@ -182,6 +182,16 @@ class SettingFragment : PreferenceFragmentCompat() {
             true
         }
 
+        val keyboardLetterSizePreference =
+            findPreference<Preference>("keyboard_key_letter_size_fragment_preference")
+
+        keyboardLetterSizePreference?.setOnPreferenceClickListener {
+            findNavController().navigate(
+                R.id.action_navigation_setting_to_keyCandidateLetterSizeFragment
+            )
+            true
+        }
+
         val clipBoardHistoryPreference =
             findPreference<Preference>("clipboard_history_preference_fragment")
         clipBoardHistoryPreference?.apply {

--- a/app/src/main/res/layout/fragment_candidate_view_height_setting.xml
+++ b/app/src/main/res/layout/fragment_candidate_view_height_setting.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".setting_activity.ui.candidate_view_height_setting.CandidateViewHeightSettingFragment">
+
+    <Button
+        android:id="@+id/toggle_candidate_list_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:text="Toggle Candidate List"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/candidate_height_setting_content"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="18dp"
+        android:background="@color/keyboard_bg"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/candidate_height_setting_recyclerview"
+            android:layout_width="match_parent"
+            android:layout_height="58dp"
+            android:background="@color/keyboard_bg"
+            app:layout_constraintBottom_toTopOf="@+id/candidate_height_setting_tenkey_preview"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent" />
+
+        <View
+            android:id="@+id/handle_top"
+            android:layout_width="156dp"
+            android:layout_height="40dp"
+            android:background="@drawable/resize_handle"
+            android:translationY="-12dp"
+            app:layout_constraintEnd_toEndOf="@id/candidate_height_setting_recyclerview"
+            app:layout_constraintStart_toStartOf="@id/candidate_height_setting_recyclerview"
+            app:layout_constraintTop_toTopOf="@id/candidate_height_setting_recyclerview" />
+
+        <com.kazumaproject.tenkey.TenKey
+            android:id="@+id/candidate_height_setting_tenkey_preview"
+            android:layout_width="match_parent"
+            android:layout_height="280dp"
+            app:layout_constraintBottom_toBottomOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_key_candidate_letter_size.xml
+++ b/app/src/main/res/layout/fragment_key_candidate_letter_size.xml
@@ -21,37 +21,17 @@
             android:paddingBottom="16dp">
 
             <TextView
-                android:id="@+id/key_letter_size_label"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:layout_marginStart="16dp"
-                android:layout_marginTop="16dp"
-                android:layout_marginEnd="16dp"
-                android:text="キーの文字サイズ"
-                android:textAppearance="?attr/textAppearanceBody1"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
-
-            <SeekBar
-                android:id="@+id/key_letter_size_seekbar"
-                android:layout_width="match_parent"
-                android:layout_height="64dp"
-                android:layout_marginTop="8dp"
-                app:layout_constraintTop_toBottomOf="@+id/key_letter_size_label" />
-
-            <TextView
                 android:id="@+id/candidate_letter_size_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="16dp"
-                android:text="候補の文字サイズ"
+                android:text="@string/setting_candidate_letter_size"
                 android:textAppearance="?attr/textAppearanceBody1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/key_letter_size_seekbar" />
+                app:layout_constraintTop_toTopOf="parent" />
 
             <SeekBar
                 android:id="@+id/candidate_letter_size_seekbar"
@@ -61,17 +41,37 @@
                 app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_label" />
 
             <TextView
+                android:id="@+id/key_letter_size_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="@string/setting_key_letter_size"
+                android:textAppearance="?attr/textAppearanceBody1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_seekbar" />
+
+            <SeekBar
+                android:id="@+id/key_letter_size_seekbar"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@+id/key_letter_size_label" />
+
+            <TextView
                 android:id="@+id/key_icon_padding_label"
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
                 android:layout_marginEnd="16dp"
-                android:text="キーアイコンのサイズ (変換キー以外)"
+                android:text="@string/setting_key_icon_size"
                 android:textAppearance="?attr/textAppearanceBody1"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_seekbar" />
+                app:layout_constraintTop_toBottomOf="@+id/key_letter_size_seekbar" />
 
             <SeekBar
                 android:id="@+id/key_icon_padding_seekbar"
@@ -86,7 +86,7 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="16dp"
-                android:text="モード切り替えキーのアイコンサイズ"
+                android:text="@string/setting_mode_switch_key_icon_size"
                 android:textAppearance="?attr/textAppearanceBody1"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/key_icon_padding_seekbar" />

--- a/app/src/main/res/layout/fragment_key_candidate_letter_size.xml
+++ b/app/src/main/res/layout/fragment_key_candidate_letter_size.xml
@@ -1,73 +1,127 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context=".setting_activity.ui.key_candidate_letter_size.KeyCandidateLetterSizeFragment">
 
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:paddingBottom="?attr/actionBarSize">
+    <ScrollView
+        android:id="@+id/settings_scroll_view"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toTopOf="@+id/suggestion_letter_size_recyclerview"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
-        <TextView
-            android:id="@+id/key_letter_size_label"
-            android:layout_width="0dp"
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="キーの文字サイズ"
-            android:textAppearance="?attr/textAppearanceBody1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:paddingBottom="16dp">
 
-        <SeekBar
-            android:id="@+id/key_letter_size_seekbar"
-            android:layout_width="match_parent"
-            android:layout_height="64dp"
-            android:layout_marginTop="8dp"
-            app:layout_constraintTop_toBottomOf="@+id/key_letter_size_label" />
+            <TextView
+                android:id="@+id/key_letter_size_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="キーの文字サイズ"
+                android:textAppearance="?attr/textAppearanceBody1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent" />
 
-        <TextView
-            android:id="@+id/candidate_letter_size_label"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="16dp"
-            android:layout_marginTop="16dp"
-            android:layout_marginEnd="16dp"
-            android:text="候補の文字サイズ"
-            android:textAppearance="?attr/textAppearanceBody1"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/key_letter_size_seekbar" />
+            <SeekBar
+                android:id="@+id/key_letter_size_seekbar"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@+id/key_letter_size_label" />
 
-        <SeekBar
-            android:id="@+id/candidate_letter_size_seekbar"
-            android:layout_width="match_parent"
-            android:layout_height="64dp"
-            android:layout_marginTop="8dp"
-            app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_label" />
+            <TextView
+                android:id="@+id/candidate_letter_size_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="候補の文字サイズ"
+                android:textAppearance="?attr/textAppearanceBody1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/key_letter_size_seekbar" />
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/suggestion_letter_size_recyclerview"
-            android:layout_width="match_parent"
-            android:layout_height="58dp"
-            android:layout_marginTop="40dp"
-            android:background="@color/keyboard_bg"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_seekbar" />
+            <SeekBar
+                android:id="@+id/candidate_letter_size_seekbar"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_label" />
 
-        <com.kazumaproject.tenkey.TenKey
-            android:id="@+id/tenkey_letter_size_preview"
-            android:layout_width="match_parent"
-            android:layout_height="280dp"
-            android:clickable="false"
-            android:focusable="false"
-            app:layout_constraintTop_toBottomOf="@+id/suggestion_letter_size_recyclerview" />
+            <TextView
+                android:id="@+id/key_icon_padding_label"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:layout_marginEnd="16dp"
+                android:text="キーアイコンのサイズ (変換キー以外)"
+                android:textAppearance="?attr/textAppearanceBody1"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_seekbar" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+            <SeekBar
+                android:id="@+id/key_icon_padding_seekbar"
+                android:layout_width="match_parent"
+                android:layout_height="64dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintTop_toBottomOf="@+id/key_icon_padding_label" />
+
+            <TextView
+                android:id="@+id/key_switch_key_mode_padding_label"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="16dp"
+                android:layout_marginTop="16dp"
+                android:text="モード切り替えキーのアイコンサイズ"
+                android:textAppearance="?attr/textAppearanceBody1"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/key_icon_padding_seekbar" />
+
+            <SeekBar
+                android:id="@+id/key_switch_key_mode_padding_seekbar"
+                android:layout_width="0dp"
+                android:layout_height="64dp"
+                android:layout_marginTop="8dp"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toBottomOf="@id/key_switch_key_mode_padding_label" />
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+    </ScrollView>
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/suggestion_letter_size_recyclerview"
+        android:layout_width="0dp"
+        android:layout_height="58dp"
+        android:background="@color/keyboard_bg"
+        app:layout_constraintBottom_toTopOf="@+id/tenkey_letter_size_preview"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <com.kazumaproject.tenkey.TenKey
+        android:id="@+id/tenkey_letter_size_preview"
+        android:layout_width="0dp"
+        android:layout_height="280dp"
+        android:layout_marginBottom="18dp"
+        android:background="@color/keyboard_bg"
+        android:clickable="false"
+        android:focusable="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/fragment_key_candidate_letter_size.xml
+++ b/app/src/main/res/layout/fragment_key_candidate_letter_size.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".setting_activity.ui.key_candidate_letter_size.KeyCandidateLetterSizeFragment">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingBottom="?attr/actionBarSize">
+
+        <TextView
+            android:id="@+id/key_letter_size_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="キーの文字サイズ"
+            android:textAppearance="?attr/textAppearanceBody1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <SeekBar
+            android:id="@+id/key_letter_size_seekbar"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintTop_toBottomOf="@+id/key_letter_size_label" />
+
+        <TextView
+            android:id="@+id/candidate_letter_size_label"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="16dp"
+            android:text="候補の文字サイズ"
+            android:textAppearance="?attr/textAppearanceBody1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/key_letter_size_seekbar" />
+
+        <SeekBar
+            android:id="@+id/candidate_letter_size_seekbar"
+            android:layout_width="match_parent"
+            android:layout_height="64dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_label" />
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/suggestion_letter_size_recyclerview"
+            android:layout_width="match_parent"
+            android:layout_height="58dp"
+            android:layout_marginTop="40dp"
+            android:background="@color/keyboard_bg"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/candidate_letter_size_seekbar" />
+
+        <com.kazumaproject.tenkey.TenKey
+            android:id="@+id/tenkey_letter_size_preview"
+            android:layout_width="match_parent"
+            android:layout_height="280dp"
+            android:clickable="false"
+            android:focusable="false"
+            app:layout_constraintTop_toBottomOf="@+id/suggestion_letter_size_recyclerview" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_keyboard_setting.xml
+++ b/app/src/main/res/layout/fragment_keyboard_setting.xml
@@ -52,25 +52,47 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/keyboard_position_button" />
 
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/tenkey_tooltip_button"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:layout_marginEnd="4dp"
+            android:text="TenKey"
+            app:layout_constraintEnd_toStartOf="@id/qwerty_tooltip_button"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/reset_layout_button" />
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/qwerty_tooltip_button"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="4dp"
+            android:text="QWERTY"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@id/tenkey_tooltip_button"
+            app:layout_constraintTop_toTopOf="@id/tenkey_tooltip_button" />
+
         <FrameLayout
             android:id="@+id/keyboard_container"
             android:layout_width="match_parent"
             android:layout_height="280dp"
-            android:layout_marginTop="32dp"
+            android:layout_marginTop="8dp"
             android:background="@drawable/resize_border"
             android:clickable="false"
             android:focusable="false"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/reset_layout_button"
+            app:layout_constraintTop_toBottomOf="@+id/tenkey_tooltip_button"
             app:layout_constraintVertical_bias="1.0">
 
-            <com.kazumaproject.tenkey.TenKey
-                android:id="@+id/keyboard_view"
+            <androidx.viewpager2.widget.ViewPager2
+                android:id="@+id/keyboard_view_pager"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent"
-                android:clickable="false"
-                android:focusable="false" />
+                android:layout_gravity="center" />
 
             <ImageView
                 android:id="@+id/handle_move"

--- a/app/src/main/res/layout/page_qwerty.xml
+++ b/app/src/main/res/layout/page_qwerty.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.kazumaproject.qwerty_keyboard.ui.QWERTYKeyboardView
+        android:id="@+id/qwerty_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="true"
+        android:focusable="true" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/page_tenkey.xml
+++ b/app/src/main/res/layout/page_tenkey.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.kazumaproject.tenkey.TenKey
+        android:id="@+id/keyboard_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:clickable="false"
+        android:focusable="false" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/suggestion_item.xml
+++ b/app/src/main/res/layout/suggestion_item.xml
@@ -2,7 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:background="@drawable/recyclerview_item_bg"
     android:paddingHorizontal="5dp">
 

--- a/app/src/main/res/menu/fragment_reset_menu.xml
+++ b/app/src/main/res/menu/fragment_reset_menu.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/action_reset"
+        android:icon="@drawable/undo_24px"
+        android:title="Reset"
+        app:showAsAction="ifRoom" />
+
+</menu>

--- a/app/src/main/res/menu/menu_keyboard_settings.xml
+++ b/app/src/main/res/menu/menu_keyboard_settings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/action_toggle_visibility"
+        android:icon="@android:drawable/ic_menu_view"
+        android:title="Toggle Controls"
+        app:showAsAction="ifRoom" />
+</menu>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -31,6 +31,9 @@
         <action
             android:id="@+id/action_navigation_setting_to_ngWordFragment"
             app:destination="@id/ngWordFragment" />
+        <action
+            android:id="@+id/action_navigation_setting_to_keyCandidateLetterSizeFragment"
+            app:destination="@id/keyCandidateLetterSizeFragment" />
     </fragment>
     <fragment
         android:id="@+id/openSourceFragment"
@@ -114,5 +117,10 @@
         android:id="@+id/ngWordFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.ng_word.ui.NgWordFragment"
         android:label="@string/ng_word_fragment_title" />
+    <fragment
+        android:id="@+id/keyCandidateLetterSizeFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.key_candidate_letter_size.KeyCandidateLetterSizeFragment"
+        android:label="@string/fragment_key_candidate_letter_size_title"
+        tools:layout="@layout/fragment_key_candidate_letter_size" />
 
 </navigation>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -34,6 +34,9 @@
         <action
             android:id="@+id/action_navigation_setting_to_keyCandidateLetterSizeFragment"
             app:destination="@id/keyCandidateLetterSizeFragment" />
+        <action
+            android:id="@+id/action_navigation_setting_to_candidateViewHeightSettingFragment"
+            app:destination="@id/candidateViewHeightSettingFragment" />
     </fragment>
     <fragment
         android:id="@+id/openSourceFragment"
@@ -122,5 +125,10 @@
         android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.key_candidate_letter_size.KeyCandidateLetterSizeFragment"
         android:label="@string/fragment_key_candidate_letter_size_title"
         tools:layout="@layout/fragment_key_candidate_letter_size" />
+    <fragment
+        android:id="@+id/candidateViewHeightSettingFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.candidate_view_height_setting.CandidateViewHeightSettingFragment"
+        android:label="@string/candidate_view_height_setting_fragment_title"
+        tools:layout="@layout/fragment_candidate_view_height_setting" />
 
 </navigation>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -296,4 +296,7 @@
     <string name="keyboard_theme_dialog_title">ベースカラーの選択</string>
     <string name="delete_key_left_flick_title">削除キーの左フリック</string>
     <string name="delete_key_left_summary">削除キーを左にフリックすると、カーソルの前にある特定の記号までの文字列もしくは全ての文字列をまとめて削除します。\n（対象: 句読点「。、！？」、括弧「「」『』」、記号「ー」、コンマ「,」、ピリオド「.」）</string>
+    <string name="key_candidate_letter_size_preference_title">キー・変換候補の文字サイズ</string>
+    <string name="key_candidate_letter_size_preference_summary">キーボードのキーと変換候補に表示される文字の大きさを設定できます</string>
+    <string name="fragment_key_candidate_letter_size_title">文字の大きさ</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -304,4 +304,5 @@
     <string name="setting_key_letter_size">キーの文字サイズ</string>
     <string name="setting_key_icon_size">キーアイコンのサイズ（通常）</string>
     <string name="setting_mode_switch_key_icon_size">モード切替キーのアイコンサイズ</string>
+    <string name="candidate_view_height_setting_fragment_title">変換欄の高さ</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -305,4 +305,6 @@
     <string name="setting_key_icon_size">キーアイコンのサイズ（通常）</string>
     <string name="setting_mode_switch_key_icon_size">モード切替キーのアイコンサイズ</string>
     <string name="candidate_view_height_setting_fragment_title">変換欄の高さ</string>
+    <string name="candidate_height_preference_title">変換欄の高さ</string>
+    <string name="candidate_height_preference_sumary">変換候補を表示するレイアウトの高さの設定ができます</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -297,6 +297,11 @@
     <string name="delete_key_left_flick_title">削除キーの左フリック</string>
     <string name="delete_key_left_summary">削除キーを左にフリックすると、カーソルの前にある特定の記号までの文字列もしくは全ての文字列をまとめて削除します。\n（対象: 句読点「。、！？」、括弧「「」『』」、記号「ー」、コンマ「,」、ピリオド「.」）</string>
     <string name="key_candidate_letter_size_preference_title">キー・変換候補の文字サイズ</string>
-    <string name="key_candidate_letter_size_preference_summary">キーボードのキーと変換候補に表示される文字の大きさを設定できます</string>
+    <string name="key_candidate_letter_size_preference_summary">キーボードのキーと変換候補に表示される文字の大きさを設定できます(※日本語かなのみ)</string>
     <string name="fragment_key_candidate_letter_size_title">文字の大きさ</string>
+
+    <string name="setting_candidate_letter_size">候補欄の文字サイズ</string>
+    <string name="setting_key_letter_size">キーの文字サイズ</string>
+    <string name="setting_key_icon_size">キーアイコンのサイズ（通常）</string>
+    <string name="setting_mode_switch_key_icon_size">モード切替キーのアイコンサイズ</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -295,4 +295,9 @@
     <string name="keyboard_theme_dialog_title">Select Base Color</string>
     <string name="delete_key_left_flick_title">Delete Key Left Flick</string>
     <string name="delete_key_left_summary">When you flick the delete key to the left, it deletes the text or symbols before the cursor. \n(Targets: punctuation [。、!?], brackets [「」『』], symbol [ー], comma [,], and period [.])</string>
+    <string name="key_candidate_letter_size_preference_title">Key and Candidate Text Size</string>
+    <string name="key_candidate_letter_size_preference_summary">Adjust the size of the characters shown on the keyboard keys and conversion candidates.</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
+    <string name="fragment_key_candidate_letter_size_title">Letter Size</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -304,4 +304,6 @@
     <string name="setting_key_icon_size">Key icon size (Standard)</string>
     <string name="setting_mode_switch_key_icon_size">Mode switch key icon size</string>
     <string name="candidate_view_height_setting_fragment_title">Candidate View height</string>
+    <string name="candidate_height_preference_title">Candidate Height</string>
+    <string name="candidate_height_preference_sumary">Adjust the height of the candidate bar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -303,4 +303,5 @@
     <string name="setting_key_letter_size">Key letter size</string>
     <string name="setting_key_icon_size">Key icon size (Standard)</string>
     <string name="setting_mode_switch_key_icon_size">Mode switch key icon size</string>
+    <string name="candidate_view_height_setting_fragment_title">Candidate View height</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -297,7 +297,10 @@
     <string name="delete_key_left_summary">When you flick the delete key to the left, it deletes the text or symbols before the cursor. \n(Targets: punctuation [。、!?], brackets [「」『』], symbol [ー], comma [,], and period [.])</string>
     <string name="key_candidate_letter_size_preference_title">Key and Candidate Text Size</string>
     <string name="key_candidate_letter_size_preference_summary">Adjust the size of the characters shown on the keyboard keys and conversion candidates.</string>
-    <!-- TODO: Remove or change this placeholder text -->
-    <string name="hello_blank_fragment">Hello blank fragment</string>
     <string name="fragment_key_candidate_letter_size_title">Letter Size</string>
+
+    <string name="setting_candidate_letter_size">Candidate letter size</string>
+    <string name="setting_key_letter_size">Key letter size</string>
+    <string name="setting_key_icon_size">Key icon size (Standard)</string>
+    <string name="setting_mode_switch_key_icon_size">Mode switch key icon size</string>
 </resources>

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -25,11 +25,18 @@
             android:title="@string/keyboard_screen_size_preference_title" />
 
         <Preference
+            android:icon="@drawable/outline_border_color_24"
+            android:key="candidate_view_height_setting_fragment_preference"
+            android:title="変換候補の高さ"
+            app:summary="変換候補を表示するレイアウトの高さの設定ができます" />
+
+        <Preference
             android:key="keyboard_theme_fragment_preference"
             android:title="@string/keyboard_theme_title"
             app:summary="@string/keyboard_theme_summary" />
 
         <Preference
+            android:icon="@drawable/outline_border_color_24"
             android:key="keyboard_key_letter_size_fragment_preference"
             android:title="@string/key_candidate_letter_size_preference_title"
             app:summary="@string/key_candidate_letter_size_preference_summary" />

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -29,6 +29,11 @@
             android:title="@string/keyboard_theme_title"
             app:summary="@string/keyboard_theme_summary" />
 
+        <Preference
+            android:key="keyboard_key_letter_size_fragment_preference"
+            android:title="@string/key_candidate_letter_size_preference_title"
+            app:summary="@string/key_candidate_letter_size_preference_summary" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="keyboard_height_fix_enable_preference"

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -25,12 +25,6 @@
             android:title="@string/keyboard_screen_size_preference_title" />
 
         <Preference
-            android:icon="@drawable/outline_border_color_24"
-            android:key="candidate_view_height_setting_fragment_preference"
-            android:title="変換候補の高さ"
-            app:summary="変換候補を表示するレイアウトの高さの設定ができます" />
-
-        <Preference
             android:key="keyboard_theme_fragment_preference"
             android:title="@string/keyboard_theme_title"
             app:summary="@string/keyboard_theme_summary" />
@@ -76,6 +70,12 @@
                 android:title="@string/candidate_tab"
                 app:defaultValue="false"
                 app:summary="@string/candidate_tab_summary" />
+
+            <Preference
+                android:icon="@drawable/outline_border_color_24"
+                android:key="candidate_view_height_setting_fragment_preference"
+                android:title="変換欄の高さ"
+                app:summary="変換候補を表示するレイアウトの高さの設定ができます" />
 
             <ListPreference
                 android:defaultValue="1"

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -37,12 +37,6 @@
 
         <SwitchPreferenceCompat
             android:defaultValue="false"
-            android:key="keyboard_height_fix_enable_preference"
-            android:summary="@string/keyboard_height_fix_specific_device_summary_on"
-            android:title="@string/keyboard_height_fix_specific_device_title" />
-
-        <SwitchPreferenceCompat
-            android:defaultValue="false"
             android:key="switch_qwerty_keyboard_password_preference"
             android:summaryOff="@string/switch_qwerty_password_summary_off"
             android:summaryOn="@string/switch_qwerty_password_summary_on"
@@ -74,8 +68,8 @@
             <Preference
                 android:icon="@drawable/outline_border_color_24"
                 android:key="candidate_view_height_setting_fragment_preference"
-                android:title="変換欄の高さ"
-                app:summary="変換候補を表示するレイアウトの高さの設定ができます" />
+                android:title="@string/candidate_height_preference_title"
+                app:summary="@string/candidate_height_preference_sumary" />
 
             <ListPreference
                 android:defaultValue="1"
@@ -85,15 +79,6 @@
                 android:key="candidate_column_preference"
                 android:summary="@string/preference_summary_num_column_conversion"
                 android:title="@string/preference_title_num_columns_conversion" />
-
-            <ListPreference
-                android:defaultValue="2"
-                android:dialogTitle="@string/candidate_height_dialog_title"
-                android:entries="@array/candidate_view_height_entries"
-                android:entryValues="@array/candidate_view_height_values"
-                android:key="candidate_view_height_preference"
-                android:summary="@string/candidate_view_height_summary"
-                android:title="@string/candidate_view_height_title" />
 
             <SwitchPreferenceCompat
                 android:defaultValue="true"

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -454,6 +454,22 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
         }
     }
 
+    /**
+     * Sets the text size for the main keys (key1 to key12).
+     * @param size The new text size in sp.
+     */
+    fun setKeyLetterSize(size: Float) {
+        binding.apply {
+            val keyButtons = listOf(
+                key1, key2, key3, key4, key5, key6,
+                key7, key8, key9, key11, key12
+            )
+            keyButtons.forEach { button ->
+                button.textSize = size
+            }
+        }
+    }
+
     private fun setMaterialYouTheme(
         isDarkMode: Boolean,
         isDynamicColorEnable: Boolean

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -5,13 +5,17 @@ import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.Configuration
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.InsetDrawable
+import android.graphics.drawable.ScaleDrawable
 import android.os.Build
 import android.util.AttributeSet
 import android.util.Log
+import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
+import android.widget.ImageView
 import android.widget.PopupWindow
 import androidx.appcompat.widget.AppCompatButton
 import androidx.appcompat.widget.AppCompatImageButton
@@ -467,6 +471,112 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
             keyButtons.forEach { button ->
                 button.textSize = size
             }
+        }
+    }
+
+    /**
+     * Sets the padding for the side/icon keys.
+     * @param paddingInPx The padding value in pixels to be applied uniformly.
+     */
+    fun setKeyIconPadding(paddingInPx: Int) {
+        binding.apply {
+            val iconKeys = listOf(
+                keySmallLetter, keyReturn, keySoftLeft, keyMoveCursorRight,
+                sideKeySymbol, keyDelete, keySpace, keyEnter
+            )
+            iconKeys.forEach { view ->
+                view.setPadding(paddingInPx)
+                view.scaleType = ImageView.ScaleType.FIT_CENTER
+            }
+        }
+    }
+
+    /**
+     * Applies padding ONLY to the keySwitchKeyMode key.
+     * @param paddingInPx The absolute padding value from its dedicated SeekBar.
+     */
+    fun setKeySwitchKeyModePadding(paddingInPx: Int) {
+        binding.keySwitchKeyMode.setPadding(paddingInPx)
+    }
+
+    /**
+     * Scales the size of the side/icon keys.
+     * @param scale The scale factor. 1.0f is normal size.
+     */
+    fun setKeyIconScale(scale: Float) {
+        binding.apply {
+            val iconKeys = listOf(
+                keySmallLetter, keyReturn, keySoftLeft, keyMoveCursorRight,
+                sideKeySymbol, keySwitchKeyMode, keyDelete, keySpace, keyEnter
+            )
+            iconKeys.forEach { view ->
+                view.scaleX = scale
+                view.scaleY = scale
+            }
+        }
+    }
+
+    /**
+     * Resizes only the icon drawable within the ImageButton.
+     * @param scale The desired scale of the icon. 1.0f is default size,
+     * 0.5f is half size, 1.5f is 50% larger, etc.
+     */
+    fun setKeyIconDrawableScale(scale: Float) {
+        binding.apply {
+            val iconKeys = listOf(
+                keySmallLetter, keyReturn, keySoftLeft, keyMoveCursorRight,
+                sideKeySymbol, keySwitchKeyMode, keyDelete, keySpace, keyEnter
+            )
+
+            iconKeys.forEach { view ->
+                // Check if we've already created a ScaleDrawable for this view
+                var scaleDrawable = view.tag as? ScaleDrawable
+
+                if (scaleDrawable == null) {
+                    // First time: create the wrapper
+                    val originalDrawable = view.drawable
+                    scaleDrawable = ScaleDrawable(originalDrawable, Gravity.CENTER, 1f, 1f)
+
+                    // Replace the button's drawable with our new wrapper
+                    view.setImageDrawable(scaleDrawable)
+                    // Store it in the tag for future updates
+                    view.tag = scaleDrawable
+                }
+
+                // Convert the scale (e.g., 1.2f) to a level (0-10000)
+                // We'll cap the max scale at 2.0f (200%) for this example
+                val level = (scale.coerceIn(0f, 2f) / 2f * 10000).toInt()
+                scaleDrawable.level = level
+            }
+        }
+    }
+
+    /**
+     * Sets the visual size of the icons inside the ImageButtons by wrapping them in an InsetDrawable.
+     * @param insetInPx The inset in pixels. A larger value makes the icon appear smaller.
+     */
+    fun setKeyIconSize(insetInPx: Int) {
+        binding.apply {
+            val deleteDrawable =
+                ContextCompat.getDrawable(context, com.kazumaproject.core.R.drawable.backspace_24px)
+            keyDelete.setImageDrawable(InsetDrawable(deleteDrawable, insetInPx))
+            keyReturn.setImageDrawable(InsetDrawable(cachedUndoDrawable, insetInPx))
+            keySoftLeft.setImageDrawable(InsetDrawable(cachedArrowLeftDrawable, insetInPx))
+            sideKeySymbol.setImageDrawable(InsetDrawable(cachedSymbolDrawable, insetInPx))
+            keyMoveCursorRight.setImageDrawable(InsetDrawable(cachedArrowRightDrawable, insetInPx))
+            keySpace.setImageDrawable(InsetDrawable(cachedSpaceDrawable, insetInPx))
+
+            // This key changes its icon based on the input mode, so we must check the current state.
+            val smallLetterDrawable = if (currentInputMode.value == InputMode.ModeNumber) {
+                cachedNumberSmallDrawable
+            } else {
+                cachedLanguageDrawable
+            }
+            keySmallLetter.setImageDrawable(InsetDrawable(smallLetterDrawable, insetInPx))
+
+            keySwitchKeyMode.setPadding(insetInPx)
+
+            keyEnter.setPadding(insetInPx)
         }
     }
 


### PR DESCRIPTION
## Issue
#168  #289  #356 #357 

## 概要
### 変換欄、変換候補
一部端末で、変換候補を表示すると変換欄の上部に空白ができる不具合がありました。端末のフォントサイズを小さく設定している場合に発生することを確認しています。これまでは個別に対処していましたが、今回の更新でアプリ内から「候補文字サイズ」と「変換欄の高さ」を調整できるようにし、根本対応しました。併せて、Galaxy を検知するための不要な Preference などを削除しています。

- 不具合修正：フォントサイズが小さい端末で、変換候補表示時に変換欄上部に空白が生じる問題を解消
- 機能追加：候補文字サイズ／変換欄の高さをアプリ設定から調整可能に
- クリーンアップ：Galaxy 検知用の不要な設定を削除

### テンキーと QWERTY で幅、高さ、位置 の個別の設定の追加