### PR TITLE
クリップボードを検知した際に変換欄に表示、非表示する設定とキーボードを角丸にする設定の追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 554
-        versionName "1.4.433"
+        versionCode 555
+        versionName "1.4.434"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -121,6 +121,12 @@ object AppPreference {
     private val CANDIDATE_VIEW_EMPTY_HEIGHT_DP =
         Pair("candidate_view_empty_height_dp_preference", 110)
 
+    private val CLIP_BOARD_PREVIEW_PREFERENCE =
+        Pair("clipboard_preview_enable_preference", true)
+
+    private val ROUND_KEYBOARD_CORNER_PREFERENCE =
+        Pair("round_corner_keyboard_preference", false)
+
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
     }
@@ -596,6 +602,24 @@ object AppPreference {
         get() = preferences.getFloat(CANDIDATE_LETTER_SIZE.first, CANDIDATE_LETTER_SIZE.second)
         set(value) = preferences.edit {
             it.putFloat(CANDIDATE_LETTER_SIZE.first, value ?: CANDIDATE_LETTER_SIZE.second)
+        }
+
+    var clipboard_preview_preference: Boolean
+        get() = preferences.getBoolean(
+            CLIP_BOARD_PREVIEW_PREFERENCE.first,
+            CLIP_BOARD_PREVIEW_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(CLIP_BOARD_PREVIEW_PREFERENCE.first, value)
+        }
+
+    var keyboard_corner_round_preference: Boolean
+        get() = preferences.getBoolean(
+            ROUND_KEYBOARD_CORNER_PREFERENCE.first,
+            ROUND_KEYBOARD_CORNER_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(ROUND_KEYBOARD_CORNER_PREFERENCE.first, value)
         }
 
     fun migrateSumirePreferenceIfNeeded() {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/adapter/KeyboardViewPagerAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/adapter/KeyboardViewPagerAdapter.kt
@@ -1,17 +1,19 @@
 package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.keyboard_size_setting.adapter
 
+import android.annotation.SuppressLint
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.recyclerview.widget.RecyclerView
 import com.kazumaproject.markdownhelperkeyboard.R
+import com.kazumaproject.qwerty_keyboard.ui.QWERTYKeyboardView
+import com.kazumaproject.tenkey.TenKey
 
 class KeyboardViewPagerAdapter : RecyclerView.Adapter<KeyboardViewPagerAdapter.ViewHolder>() {
 
-    // 表示するページのレイアウトリスト
     private val pageLayouts = listOf(
         R.layout.page_tenkey,
-        R.layout.page_qwerty // QWERTYレイアウトを追加
+        R.layout.page_qwerty
     )
 
     companion object {
@@ -24,8 +26,21 @@ class KeyboardViewPagerAdapter : RecyclerView.Adapter<KeyboardViewPagerAdapter.V
         return ViewHolder(view)
     }
 
+    @SuppressLint("ClickableViewAccessibility")
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        // 必要に応じて、各ページのビューに対する処理をここに記述
+        when (position) {
+            TEN_KEY_PAGE_POSITION -> {
+                holder.tenKeyView?.setOnTouchListener { _, _ ->
+                    true
+                }
+            }
+
+            QWERTY_PAGE_POSITION -> {
+                holder.qwertyView?.setOnTouchListener { _, _ ->
+                    true
+                }
+            }
+        }
     }
 
     override fun getItemCount(): Int = pageLayouts.size
@@ -34,5 +49,10 @@ class KeyboardViewPagerAdapter : RecyclerView.Adapter<KeyboardViewPagerAdapter.V
         return pageLayouts[position]
     }
 
-    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView)
+    // Updated ViewHolder to hold references to the specific keyboard views
+    class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        // These can be nullable because a given layout will only have one of them.
+        val tenKeyView: TenKey? = itemView.findViewById(R.id.keyboard_view)
+        val qwertyView: QWERTYKeyboardView? = itemView.findViewById(R.id.qwerty_view)
+    }
 }

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -307,4 +307,10 @@
     <string name="candidate_view_height_setting_fragment_title">変換欄の高さ</string>
     <string name="candidate_height_preference_title">変換欄の高さ</string>
     <string name="candidate_height_preference_sumary">変換候補を表示するレイアウトの高さの設定ができます</string>
+
+    <string name="pref_clipboard_preview_title">クリップボードの内容を変換欄に表示</string>
+    <string name="pref_clipboard_preview_summary">クリップボードにコピーした文字や画像を検知したとき、変換欄に表示します。</string>
+
+    <string name="pref_round_corner_keyboard_title">キーボードの角を丸くする</string>
+    <string name="pref_round_corner_keyboard_summary">オンにすると、キーボード枠の四隅が丸くなります</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -306,4 +306,10 @@
     <string name="candidate_view_height_setting_fragment_title">Candidate View height</string>
     <string name="candidate_height_preference_title">Candidate Height</string>
     <string name="candidate_height_preference_sumary">Adjust the height of the candidate bar</string>
+
+    <string name="pref_clipboard_preview_title">Show clipboard contents in the conversion bar</string>
+    <string name="pref_clipboard_preview_summary">When text or images are copied to the clipboard, show them in the conversion bar.</string>
+
+    <string name="pref_round_corner_keyboard_title">Round the keyboard’s corners</string>
+    <string name="pref_round_corner_keyboard_summary">When on, all four corners of the keyboard are rounded.</string>
 </resources>

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -40,8 +40,13 @@
             android:key="switch_qwerty_keyboard_password_preference"
             android:summaryOff="@string/switch_qwerty_password_summary_off"
             android:summaryOn="@string/switch_qwerty_password_summary_on"
-            android:title="@string/switch_qwerty_preference_title"
-            app:defaultValue="false" />
+            android:title="@string/switch_qwerty_preference_title" />
+
+        <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="round_corner_keyboard_preference"
+            android:summary="@string/pref_round_corner_keyboard_summary"
+            android:title="@string/pref_round_corner_keyboard_title" />
 
         <PreferenceCategory android:title="@string/conversion_preference_title">
             <SeekBarPreference
@@ -117,6 +122,12 @@
                 android:key="undo_enable_preference"
                 android:summary="@string/undo_enable_summary"
                 android:title="@string/undo_enable_title" />
+
+            <SwitchPreferenceCompat
+                android:defaultValue="true"
+                android:key="clipboard_preview_enable_preference"
+                android:summary="@string/pref_clipboard_preview_summary"
+                android:title="@string/pref_clipboard_preview_title" />
 
             <SwitchPreferenceCompat
                 android:defaultValue="false"

--- a/core/src/main/res/drawable/recyclerview_item_bg.xml
+++ b/core/src/main/res/drawable/recyclerview_item_bg.xml
@@ -11,7 +11,7 @@
     <!-- Normal state -->
     <item>
         <shape>
-            <solid android:color="@color/keyboard_bg" /> <!-- Normal background color -->
+            <solid android:color="@android:color/transparent" /> <!-- Normal background color -->
             <corners android:radius="16dp" /> <!-- Rounded corners -->
         </shape>
     </item>

--- a/core/src/main/res/drawable/recyclerview_item_bg_material.xml
+++ b/core/src/main/res/drawable/recyclerview_item_bg_material.xml
@@ -11,7 +11,7 @@
     <!-- Normal state -->
     <item>
         <shape>
-            <solid android:color="?attr/colorSurfaceContainer" /> <!-- Normal background color -->
+            <solid android:color="@android:color/transparent" /> <!-- Normal background color -->
             <corners android:radius="16dp" /> <!-- Rounded corners -->
         </shape>
     </item>

--- a/core/src/main/res/drawable/rounded_corners_bg_material_dark.xml
+++ b/core/src/main/res/drawable/rounded_corners_bg_material_dark.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainer" />
+    <corners
+       android:topRightRadius="32dp"
+        android:topLeftRadius="32dp"/>
+</shape>

--- a/core/src/main/res/drawable/rounded_corners_bg_material_root.xml
+++ b/core/src/main/res/drawable/rounded_corners_bg_material_root.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainer" />
+    <corners android:radius="32dp" />
+</shape>

--- a/core/src/main/res/drawable/rounded_corners_bg_root.xml
+++ b/core/src/main/res/drawable/rounded_corners_bg_root.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/keyboard_bg" />
+    <corners android:radius="32dp" />
+</shape>

--- a/core/src/main/res/drawable/rounded_corners_bg_suggestion.xml
+++ b/core/src/main/res/drawable/rounded_corners_bg_suggestion.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/keyboard_bg" />
+    <corners
+        android:topLeftRadius="32dp"
+        android:topRightRadius="32dp" />
+</shape>

--- a/core/src/main/res/drawable/square_corners_bg_material_root.xml
+++ b/core/src/main/res/drawable/square_corners_bg_material_root.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="?attr/colorSurfaceContainer" />/>
+</shape>

--- a/core/src/main/res/drawable/square_corners_bg_root.xml
+++ b/core/src/main/res/drawable/square_corners_bg_root.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/keyboard_bg" />
+</shape>


### PR DESCRIPTION
## Issue
#359 #374 

## 概要
- キーボードの位置とサイズの設定をするときキーをタップしてしまうとフリック画面が出てきてしまい操作できなくなるバグの修正
- クリップボードを検知した際に変換欄に表示、非表示にする設定の追加
- キーボードの角丸にする設定の追加