### PR TITLE
QWERTY が Password タイプのエディタの場合、英字フリックに戻るバグの修正

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -813,9 +813,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         suggestionClickNum = 0
         if (!restarting) {
             setCurrentInputType(editorInfo)
-            resetKeyboard()
             if (qwertyMode.value == TenKeyQWERTYMode.Sumire) {
                 mainLayoutBinding?.let { mainView ->
+                    val excludeResetKeyboardOrderFlag =
+                        mainView.keyboardView.currentInputMode.value == InputMode.ModeEnglish && switchQWERTYPassword == true && currentInputType in passwordTypes
+                    if (!excludeResetKeyboardOrderFlag) {
+                        resetKeyboard()
+                    }
                     Timber.d("TenKeyQWERTYMode.Sumire: ${mainView.keyboardView.currentInputMode.value} ${switchQWERTYPassword}")
                     when (mainView.keyboardView.currentInputMode.value) {
                         InputMode.ModeJapanese -> {


### PR DESCRIPTION
## Issue
#435 

## 概要
バグの原因は、onStartInputView でキーボードの順番をリセットする関数が実行されていたことでした。
これを修正し、英語モード＋パスワード入力時 に QWERTY に自動切り替えを行う設定（Preference） が有効で、かつ入力エディタがパスワードタイプの場合は、このリセット関数を実行しないようにしました。