### PR TITLE
QWERTY ローマ字の ｔ と ｙ の長押しの記号の表示が違うバグの修正

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -8083,6 +8083,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                             } else {
                                                 c
                                             }
+                                            Timber.d("QWERTY romaji : $charToAppend")
                                             sb.append(insertString).append(charToAppend)
                                             romajiConverter?.let { converter ->
                                                 _inputString.update {
@@ -8100,6 +8101,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                                 } else {
                                                     c
                                                 }
+                                            Timber.d("QWERTY romaji 2: $charToAppend")
                                             _inputString.update {
                                                 converter.convertQWERTYZenkaku(
                                                     charToAppend.toString()

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/romaji_kana/RomajiKanaConverter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/romaji_kana/RomajiKanaConverter.kt
@@ -485,7 +485,7 @@ class RomajiKanaConverter(private val romajiToKana: Map<String, Pair<String, Int
             val currentChar = text[i]
 
             // 1. '[' または ']' の場合は、変換せずにそのまま追加し、次の文字へ進む
-            if (currentChar == '[' || currentChar == ']') {
+            if (currentChar == '［' || currentChar == '］') {
                 result.append(currentChar)
                 i++
                 continue


### PR DESCRIPTION
## Issue
#431 