### PR TITLE
数字を入力したときに全角になってしまう不具合の修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 574
-        versionName "1.4.453"
+        versionCode 575
+        versionName "1.4.454"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
@@ -610,8 +610,18 @@ class KanaKanjiEngine {
             isOmissionSearchEnable = isOmissionSearchEnable
         )
 
-        val resultNBestFinalDeferred: List<Candidate> =
+        val resultNBestFinalDeferred: List<Candidate> = if (graph.isEmpty()) {
+            listOf(
+                Candidate(
+                    string = input,
+                    type = (1).toByte(),
+                    length = input.length.toUByte(),
+                    score = 4000
+                )
+            )
+        } else {
             findPath.backwardAStar(graph, input.length, connectionIds, n)
+        }
 
         if (input.isDigitsOnly()) {
             // 1. Generate full-width, time, and date candidates as before.
@@ -1076,8 +1086,20 @@ class KanaKanjiEngine {
             isOmissionSearchEnable = isOmissionSearchEnable
         )
 
-        val resultNBestFinalDeferred: Pair<List<Candidate>, List<Int>> =
+        val resultNBestFinalDeferred: Pair<List<Candidate>, List<Int>> = if (graph.isEmpty()) {
+            Pair(
+                listOf(
+                    Candidate(
+                        string = input,
+                        type = (1).toByte(),
+                        length = input.length.toUByte(),
+                        score = 4000
+                    )
+                ), emptyList()
+            )
+        } else {
             findPath.backwardAStarWithBunsetsu(graph, input.length, connectionIds, n)
+        }
 
         if (input.isDigitsOnly()) {
             // 1. Generate full-width, time, and date candidates as before.
@@ -1663,9 +1685,9 @@ class KanaKanjiEngine {
 
         val englishDeferred = if (input.isAllEnglishLetters()) {
             englishEngine.getCandidates(input)
-        }else if (input.isAllFullWidthAscii()){
+        } else if (input.isAllFullWidthAscii()) {
             englishEngine.getCandidates(input.toHankakuAlphabet())
-        }  else {
+        } else {
             emptyList()
         }
 
@@ -1982,8 +2004,18 @@ class KanaKanjiEngine {
             isOmissionSearchEnable = isOmissionSearchEnable
         )
 
-        val resultNBestFinalDeferred: List<Candidate> =
+        val resultNBestFinalDeferred: List<Candidate> = if (graph.isEmpty()) {
+            listOf(
+                Candidate(
+                    string = input,
+                    type = (1).toByte(),
+                    length = input.length.toUByte(),
+                    score = 4000
+                )
+            )
+        } else {
             findPath.backwardAStar(graph, input.length, connectionIds, n)
+        }
 
         if (input.isDigitsOnly()) {
             // 1. Generate full-width, time, and date candidates as before.
@@ -2405,8 +2437,18 @@ class KanaKanjiEngine {
             isOmissionSearchEnable = false
         )
 
-        val resultNBestFinalDeferred: List<Candidate> =
+        val resultNBestFinalDeferred: List<Candidate> = if (graph.isEmpty()) {
+            listOf(
+                Candidate(
+                    string = input,
+                    type = (1).toByte(),
+                    length = input.length.toUByte(),
+                    score = 4000
+                )
+            )
+        } else {
             findPath.backwardAStar(graph, input.length, connectionIds, n)
+        }
 
         if (input.isDigitsOnly()) {
             // 1. Generate full-width, time, and date candidates as before.
@@ -2826,8 +2868,20 @@ class KanaKanjiEngine {
             isOmissionSearchEnable = false
         )
 
-        val resultNBestFinalDeferred: Pair<List<Candidate>, List<Int>> =
+        val resultNBestFinalDeferred: Pair<List<Candidate>, List<Int>> = if (graph.isEmpty()) {
+            Pair(
+                listOf(
+                    Candidate(
+                        string = input,
+                        type = (1).toByte(),
+                        length = input.length.toUByte(),
+                        score = 4000
+                    )
+                ), emptyList()
+            )
+        } else {
             findPath.backwardAStarWithBunsetsu(graph, input.length, connectionIds, n)
+        }
 
         if (input.isDigitsOnly()) {
             // 1. Generate full-width, time, and date candidates as before.


### PR DESCRIPTION
## Issue
#450 

## 概要
変換エンジン内で graph が空の場合、単一の `Candidate` のアイテムを含んだリストを返すように修正した。