### PR TITLE
[QWERTY] ローマ字変換においてShift直後の1キーのみが大文字英字にする設定の追加

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -370,6 +370,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var qwertyShowSwitchRomajiEnglishPreference: Boolean? = false
     private var qwertyShowKutoutenButtonsPreference: Boolean? = false
     private var qwertyShowKeymapSymbolsPreference: Boolean? = false
+    private var qwertyRomajiShiftConversionPreference: Boolean? = false
     private var showCandidateInPasswordPreference: Boolean? = true
     private var showCandidateInPasswordComposePreference: Boolean? = false
     private var isVibration: Boolean? = true
@@ -704,6 +705,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             qwertyShowKutoutenButtonsPreference = qwerty_show_kutouten_buttons ?: false
             showCandidateInPasswordPreference = show_candidates_password ?: true
             qwertyShowKeymapSymbolsPreference = qwerty_show_keymap_symbols ?: false
+            qwertyRomajiShiftConversionPreference = qwerty_romaji_shift_conversion_preference
             showCandidateInPasswordComposePreference = show_candidates_password_compose ?: false
             isNgWordEnable = ng_word_preference ?: true
             deleteKeyHighLight = delete_key_high_light_preference ?: true
@@ -1123,6 +1125,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         qwertyShowCursorButtonsPreference = null
         qwertyShowNumberButtonsPreference = null
         qwertyShowSwitchRomajiEnglishPreference = null
+        qwertyRomajiShiftConversionPreference = null
         qwertyShowPopupWindowPreference = null
         switchQWERTYPassword = null
         shortcutTollbarVisibility = null
@@ -7893,7 +7896,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         else -> {
                             if (mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                                 if (insertString.isNotEmpty()) {
-                                    if (hardKeyboardShiftPressd) {
+                                    if (hardKeyboardShiftPressd && qwertyRomajiShiftConversionPreference != true) {
                                         Timber.d("QWERTY romaji hardKeyboardShiftPressd: $tap")
                                         handleTap(tap, insertString, sb, mainView)
                                     } else {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -173,6 +173,9 @@ object AppPreference {
 
     private val ROMAJI_MAP_DATA_VERSION = Pair("romaji_map_data_version", 0)
 
+    private val QWERTY_ROMAJI_SHIFT_CONVERSION_PREFERENCE =
+        Pair("qwerty_romaji_shift_conversion_preference", false)
+
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
     }
@@ -812,6 +815,15 @@ object AppPreference {
         get() = preferences.getInt(ROMAJI_MAP_DATA_VERSION.first, ROMAJI_MAP_DATA_VERSION.second)
         set(value) = preferences.edit {
             it.putInt(ROMAJI_MAP_DATA_VERSION.first, value)
+        }
+
+    var qwerty_romaji_shift_conversion_preference: Boolean
+        get() = preferences.getBoolean(
+            QWERTY_ROMAJI_SHIFT_CONVERSION_PREFERENCE.first,
+            QWERTY_ROMAJI_SHIFT_CONVERSION_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(QWERTY_ROMAJI_SHIFT_CONVERSION_PREFERENCE.first, value)
         }
 
     fun migrateSumirePreferenceIfNeeded() {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -327,6 +327,7 @@
     <string name="pref_qwerty_shift_key_action_title">Shift キー動作 (ローマ字)</string>
     <string name="pref_qwerty_shift_key_action_summary">Shift 直後の 1 キーのみ大文字英字に統一します</string>
     <string name="pref_clipboard_tap_delete_title">クリップボード タップで候補から削除</string>
-    <string name="pref_clipboard_tap_delete_summary">クリップボード項目をタップしたとき、変換欄から削除します。
-</string>
+    <string name="pref_clipboard_tap_delete_summary">クリップボード項目をタップしたとき、変換欄から削除します。</string>
+    <string name="pref_romaji_shift_title">Shift直後の1文字だけ大文字</string>
+    <string name="pref_romaji_shift_summary">ローマ字入力で、Shiftキーを押した直後の最初の1文字のみをアルファベットの大文字にします。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -330,4 +330,6 @@
     <string name="pref_qwerty_shift_key_action_summary"> Makes only the first letter after Shift uppercase for consistency in all cases</string>
     <string name="pref_clipboard_tap_delete_title">Tap to remove from candidate bar</string>
     <string name="pref_clipboard_tap_delete_summary">When you tap a clipboard item in the candidate bar, it will be removed from the bar.</string>
+    <string name="pref_romaji_shift_title">Capitalize only the first character after Shift</string>
+    <string name="pref_romaji_shift_summary">In romaji input, only the first character after pressing the Shift key becomes uppercase.</string>
 </resources>

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -164,10 +164,10 @@
 
             <SwitchPreferenceCompat
                 android:defaultValue="false"
+                android:dependency="clipboard_preview_enable_preference"
                 android:key="clipboard_preview_tap_delete_preference"
                 android:summary="@string/pref_clipboard_tap_delete_summary"
-                android:title="@string/pref_clipboard_tap_delete_title"
-                android:dependency="clipboard_preview_enable_preference"/>
+                android:title="@string/pref_clipboard_tap_delete_title" />
 
             <SwitchPreferenceCompat
                 android:defaultValue="false"
@@ -275,6 +275,13 @@
                 android:title="@string/qwerty_romaji_english_visibility_title"
                 app:defaultValue="true"
                 app:summary="@string/qwerty_romaji_english_visibility_summary" />
+
+            <SwitchPreferenceCompat
+                android:key="qwerty_romaji_shift_conversion_preference"
+                android:title="@string/pref_romaji_shift_title"
+                app:defaultValue="false"
+                app:summary="@string/pref_romaji_shift_summary" />
+
         </PreferenceCategory>
 
         <PreferenceCategory android:title="@string/category_symbol_keyboard_title">


### PR DESCRIPTION
## Issue
#384 

## 概要
QWERTY のローマ字変換において、 Shift キー押下直後の１文字のみを大文字のアルファベットにする設定の追加