### PR TITLE
五十音キーボードの際に変換候補が表示されないバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 578
-        versionName "1.4.457"
+        versionCode 579
+        versionName "1.4.458"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -373,6 +373,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var qwertyRomajiShiftConversionPreference: Boolean? = false
     private var showCandidateInPasswordPreference: Boolean? = true
     private var showCandidateInPasswordComposePreference: Boolean? = false
+    private var tabletGojuonLayoutPreference: Boolean? = true
     private var isVibration: Boolean? = true
     private var vibrationTimingStr: String? = "both"
     private var mozcUTPersonName: Boolean? = false
@@ -670,6 +671,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         super.onStartInput(attribute, restarting)
         Timber.d("onStartInput: ${Build.MANUFACTURER}")
         Timber.d("onUpdate onStartInput called $restarting ${attribute?.imeOptions}")
+        isTablet = resources.getBoolean(com.kazumaproject.core.R.bool.isTablet)
         if (!restarting) {
             resetAllFlags()
         } else {
@@ -707,6 +709,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             qwertyShowKeymapSymbolsPreference = qwerty_show_keymap_symbols ?: false
             qwertyRomajiShiftConversionPreference = qwerty_romaji_shift_conversion_preference
             showCandidateInPasswordComposePreference = show_candidates_password_compose ?: false
+            tabletGojuonLayoutPreference = tablet_gojuon_layout_preference
             isNgWordEnable = ng_word_preference ?: true
             deleteKeyHighLight = delete_key_high_light_preference ?: true
             customKeyboardSuggestionPreference = custom_keyboard_suggestion_preference ?: true
@@ -1136,6 +1139,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         qwertyShowKeymapSymbolsPreference = null
         showCandidateInPasswordPreference = null
         showCandidateInPasswordComposePreference = null
+        tabletGojuonLayoutPreference = null
         isVibration = null
         tenkeyHeightPreferenceValue = null
         tenkeyWidthPreferenceValue = null
@@ -1449,9 +1453,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     setQWERTYKeyboard(mainView)
                     if (isTablet == true) {
                         setTabletKeyListeners(mainView)
-                    } else {
-                        setTenKeyListeners(mainView)
                     }
+                    setTenKeyListeners(mainView)
                     setKeyboardSizeSwitchKeyboard(mainView)
                     updateClipboardPreview()
                     mainView.suggestionRecyclerView.isVisible = suggestionViewStatus.value
@@ -3606,11 +3609,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             when (type) {
                 KeyboardType.TENKEY -> {
                     if (qwertyMode.value != TenKeyQWERTYMode.Number) {
-                        if (isTablet == true) {
+                        if (isTablet == true && tabletGojuonLayoutPreference == true) {
                             tabletView.isVisible = true
                             tabletView.resetLayout()
+                            keyboardView.isVisible = false
                         } else {
                             keyboardView.isVisible = true
+                            tabletView.isVisible = false
                         }
                         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.Default }
                     } else {
@@ -5842,8 +5847,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 customLayoutDefault.visibility = View.INVISIBLE
                             }
 
-                            tabletView.isVisible -> {
+                            tabletView.isVisible && tabletGojuonLayoutPreference == true -> {
                                 tabletView.visibility = View.INVISIBLE
+                            }
+
+                            tabletView.isVisible && tabletGojuonLayoutPreference != true -> {
+                                keyboardView.visibility = View.INVISIBLE
                             }
 
                             keyboardView.isVisible -> {
@@ -5920,10 +5929,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.Default, emptyList()
                         )
                         mainView.apply {
-                            if (isTablet == true) {
+                            if (isTablet == true && tabletGojuonLayoutPreference == true) {
                                 tabletView.isVisible = true
+                                keyboardView.isVisible = false
                             } else {
                                 keyboardView.isVisible = true
+                                tabletView.isVisible = false
                             }
                             qwertyView.isVisible = false
                             customLayoutDefault.isVisible = false
@@ -5935,7 +5946,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.TenKeyQWERTY, emptyList()
                         )
                         mainView.apply {
-                            if (isTablet == true) {
+                            if (isTablet == true && tabletGojuonLayoutPreference == true) {
                                 tabletView.isVisible = false
                             } else {
                                 keyboardView.isVisible = false
@@ -5951,7 +5962,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.TenKeyQWERTY, emptyList()
                         )
                         mainView.apply {
-                            if (isTablet == true) {
+                            if (isTablet == true && tabletGojuonLayoutPreference == true) {
                                 tabletView.isVisible = false
                             } else {
                                 keyboardView.isVisible = false
@@ -5971,7 +5982,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.Custom, customLayouts
                         )
                         mainView.apply {
-                            if (isTablet == true) {
+                            if (isTablet == true && tabletGojuonLayoutPreference == true) {
                                 tabletView.isVisible = false
                             } else {
                                 keyboardView.isVisible = false
@@ -5986,7 +5997,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.Sumire, emptyList()
                         )
                         mainView.apply {
-                            if (isTablet == true) {
+                            if (isTablet == true && tabletGojuonLayoutPreference == true) {
                                 tabletView.isVisible = false
                             } else {
                                 keyboardView.isVisible = false
@@ -6001,7 +6012,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.Sumire, emptyList()
                         )
                         mainView.apply {
-                            if (isTablet == true) {
+                            if (isTablet == true && tabletGojuonLayoutPreference == true) {
                                 tabletView.isVisible = false
                             } else {
                                 keyboardView.isVisible = false
@@ -6273,6 +6284,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             (mainView.keyboardSymbolView.layoutParams as? FrameLayout.LayoutParams)?.let { param ->
                 param.height = heightPx
                 param.width = finalKeyboardWidth
+                mainView.keyboardSymbolView.layoutParams = param
+            }
+        }
+
+        if (isTablet == true) {
+            (mainView.tabletView.layoutParams as? FrameLayout.LayoutParams)?.let { param ->
+                param.height = heightPx
                 mainView.keyboardSymbolView.layoutParams = param
             }
         }
@@ -7896,21 +7914,57 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         else -> {
                             if (mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                                 if (insertString.isNotEmpty()) {
-                                    if (hardKeyboardShiftPressd && qwertyRomajiShiftConversionPreference != true) {
-                                        Timber.d("QWERTY romaji hardKeyboardShiftPressd: $tap")
-                                        handleTap(tap, insertString, sb, mainView)
-                                    } else {
-                                        tap?.let { c ->
-                                            val charToAppend = if (isDefaultRomajiHenkanMap) {
-                                                c.toZenkaku()
-                                            } else {
-                                                c
+                                    Timber.d("QWERTY romaji not empty: $hardKeyboardShiftPressd $qwertyRomajiShiftConversionPreference")
+                                    if (qwertyRomajiShiftConversionPreference == true){
+                                        if (hardKeyboardShiftPressd) {
+                                            Timber.d("QWERTY romaji hardKeyboardShiftPressd: $tap")
+                                            tap?.let { c ->
+                                                val charToAppend = if (isDefaultRomajiHenkanMap && c.isLowerCase()) {
+                                                    c.toZenkaku()
+                                                } else {
+                                                    c
+                                                }
+                                                Timber.d("QWERTY romaji : $charToAppend")
+                                                sb.append(insertString).append(charToAppend)
+                                                romajiConverter?.let { converter ->
+                                                    _inputString.update {
+                                                        converter.convertQWERTYZenkaku(sb.toString())
+                                                    }
+                                                }
                                             }
-                                            Timber.d("QWERTY romaji : $charToAppend")
-                                            sb.append(insertString).append(charToAppend)
-                                            romajiConverter?.let { converter ->
-                                                _inputString.update {
-                                                    converter.convertQWERTYZenkaku(sb.toString())
+                                        } else {
+                                            tap?.let { c ->
+                                                val charToAppend = if (isDefaultRomajiHenkanMap) {
+                                                    c.toZenkaku()
+                                                } else {
+                                                    c
+                                                }
+                                                Timber.d("QWERTY romaji : $charToAppend")
+                                                sb.append(insertString).append(charToAppend)
+                                                romajiConverter?.let { converter ->
+                                                    _inputString.update {
+                                                        converter.convertQWERTYZenkaku(sb.toString())
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }else{
+                                        if (hardKeyboardShiftPressd) {
+                                            Timber.d("QWERTY romaji hardKeyboardShiftPressd: $tap")
+                                            handleTap(tap, insertString, sb, mainView)
+                                        } else {
+                                            tap?.let { c ->
+                                                val charToAppend = if (isDefaultRomajiHenkanMap) {
+                                                    c.toZenkaku()
+                                                } else {
+                                                    c
+                                                }
+                                                Timber.d("QWERTY romaji : $charToAppend")
+                                                sb.append(insertString).append(charToAppend)
+                                                romajiConverter?.let { converter ->
+                                                    _inputString.update {
+                                                        converter.convertQWERTYZenkaku(sb.toString())
+                                                    }
                                                 }
                                             }
                                         }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -176,6 +176,9 @@ object AppPreference {
     private val QWERTY_ROMAJI_SHIFT_CONVERSION_PREFERENCE =
         Pair("qwerty_romaji_shift_conversion_preference", false)
 
+    private val TABLET_GOJUON_LAYOUT_PREFERENCE =
+        Pair("tablet_use_gojuon_layout_preference", true)
+
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
     }
@@ -824,6 +827,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(QWERTY_ROMAJI_SHIFT_CONVERSION_PREFERENCE.first, value)
+        }
+
+    var tablet_gojuon_layout_preference: Boolean
+        get() = preferences.getBoolean(
+            TABLET_GOJUON_LAYOUT_PREFERENCE.first,
+            TABLET_GOJUON_LAYOUT_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(TABLET_GOJUON_LAYOUT_PREFERENCE.first, value)
         }
 
     fun migrateSumirePreferenceIfNeeded() {

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -330,4 +330,7 @@
     <string name="pref_clipboard_tap_delete_summary">クリップボード項目をタップしたとき、変換欄から削除します。</string>
     <string name="pref_romaji_shift_title">Shift直後の1文字だけ大文字</string>
     <string name="pref_romaji_shift_summary">ローマ字入力で、Shiftキーを押した直後の最初の1文字のみをアルファベットの大文字にします。</string>
+    <string name="tablet_preference_category_title">タブレット</string>
+    <string name="pref_tablet_layout_title">タブレットのレイアウト</string>
+    <string name="pref_tablet_layout_summary">タブレットでは五十音（かな）レイアウトを使用します。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -332,4 +332,7 @@
     <string name="pref_clipboard_tap_delete_summary">When you tap a clipboard item in the candidate bar, it will be removed from the bar.</string>
     <string name="pref_romaji_shift_title">Capitalize only the first character after Shift</string>
     <string name="pref_romaji_shift_summary">In romaji input, only the first character after pressing the Shift key becomes uppercase.</string>
+    <string name="tablet_preference_category_title">Tablet</string>
+    <string name="pref_tablet_layout_title">Tablet layout</string>
+    <string name="pref_tablet_layout_summary">Use the kana (Gojūon) layout on tablets.</string>
 </resources>

--- a/app/src/main/res/xml/setting_preference.xml
+++ b/app/src/main/res/xml/setting_preference.xml
@@ -345,6 +345,14 @@
 
     </PreferenceCategory>
 
+    <PreferenceCategory android:title="@string/tablet_preference_category_title">
+        <SwitchPreferenceCompat
+            android:defaultValue="true"
+            android:key="tablet_use_gojuon_layout_preference"
+            android:summary="@string/pref_tablet_layout_summary"
+            android:title="@string/pref_tablet_layout_title" />
+    </PreferenceCategory>
+
     <PreferenceCategory android:title="@string/category_operation_title">
         <SeekBarPreference
             android:defaultValue="1000"


### PR DESCRIPTION
## Issue
#455 #384 

## 概要
- 五十音キーボードの高さの修正
- 折りたたみ式の際に五十音キーボードが重なってしまうバグの修正
- QWERTY ローマ字のShiftキーを続けて押下後、全角になるバグの修正