### PR TITLE
２段フリックで２文字目が入力できないバグの修正

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -120,7 +120,10 @@ import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionA
 import com.kazumaproject.markdownhelperkeyboard.ime_service.clipboard.ClipboardUtil
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.correctReading
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getCurrentInputTypeForIME2
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getEnterKeyIndexSumire
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getLastCharacterAsString
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getQWERTYReturnTextInEn
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.getQWERTYReturnTextInJp
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isAllEnglishLetters
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isOnlyTwoCharBracketPair
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isPassword
@@ -3635,70 +3638,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         customLayoutDefault.isVisible = false
                         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.TenKeyQWERTY }
                         keyboardView.setCurrentMode(InputMode.ModeEnglish)
-                        val qwertyEnterKeyText = when (currentInputType) {
-                            InputTypeForIME.Text,
-                            InputTypeForIME.TextAutoComplete,
-                            InputTypeForIME.TextAutoCorrect,
-                            InputTypeForIME.TextCapCharacters,
-                            InputTypeForIME.TextCapSentences,
-                            InputTypeForIME.TextCapWords,
-                            InputTypeForIME.TextFilter,
-                            InputTypeForIME.TextNoSuggestion,
-                            InputTypeForIME.TextPersonName,
-                            InputTypeForIME.TextPhonetic,
-                            InputTypeForIME.TextWebEditText,
-                                -> {
-                                "return"
-                            }
-
-                            InputTypeForIME.TextMultiLine,
-                            InputTypeForIME.TextImeMultiLine,
-                            InputTypeForIME.TextShortMessage,
-                            InputTypeForIME.TextLongMessage,
-                                -> {
-                                "return"
-                            }
-
-                            InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
-                                "return"
-                            }
-
-                            InputTypeForIME.TextDone -> {
-                                "return"
-                            }
-
-                            InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
-                                "search"
-                            }
-
-                            InputTypeForIME.TextEditTextInWebView,
-                            InputTypeForIME.TextUri,
-                            InputTypeForIME.TextPostalAddress,
-                            InputTypeForIME.TextWebEmailAddress,
-                            InputTypeForIME.TextPassword,
-                            InputTypeForIME.TextVisiblePassword,
-                            InputTypeForIME.TextWebPassword,
-                                -> {
-                                "return"
-                            }
-
-                            InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
-                                "return"
-                            }
-
-                            InputTypeForIME.Number,
-                            InputTypeForIME.NumberDecimal,
-                            InputTypeForIME.NumberPassword,
-                            InputTypeForIME.NumberSigned,
-                            InputTypeForIME.Phone,
-                            InputTypeForIME.Date,
-                            InputTypeForIME.Datetime,
-                            InputTypeForIME.Time,
-                                -> {
-                                "return"
-                            }
-
-                        }
+                        val qwertyEnterKeyText = currentInputType.getQWERTYReturnTextInEn()
                         qwertyView.resetQWERTYKeyboard(qwertyEnterKeyText)
                     } else {
                         customKeyboardMode = KeyboardInputMode.HIRAGANA
@@ -3717,70 +3657,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         customLayoutDefault.isVisible = false
                         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.TenKeyQWERTYRomaji }
                         keyboardView.setCurrentMode(InputMode.ModeJapanese)
-                        val qwertyEnterKeyText = when (currentInputType) {
-                            InputTypeForIME.Text,
-                            InputTypeForIME.TextAutoComplete,
-                            InputTypeForIME.TextAutoCorrect,
-                            InputTypeForIME.TextCapCharacters,
-                            InputTypeForIME.TextCapSentences,
-                            InputTypeForIME.TextCapWords,
-                            InputTypeForIME.TextFilter,
-                            InputTypeForIME.TextNoSuggestion,
-                            InputTypeForIME.TextPersonName,
-                            InputTypeForIME.TextPhonetic,
-                            InputTypeForIME.TextWebEditText,
-                                -> {
-                                "確定"
-                            }
-
-                            InputTypeForIME.TextMultiLine,
-                            InputTypeForIME.TextImeMultiLine,
-                            InputTypeForIME.TextShortMessage,
-                            InputTypeForIME.TextLongMessage,
-                                -> {
-                                "改行"
-                            }
-
-                            InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
-                                "確定"
-                            }
-
-                            InputTypeForIME.TextDone -> {
-                                "確定"
-                            }
-
-                            InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
-                                "検索"
-                            }
-
-                            InputTypeForIME.TextEditTextInWebView,
-                            InputTypeForIME.TextUri,
-                            InputTypeForIME.TextPostalAddress,
-                            InputTypeForIME.TextWebEmailAddress,
-                            InputTypeForIME.TextPassword,
-                            InputTypeForIME.TextVisiblePassword,
-                            InputTypeForIME.TextWebPassword,
-                                -> {
-                                "確定"
-                            }
-
-                            InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
-                                "確定"
-                            }
-
-                            InputTypeForIME.Number,
-                            InputTypeForIME.NumberDecimal,
-                            InputTypeForIME.NumberPassword,
-                            InputTypeForIME.NumberSigned,
-                            InputTypeForIME.Phone,
-                            InputTypeForIME.Date,
-                            InputTypeForIME.Datetime,
-                            InputTypeForIME.Time,
-                                -> {
-                                "確定"
-                            }
-
-                        }
+                        val qwertyEnterKeyText = currentInputType.getQWERTYReturnTextInJp()
                         qwertyView.setRomajiKeyboard(
                             qwertyEnterKeyText
                         )
@@ -3798,70 +3675,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     Timber.d("showKeyboard keyboard: ${this.keyboardView.currentInputMode.value}")
                     customLayoutDefault.isVisible = true
                     if (qwertyMode.value != TenKeyQWERTYMode.Number) {
-                        currentEnterKeyIndex = when (currentInputType) {
-                            InputTypeForIME.Text,
-                            InputTypeForIME.TextAutoComplete,
-                            InputTypeForIME.TextAutoCorrect,
-                            InputTypeForIME.TextCapCharacters,
-                            InputTypeForIME.TextCapSentences,
-                            InputTypeForIME.TextCapWords,
-                            InputTypeForIME.TextFilter,
-                            InputTypeForIME.TextNoSuggestion,
-                            InputTypeForIME.TextPersonName,
-                            InputTypeForIME.TextPhonetic,
-                            InputTypeForIME.TextWebEditText,
-                                -> {
-                                1
-                            }
-
-                            InputTypeForIME.TextMultiLine,
-                            InputTypeForIME.TextImeMultiLine,
-                            InputTypeForIME.TextShortMessage,
-                            InputTypeForIME.TextLongMessage,
-                                -> {
-                                0
-                            }
-
-                            InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
-                                4
-                            }
-
-                            InputTypeForIME.TextDone -> {
-                                1
-                            }
-
-                            InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
-                                3
-                            }
-
-                            InputTypeForIME.TextEditTextInWebView,
-                            InputTypeForIME.TextUri,
-                            InputTypeForIME.TextPostalAddress,
-                            InputTypeForIME.TextWebEmailAddress,
-                            InputTypeForIME.TextPassword,
-                            InputTypeForIME.TextVisiblePassword,
-                            InputTypeForIME.TextWebPassword,
-                                -> {
-                                1
-                            }
-
-                            InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
-                                1
-                            }
-
-                            InputTypeForIME.Number,
-                            InputTypeForIME.NumberDecimal,
-                            InputTypeForIME.NumberPassword,
-                            InputTypeForIME.NumberSigned,
-                            InputTypeForIME.Phone,
-                            InputTypeForIME.Date,
-                            InputTypeForIME.Datetime,
-                            InputTypeForIME.Time,
-                                -> {
-                                1
-                            }
-
-                        }
+                        currentEnterKeyIndex = currentInputType.getEnterKeyIndexSumire()
                         val hiraganaLayout = KeyboardDefaultLayouts.createFinalLayout(
                             mode = customKeyboardMode,
                             dynamicKeyStates = mapOf(
@@ -3928,6 +3742,46 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             TenKeyQWERTYMode.TenKeyQWERTY -> {}
             TenKeyQWERTYMode.TenKeyQWERTYRomaji -> {}
             TenKeyQWERTYMode.Sumire -> {
+                Timber.d("updateKeyboardLayout: $isFlickOnlyMode $sumireInputKeyType")
+
+                mainLayoutBinding?.customLayoutDefault?.apply {
+                    updateDynamicKey(
+                        keyId = "enter_key",
+                        stateIndex = currentEnterKeyIndex
+                    )
+                    updateDynamicKey(
+                        keyId = "dakuten_toggle_key",
+                        stateIndex = currentDakutenKeyIndex
+                    )
+                    updateDynamicKey(
+                        keyId = "space_convert_key",
+                        stateIndex = currentSpaceKeyIndex
+                    )
+                    updateDynamicKey(
+                        keyId = "katakana_toggle_key",
+                        stateIndex = currentKatakanaKeyIndex
+                    )
+                }
+            }
+
+            TenKeyQWERTYMode.Number -> {
+
+            }
+
+        }
+    }
+
+    private fun createNewKeyboardLayoutForSumire() {
+        Timber.d("updateKeyboardLayout: ${qwertyMode.value} $currentEnterKeyIndex")
+        when (qwertyMode.value) {
+            TenKeyQWERTYMode.Custom -> {
+                //setInitialKeyboardTab()
+            }
+
+            TenKeyQWERTYMode.Default -> {}
+            TenKeyQWERTYMode.TenKeyQWERTY -> {}
+            TenKeyQWERTYMode.TenKeyQWERTYRomaji -> {}
+            TenKeyQWERTYMode.Sumire -> {
                 val dynamicStates = mapOf(
                     "enter_key" to currentEnterKeyIndex,
                     "dakuten_toggle_key" to currentDakutenKeyIndex,
@@ -3948,8 +3802,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
 
             TenKeyQWERTYMode.Number -> {
-                val finalLayout = KeyboardDefaultLayouts.createNumberLayout()
-                mainLayoutBinding?.customLayoutDefault?.setKeyboard(finalLayout)
+
             }
 
         }
@@ -4010,99 +3863,63 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun setSumireKeyboardDakutenKey() {
         // 0と1を交互に切り替える
         currentDakutenKeyIndex = 1
-        updateKeyboardLayout()
-    }
-
-    private fun setSumireKeyboardDakutenKeyEmpty() {
-        // 0と1を交互に切り替える
-        currentDakutenKeyIndex = 0
-        updateKeyboardLayout()
+        mainLayoutBinding?.customLayoutDefault?.apply {
+            updateDynamicKey(
+                keyId = "dakuten_toggle_key",
+                stateIndex = 1
+            )
+        }
     }
 
     private fun setSumireKeyboardEnterKey(index: Int) {
         currentEnterKeyIndex = index
-        updateKeyboardLayout()
+        mainLayoutBinding?.customLayoutDefault?.apply {
+            updateDynamicKey(
+                keyId = "enter_key",
+                stateIndex = index
+            )
+        }
     }
 
     private fun setSumireKeyboardSpaceKey(index: Int) {
         currentSpaceKeyIndex = index
-        updateKeyboardLayout()
+        mainLayoutBinding?.customLayoutDefault?.apply {
+            updateDynamicKey(
+                keyId = "space_convert_key",
+                stateIndex = index
+            )
+        }
     }
 
     private fun setSumireKeyboardSwitchNumberAndKatakanaKey(index: Int) {
         currentKatakanaKeyIndex = index
-        updateKeyboardLayout()
+        mainLayoutBinding?.customLayoutDefault?.apply {
+            updateDynamicKey(
+                keyId = "katakana_toggle_key",
+                stateIndex = index
+            )
+        }
     }
 
     private fun resetSumireKeyboardDakutenMode() {
         currentDakutenKeyIndex = 0
-        currentEnterKeyIndex = when (currentInputType) {
-            InputTypeForIME.Text,
-            InputTypeForIME.TextAutoComplete,
-            InputTypeForIME.TextAutoCorrect,
-            InputTypeForIME.TextCapCharacters,
-            InputTypeForIME.TextCapSentences,
-            InputTypeForIME.TextCapWords,
-            InputTypeForIME.TextFilter,
-            InputTypeForIME.TextNoSuggestion,
-            InputTypeForIME.TextPersonName,
-            InputTypeForIME.TextPhonetic,
-            InputTypeForIME.TextWebEditText,
-                -> {
-                1
-            }
-
-            InputTypeForIME.TextMultiLine,
-            InputTypeForIME.TextImeMultiLine,
-            InputTypeForIME.TextShortMessage,
-            InputTypeForIME.TextLongMessage,
-                -> {
-                0
-            }
-
-            InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
-                4
-            }
-
-            InputTypeForIME.TextDone -> {
-                1
-            }
-
-            InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
-                3
-            }
-
-            InputTypeForIME.TextEditTextInWebView,
-            InputTypeForIME.TextUri,
-            InputTypeForIME.TextPostalAddress,
-            InputTypeForIME.TextWebEmailAddress,
-            InputTypeForIME.TextPassword,
-            InputTypeForIME.TextVisiblePassword,
-            InputTypeForIME.TextWebPassword,
-                -> {
-                1
-            }
-
-            InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
-                1
-            }
-
-            InputTypeForIME.Number,
-            InputTypeForIME.NumberDecimal,
-            InputTypeForIME.NumberPassword,
-            InputTypeForIME.NumberSigned,
-            InputTypeForIME.Phone,
-            InputTypeForIME.Date,
-            InputTypeForIME.Datetime,
-            InputTypeForIME.Time,
-                -> {
-                1
-            }
-
-        }
+        currentEnterKeyIndex = currentInputType.getEnterKeyIndexSumire()
         currentSpaceKeyIndex = 0
         Timber.d("resetSumireKeyboardDakutenMode called: $currentEnterKeyIndex")
-        updateKeyboardLayout()
+        mainLayoutBinding?.customLayoutDefault?.apply {
+            updateDynamicKey(
+                keyId = "enter_key",
+                stateIndex = currentEnterKeyIndex
+            )
+            updateDynamicKey(
+                keyId = "dakuten_toggle_key",
+                stateIndex = 0
+            )
+            updateDynamicKey(
+                keyId = "space_convert_key",
+                stateIndex = 0
+            )
+        }
     }
 
     private fun showKeyboardPicker() {
@@ -4743,7 +4560,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             KeyboardInputMode.ENGLISH -> KeyboardInputMode.SYMBOLS
                             KeyboardInputMode.SYMBOLS -> KeyboardInputMode.HIRAGANA
                         }
-                        updateKeyboardLayout()
+                        createNewKeyboardLayoutForSumire()
 
                         val inputMode = when (customKeyboardMode) {
                             KeyboardInputMode.HIRAGANA -> InputMode.ModeJapanese
@@ -4878,21 +4695,21 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     KeyAction.SwitchToEnglishLayout -> {
                         customKeyboardMode = KeyboardInputMode.ENGLISH
-                        updateKeyboardLayout()
+                        createNewKeyboardLayoutForSumire()
                         val inputMode = InputMode.ModeEnglish
                         mainView.keyboardView.setCurrentMode(inputMode)
                     }
 
                     KeyAction.SwitchToKanaLayout -> {
                         customKeyboardMode = KeyboardInputMode.HIRAGANA
-                        updateKeyboardLayout()
+                        createNewKeyboardLayoutForSumire()
                         val inputMode = InputMode.ModeJapanese
                         mainView.keyboardView.setCurrentMode(inputMode)
                     }
 
                     KeyAction.SwitchToNumberLayout -> {
                         customKeyboardMode = KeyboardInputMode.SYMBOLS
-                        updateKeyboardLayout()
+                        createNewKeyboardLayoutForSumire()
                         val inputMode = InputMode.ModeNumber
                         mainView.keyboardView.setCurrentMode(inputMode)
                     }
@@ -5582,7 +5399,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     }
                     if (mainView.customLayoutDefault.isVisible) {
                         setSumireKeyboardDakutenKey()
-                        setSumireKeyboardEnterKey(1)
+                        setSumireKeyboardEnterKey(5)
                         when (mainView.keyboardView.currentInputMode.value) {
                             InputMode.ModeJapanese -> {
                                 setSumireKeyboardSpaceKey(1)
@@ -5655,145 +5472,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTYRomaji && mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                             mainView.qwertyView.apply {
                                 setSpaceKeyText("空白")
-                                val qwertyEnterKeyText = when (currentInputType) {
-                                    InputTypeForIME.Text,
-                                    InputTypeForIME.TextAutoComplete,
-                                    InputTypeForIME.TextAutoCorrect,
-                                    InputTypeForIME.TextCapCharacters,
-                                    InputTypeForIME.TextCapSentences,
-                                    InputTypeForIME.TextCapWords,
-                                    InputTypeForIME.TextFilter,
-                                    InputTypeForIME.TextNoSuggestion,
-                                    InputTypeForIME.TextPersonName,
-                                    InputTypeForIME.TextPhonetic,
-                                    InputTypeForIME.TextWebEditText,
-                                        -> {
-                                        "確定"
-                                    }
-
-                                    InputTypeForIME.TextMultiLine,
-                                    InputTypeForIME.TextImeMultiLine,
-                                    InputTypeForIME.TextShortMessage,
-                                    InputTypeForIME.TextLongMessage,
-                                        -> {
-                                        "改行"
-                                    }
-
-                                    InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject -> {
-                                        "確定"
-                                    }
-
-                                    InputTypeForIME.TextNextLine -> {
-                                        "次"
-                                    }
-
-                                    InputTypeForIME.TextDone -> {
-                                        "確定"
-                                    }
-
-                                    InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
-                                        "検索"
-                                    }
-
-                                    InputTypeForIME.TextEditTextInWebView,
-                                    InputTypeForIME.TextUri,
-                                    InputTypeForIME.TextPostalAddress,
-                                    InputTypeForIME.TextWebEmailAddress,
-                                    InputTypeForIME.TextPassword,
-                                    InputTypeForIME.TextVisiblePassword,
-                                    InputTypeForIME.TextWebPassword,
-                                        -> {
-                                        "確定"
-                                    }
-
-                                    InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
-                                        "確定"
-                                    }
-
-                                    InputTypeForIME.Number,
-                                    InputTypeForIME.NumberDecimal,
-                                    InputTypeForIME.NumberPassword,
-                                    InputTypeForIME.NumberSigned,
-                                    InputTypeForIME.Phone,
-                                    InputTypeForIME.Date,
-                                    InputTypeForIME.Datetime,
-                                    InputTypeForIME.Time,
-                                        -> {
-                                        "確定"
-                                    }
-
-                                }
+                                val qwertyEnterKeyText = currentInputType.getQWERTYReturnTextInJp()
                                 setReturnKeyText(qwertyEnterKeyText)
                             }
                         } else if ((qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY && mainView.keyboardView.currentInputMode.value == InputMode.ModeEnglish) || qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTYRomaji && mainView.keyboardView.currentInputMode.value == InputMode.ModeEnglish) {
-                            val qwertyEnterKeyText = when (currentInputType) {
-                                InputTypeForIME.Text,
-                                InputTypeForIME.TextAutoComplete,
-                                InputTypeForIME.TextAutoCorrect,
-                                InputTypeForIME.TextCapCharacters,
-                                InputTypeForIME.TextCapSentences,
-                                InputTypeForIME.TextCapWords,
-                                InputTypeForIME.TextFilter,
-                                InputTypeForIME.TextNoSuggestion,
-                                InputTypeForIME.TextPersonName,
-                                InputTypeForIME.TextPhonetic,
-                                InputTypeForIME.TextWebEditText,
-                                    -> {
-                                    "return"
-                                }
-
-                                InputTypeForIME.TextMultiLine,
-                                InputTypeForIME.TextImeMultiLine,
-                                InputTypeForIME.TextShortMessage,
-                                InputTypeForIME.TextLongMessage,
-                                    -> {
-                                    "return"
-                                }
-
-                                InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject -> {
-                                    "return"
-                                }
-
-                                InputTypeForIME.TextNextLine -> {
-                                    "next"
-                                }
-
-                                InputTypeForIME.TextDone -> {
-                                    "return"
-                                }
-
-                                InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
-                                    "search"
-                                }
-
-                                InputTypeForIME.TextEditTextInWebView,
-                                InputTypeForIME.TextUri,
-                                InputTypeForIME.TextPostalAddress,
-                                InputTypeForIME.TextWebEmailAddress,
-                                InputTypeForIME.TextPassword,
-                                InputTypeForIME.TextVisiblePassword,
-                                InputTypeForIME.TextWebPassword,
-                                    -> {
-                                    "return"
-                                }
-
-                                InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
-                                    "return"
-                                }
-
-                                InputTypeForIME.Number,
-                                InputTypeForIME.NumberDecimal,
-                                InputTypeForIME.NumberPassword,
-                                InputTypeForIME.NumberSigned,
-                                InputTypeForIME.Phone,
-                                InputTypeForIME.Date,
-                                InputTypeForIME.Datetime,
-                                InputTypeForIME.Time,
-                                    -> {
-                                    "return"
-                                }
-
-                            }
+                            val qwertyEnterKeyText = currentInputType.getQWERTYReturnTextInEn()
                             mainView.qwertyView.setReturnKeyText(qwertyEnterKeyText)
                         }
                         setKeyboardHeightDefault(mainView)
@@ -7915,15 +7598,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             if (mainView.keyboardView.currentInputMode.value == InputMode.ModeJapanese) {
                                 if (insertString.isNotEmpty()) {
                                     Timber.d("QWERTY romaji not empty: $hardKeyboardShiftPressd $qwertyRomajiShiftConversionPreference")
-                                    if (qwertyRomajiShiftConversionPreference == true){
+                                    if (qwertyRomajiShiftConversionPreference == true) {
                                         if (hardKeyboardShiftPressd) {
                                             Timber.d("QWERTY romaji hardKeyboardShiftPressd: $tap")
                                             tap?.let { c ->
-                                                val charToAppend = if (isDefaultRomajiHenkanMap && c.isLowerCase()) {
-                                                    c.toZenkaku()
-                                                } else {
-                                                    c
-                                                }
+                                                val charToAppend =
+                                                    if (isDefaultRomajiHenkanMap && c.isLowerCase()) {
+                                                        c.toZenkaku()
+                                                    } else {
+                                                        c
+                                                    }
                                                 Timber.d("QWERTY romaji : $charToAppend")
                                                 sb.append(insertString).append(charToAppend)
                                                 romajiConverter?.let { converter ->
@@ -7948,7 +7632,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                                 }
                                             }
                                         }
-                                    }else{
+                                    } else {
                                         if (hardKeyboardShiftPressd) {
                                             Timber.d("QWERTY romaji hardKeyboardShiftPressd: $tap")
                                             handleTap(tap, insertString, sb, mainView)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeForIME.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeForIME.kt
@@ -1,0 +1,202 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.extensions
+
+import com.kazumaproject.markdownhelperkeyboard.ime_service.state.InputTypeForIME
+
+fun InputTypeForIME.getQWERTYReturnTextInJp(): String {
+    return when (this) {
+        InputTypeForIME.Text,
+        InputTypeForIME.TextAutoComplete,
+        InputTypeForIME.TextAutoCorrect,
+        InputTypeForIME.TextCapCharacters,
+        InputTypeForIME.TextCapSentences,
+        InputTypeForIME.TextCapWords,
+        InputTypeForIME.TextFilter,
+        InputTypeForIME.TextNoSuggestion,
+        InputTypeForIME.TextPersonName,
+        InputTypeForIME.TextPhonetic,
+        InputTypeForIME.TextWebEditText,
+            -> {
+            "確定"
+        }
+
+        InputTypeForIME.TextMultiLine,
+        InputTypeForIME.TextImeMultiLine,
+        InputTypeForIME.TextShortMessage,
+        InputTypeForIME.TextLongMessage,
+            -> {
+            "改行"
+        }
+
+        InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
+            "確定"
+        }
+
+        InputTypeForIME.TextDone -> {
+            "確定"
+        }
+
+        InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
+            "検索"
+        }
+
+        InputTypeForIME.TextEditTextInWebView,
+        InputTypeForIME.TextUri,
+        InputTypeForIME.TextPostalAddress,
+        InputTypeForIME.TextWebEmailAddress,
+        InputTypeForIME.TextPassword,
+        InputTypeForIME.TextVisiblePassword,
+        InputTypeForIME.TextWebPassword,
+            -> {
+            "確定"
+        }
+
+        InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
+            "確定"
+        }
+
+        InputTypeForIME.Number,
+        InputTypeForIME.NumberDecimal,
+        InputTypeForIME.NumberPassword,
+        InputTypeForIME.NumberSigned,
+        InputTypeForIME.Phone,
+        InputTypeForIME.Date,
+        InputTypeForIME.Datetime,
+        InputTypeForIME.Time,
+            -> {
+            "確定"
+        }
+    }
+}
+
+fun InputTypeForIME.getQWERTYReturnTextInEn(): String {
+    return when (this) {
+        InputTypeForIME.Text,
+        InputTypeForIME.TextAutoComplete,
+        InputTypeForIME.TextAutoCorrect,
+        InputTypeForIME.TextCapCharacters,
+        InputTypeForIME.TextCapSentences,
+        InputTypeForIME.TextCapWords,
+        InputTypeForIME.TextFilter,
+        InputTypeForIME.TextNoSuggestion,
+        InputTypeForIME.TextPersonName,
+        InputTypeForIME.TextPhonetic,
+        InputTypeForIME.TextWebEditText,
+            -> {
+            "return"
+        }
+
+        InputTypeForIME.TextMultiLine,
+        InputTypeForIME.TextImeMultiLine,
+        InputTypeForIME.TextShortMessage,
+        InputTypeForIME.TextLongMessage,
+            -> {
+            "return"
+        }
+
+        InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
+            "return"
+        }
+
+        InputTypeForIME.TextDone -> {
+            "return"
+        }
+
+        InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
+            "search"
+        }
+
+        InputTypeForIME.TextEditTextInWebView,
+        InputTypeForIME.TextUri,
+        InputTypeForIME.TextPostalAddress,
+        InputTypeForIME.TextWebEmailAddress,
+        InputTypeForIME.TextPassword,
+        InputTypeForIME.TextVisiblePassword,
+        InputTypeForIME.TextWebPassword,
+            -> {
+            "return"
+        }
+
+        InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
+            "return"
+        }
+
+        InputTypeForIME.Number,
+        InputTypeForIME.NumberDecimal,
+        InputTypeForIME.NumberPassword,
+        InputTypeForIME.NumberSigned,
+        InputTypeForIME.Phone,
+        InputTypeForIME.Date,
+        InputTypeForIME.Datetime,
+        InputTypeForIME.Time,
+            -> {
+            "return"
+        }
+    }
+}
+
+fun InputTypeForIME.getEnterKeyIndexSumire(): Int {
+    return when (this) {
+        InputTypeForIME.Text,
+        InputTypeForIME.TextAutoComplete,
+        InputTypeForIME.TextAutoCorrect,
+        InputTypeForIME.TextCapCharacters,
+        InputTypeForIME.TextCapSentences,
+        InputTypeForIME.TextCapWords,
+        InputTypeForIME.TextFilter,
+        InputTypeForIME.TextNoSuggestion,
+        InputTypeForIME.TextPersonName,
+        InputTypeForIME.TextPhonetic,
+        InputTypeForIME.TextWebEditText,
+            -> {
+            1
+        }
+
+        InputTypeForIME.TextMultiLine,
+        InputTypeForIME.TextImeMultiLine,
+        InputTypeForIME.TextShortMessage,
+        InputTypeForIME.TextLongMessage,
+            -> {
+            0
+        }
+
+        InputTypeForIME.TextEmailAddress, InputTypeForIME.TextEmailSubject, InputTypeForIME.TextNextLine -> {
+            4
+        }
+
+        InputTypeForIME.TextDone -> {
+            1
+        }
+
+        InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
+            3
+        }
+
+        InputTypeForIME.TextEditTextInWebView,
+        InputTypeForIME.TextUri,
+        InputTypeForIME.TextPostalAddress,
+        InputTypeForIME.TextWebEmailAddress,
+        InputTypeForIME.TextPassword,
+        InputTypeForIME.TextVisiblePassword,
+        InputTypeForIME.TextWebPassword,
+            -> {
+            1
+        }
+
+        InputTypeForIME.None, InputTypeForIME.TextNotCursorUpdate -> {
+            1
+        }
+
+        InputTypeForIME.Number,
+        InputTypeForIME.NumberDecimal,
+        InputTypeForIME.NumberPassword,
+        InputTypeForIME.NumberSigned,
+        InputTypeForIME.Phone,
+        InputTypeForIME.Date,
+        InputTypeForIME.Datetime,
+        InputTypeForIME.Time,
+            -> {
+            1
+        }
+
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiInputController.kt
@@ -2,6 +2,7 @@ package com.kazumaproject.custom_keyboard.view
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.util.Log
 import android.view.GestureDetector
 import android.view.Gravity
 import android.view.MotionEvent
@@ -86,11 +87,22 @@ class TfbiInputController(
         // ★ タッチイベントをまずGestureDetectorに渡す
         gestureDetector.onTouchEvent(event)
 
+        Log.d("TfbInput", "handleTouchEvent: ${MotionEvent.actionToString(event.action)}")
+
         val view = attachedView ?: return false
         when (event.action) {
-            MotionEvent.ACTION_DOWN -> handleTouchDown(event, view)
-            MotionEvent.ACTION_MOVE -> handleTouchMove(event, view)
-            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> handleTouchUp(event)
+            MotionEvent.ACTION_DOWN -> {
+                Log.d("TfbInput: handleTouchEvent","ACTION_DOWN")
+                handleTouchDown(event, view)
+            }
+            MotionEvent.ACTION_MOVE -> {
+                Log.d("TfbInput: handleTouchEvent","ACTION_MOVE")
+                handleTouchMove(event, view)
+            }
+            MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                Log.d("TfbInput: handleTouchEvent","ACTION_UP")
+                handleTouchUp(event)
+            }
         }
         return true
     }
@@ -159,7 +171,13 @@ class TfbiInputController(
     }
 
     private fun handleTouchUp(event: MotionEvent) {
-        // ★ 長押しタイマーのキャンセル処理は不要になった
+        // ▼▼▼ ログ追加 ▼▼▼
+        Log.d(
+            "TfbInput",
+            "handleTouchUp: START. Current state = $flickState"
+        )
+        // ▲▲▲ ログ追加 ▲▲▲
+
         var finalSecondDirection: TfbiFlickDirection
         if (flickState == FlickState.FIRST_FLICK_DETERMINED) {
             val dx = event.x - intermediateTouchX
@@ -167,8 +185,22 @@ class TfbiInputController(
             val enabledSecondDirections = getEnabledSecondFlickDirections(firstFlickDirection)
             finalSecondDirection =
                 calculateDirection(dx, dy, flickSensitivity, enabledSecondDirections)
+
+            // ▼▼▼ ログ追加 ▼▼▼
+            Log.d(
+                "TfbInput",
+                "handleTouchUp: State=FIRST_FLICK_DETERMINED. dx=$dx, dy=$dy, calculatedDir=$finalSecondDirection"
+            )
+            // ▲▲▲ ログ追加 ▲▲▲
+
             if (finalSecondDirection == TfbiFlickDirection.TAP && currentSecondFlickDirection != TfbiFlickDirection.TAP) {
                 finalSecondDirection = currentSecondFlickDirection
+                // ▼▼▼ ログ追加 ▼▼▼
+                Log.d(
+                    "TfbInput",
+                    "handleTouchUp: Using currentSecondFlickDirection. finalDir=$finalSecondDirection"
+                )
+                // ▲▲▲ ログ追加 ▲▲▲
             }
         } else {
             val dx = event.x - initialTouchX
@@ -177,7 +209,25 @@ class TfbiInputController(
             firstFlickDirection =
                 calculateDirection(dx, dy, flickSensitivity, enabledFirstDirections)
             finalSecondDirection = TfbiFlickDirection.TAP
+
+            // ▼▼▼ ログ追加 ▼▼▼
+            Log.d(
+                "TfbInput",
+                "handleTouchUp: State=NEUTRAL. dx=$dx, dy=$dy. firstDir=$firstFlickDirection, finalDir=$finalSecondDirection"
+            )
+            // ▲▲▲ ログ追加 ▲▲▲
         }
+
+        // ▼▼▼ ログ追加 ▼▼▼
+        if (listener == null) {
+            Log.w("TfbInput", "handleTouchUp: Listener is NULL!")
+        }
+        Log.d(
+            "TfbInput",
+            "handleTouchUp: Calling onFlick(first=$firstFlickDirection, second=$finalSecondDirection)"
+        )
+        // ▲▲▲ ログ追加 ▲▲▲
+
         listener?.onFlick(firstFlickDirection, finalSecondDirection)
         resetState()
     }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -136,14 +136,16 @@ object KeyboardDefaultLayouts {
 
     private val enterKeyStates = listOf(
         FlickAction.Action(KeyAction.NewLine, "改行"),
-        FlickAction.Action(KeyAction.Confirm, "確定"),
         FlickAction.Action(
-            KeyAction.Enter, "実行",
-        ),
-        FlickAction.Action(
+            KeyAction.Confirm,
+            drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_alt_24
+        ), FlickAction.Action(
+            KeyAction.Enter,
+            drawableResId = com.kazumaproject.core.R.drawable.baseline_keyboard_return_24,
+        ), FlickAction.Action(
             KeyAction.Enter, "検索",
-        ),
-        FlickAction.Action(KeyAction.Enter, "次")
+        ), FlickAction.Action(KeyAction.Enter, "次"),
+        FlickAction.Action(KeyAction.Enter, "確定")
     )
 
     private val dakutenToggleStates = listOf(
@@ -190,15 +192,17 @@ object KeyboardDefaultLayouts {
     )
 
     private val enterKeyStatesCursor = listOf(
-        FlickAction.Action(KeyAction.NewLine, "改行"), FlickAction.Action(
+        FlickAction.Action(KeyAction.NewLine, "改行"),
+        FlickAction.Action(
             KeyAction.Confirm,
-            drawableResId = com.kazumaproject.core.R.drawable.baseline_keyboard_return_24
+            drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_alt_24
         ), FlickAction.Action(
             KeyAction.Enter,
             drawableResId = com.kazumaproject.core.R.drawable.baseline_keyboard_return_24,
         ), FlickAction.Action(
             KeyAction.Enter, "Go",
-        ), FlickAction.Action(KeyAction.Enter, "Next")
+        ), FlickAction.Action(KeyAction.Enter, "Next"),
+        FlickAction.Action(KeyAction.Enter, "確定")
     )
 
     /**


### PR DESCRIPTION
## 概要
調査の結果 `エンターキ` や `濁点キー` のテキストを更新するために全てのレイアウトを更新していて、その際に controller を cancel していたため、２文字目が入力できないということが判明した。
効率も良くないため、テキストの更新が必要な View のみを更新するように修正した。