### PR TITLE
カスタムキーボードが先頭でキーボードの初期読み込みで customLayout が読み込まれないバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 580
-        versionName "1.4.459"
+        versionCode 581
+        versionName "1.4.460"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -613,6 +613,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         listAdapter.onPagerClicked = {
             goToNextPageForFloatingCandidate()
         }
+        ioScope.launch {
+            customLayouts = keyboardRepository.getLayoutsNotFlow()
+        }
     }
 
     override fun onCreateInputView(): View? {


### PR DESCRIPTION
## Issue
#466 

## 概要
カスタムキーボードが読み込まれずに空のレイアウトが表示される現象を確認した。
上記の Issue に関連すると思われる。
`onCreate` で customLayout を読み込む関数を追加した。