### PR TITLE
文節ごとに分割する機能の修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 585
-        versionName "1.4.464"
+        versionCode 586
+        versionName "1.4.465"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## 概要
これまでは、文節を分割する際に「最初の文節」と「それ以外」の2つにしか分けられませんでした。
変換キーで複数の文節に分かれた場合でも、エンターキーを使って各文節を個別に選択できるように修正した。

例：
わたしの、なまえは、なかのです