### PR TITLE
QWERTYレイアウトで上フリック時に数字が出るようlistの並びを修正

### DIFF
--- a/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKeyInfo.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/qwerty/QWERTYKeyInfo.kt
@@ -16,7 +16,6 @@ sealed class QWERTYKeyInfo {
         override val variations: List<Char>
             get() = listOf(
                 '@',
-                'A',
                 'à',
                 'á',
                 'â',
@@ -34,7 +33,7 @@ sealed class QWERTYKeyInfo {
     object KeyB : QWERTYVariation() {
         override val tap: Char get() = 'b'
         override val capChar: Char get() = 'B'
-        override val variations: List<Char> = listOf(';', 'B')
+        override val variations: List<Char> = listOf(';')
         override val capVariations: List<Char> = listOf(';')
     }
 
@@ -44,7 +43,6 @@ sealed class QWERTYKeyInfo {
         override val variations: List<Char>
             get() = listOf(
                 '\'',
-                'C',
                 'ç',
             )
         override val capVariations: List<Char>
@@ -56,7 +54,7 @@ sealed class QWERTYKeyInfo {
     object KeyD : QWERTYVariation() {
         override val tap: Char get() = 'd'
         override val capChar: Char get() = 'D'
-        override val variations: List<Char> get() = listOf('$', 'D')
+        override val variations: List<Char> get() = listOf('$')
         override val capVariations: List<Char> get() = listOf('$')
     }
 
@@ -66,7 +64,6 @@ sealed class QWERTYKeyInfo {
         override val variations: List<Char>
             get() = listOf(
                 '3',
-                'E',
                 'ē',
                 'ê',
                 'ë',
@@ -87,21 +84,21 @@ sealed class QWERTYKeyInfo {
     object KeyF : QWERTYVariation() {
         override val tap: Char get() = 'f'
         override val capChar: Char get() = 'F'
-        override val variations: List<Char> get() = listOf('_', 'F')
+        override val variations: List<Char> get() = listOf('_')
         override val capVariations: List<Char> get() = listOf('_')
     }
 
     object KeyG : QWERTYVariation() {
         override val tap: Char get() = 'g'
         override val capChar: Char get() = 'G'
-        override val variations: List<Char> get() = listOf('&', 'G')
+        override val variations: List<Char> get() = listOf('&')
         override val capVariations: List<Char> get() = listOf('&')
     }
 
     object KeyH : QWERTYVariation() {
         override val tap: Char get() = 'h'
         override val capChar: Char get() = 'H'
-        override val variations: List<Char> get() = listOf('-', 'H')
+        override val variations: List<Char> get() = listOf('-')
         override val capVariations: List<Char> get() = listOf('-')
     }
 
@@ -110,52 +107,46 @@ sealed class QWERTYKeyInfo {
         override val capChar: Char get() = 'I'
         override val variations: List<Char>
             get() = listOf(
-                '8',
-                'I',
-                'ì',
-                'ï',
-                'ī',
-                'î',
-                'í',
+                '8', 'ì', 'ï', 'ī', 'î', 'í',
             )
         override val capVariations: List<Char>
             get() = listOf(
-                '8', 'Ì', 'Ï', 'Ī', 'Î', 'Í'
+                '8', 'Ì', 'Ï', 'Ī', 'Î', 'Í',
             )
     }
 
     object KeyJ : QWERTYVariation() {
         override val tap: Char get() = 'j'
         override val capChar: Char get() = 'J'
-        override val variations: List<Char> get() = listOf('+', 'J')
+        override val variations: List<Char> get() = listOf('+')
         override val capVariations: List<Char> get() = listOf('+')
     }
 
     object KeyK : QWERTYVariation() {
         override val tap: Char get() = 'k'
         override val capChar: Char get() = 'K'
-        override val variations: List<Char> get() = listOf('(', 'K')
+        override val variations: List<Char> get() = listOf('(')
         override val capVariations: List<Char> get() = listOf('(')
     }
 
     object KeyL : QWERTYVariation() {
         override val tap: Char get() = 'l'
         override val capChar: Char get() = 'L'
-        override val variations: List<Char> get() = listOf(')', 'L')
+        override val variations: List<Char> get() = listOf(')')
         override val capVariations: List<Char> get() = listOf(')')
     }
 
     object KeyM : QWERTYVariation() {
         override val tap: Char get() = 'm'
         override val capChar: Char get() = 'M'
-        override val variations: List<Char> get() = listOf('?', 'M')
+        override val variations: List<Char> get() = listOf('?')
         override val capVariations: List<Char> get() = listOf('?')
     }
 
     object KeyN : QWERTYVariation() {
         override val tap: Char get() = 'n'
         override val capChar: Char get() = 'N'
-        override val variations: List<Char> get() = listOf('!', 'N', 'ñ')
+        override val variations: List<Char> get() = listOf('!', 'ñ')
         override val capVariations: List<Char> get() = listOf('!', 'Ñ')
     }
 
@@ -164,55 +155,46 @@ sealed class QWERTYKeyInfo {
         override val capChar: Char get() = 'O'
         override val variations: List<Char>
             get() = listOf(
-                '9',
-                'O',
-                'ò',
-                'ó',
-                'ô',
-                'õ',
-                'ö',
-                'ø',
-                'ō',
-                'ő',
+                '9', 'ò', 'ó', 'ô', 'õ', 'ö', 'ø', 'ō', 'ő',
             )
         override val capVariations: List<Char>
             get() = listOf(
-                '9', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ø', 'Ō', 'Ő'
+                '9', 'Ò', 'Ó', 'Ô', 'Õ', 'Ö', 'Ø', 'Ō', 'Ő',
             )
     }
 
     object KeyP : QWERTYVariation() {
         override val tap: Char get() = 'p'
         override val capChar: Char get() = 'P'
-        override val variations: List<Char> get() = listOf('0', 'P')
+        override val variations: List<Char> get() = listOf('0')
         override val capVariations: List<Char> get() = listOf('0')
     }
 
     object KeyQ : QWERTYVariation() {
         override val tap: Char get() = 'q'
         override val capChar: Char get() = 'Q'
-        override val variations: List<Char> get() = listOf('1', 'Q')
+        override val variations: List<Char> get() = listOf('1')
         override val capVariations: List<Char> get() = listOf('1')
     }
 
     object KeyR : QWERTYVariation() {
         override val tap: Char get() = 'r'
         override val capChar: Char get() = 'R'
-        override val variations: List<Char> get() = listOf('4', 'R')
+        override val variations: List<Char> get() = listOf('4')
         override val capVariations: List<Char> get() = listOf('4')
     }
 
     object KeyS : QWERTYVariation() {
         override val tap: Char get() = 's'
         override val capChar: Char get() = 'S'
-        override val variations: List<Char> get() = listOf('#', 'S', 'β')
+        override val variations: List<Char> get() = listOf('#', 'β')
         override val capVariations: List<Char> get() = listOf('#', 'β')
     }
 
     object KeyT : QWERTYVariation() {
         override val tap: Char get() = 't'
         override val capChar: Char get() = 'T'
-        override val variations: List<Char> get() = listOf('5', 'T')
+        override val variations: List<Char> get() = listOf('5')
         override val capVariations: List<Char> get() = listOf('5')
     }
 
@@ -221,52 +203,46 @@ sealed class QWERTYKeyInfo {
         override val capChar: Char get() = 'U'
         override val variations: List<Char>
             get() = listOf(
-                '7',
-                'U',
-                'ū',
-                'ü',
-                'ù',
-                'ú',
-                'û',
+                '7', 'ū', 'ü', 'ù', 'ú', 'û',
             )
         override val capVariations: List<Char>
             get() = listOf(
-                '7', 'Ū', 'Ü', 'Ù', 'Ú', 'Û'
+                '7', 'Ū', 'Ü', 'Ù', 'Ú', 'Û',
             )
     }
 
     object KeyV : QWERTYVariation() {
         override val tap: Char get() = 'v'
         override val capChar: Char get() = 'V'
-        override val variations: List<Char> get() = listOf(':', 'V')
+        override val variations: List<Char> get() = listOf(':')
         override val capVariations: List<Char> get() = listOf(':')
     }
 
     object KeyW : QWERTYVariation() {
         override val tap: Char get() = 'w'
         override val capChar: Char get() = 'W'
-        override val variations: List<Char> get() = listOf('2', 'W')
+        override val variations: List<Char> get() = listOf('2')
         override val capVariations: List<Char> get() = listOf('2')
     }
 
     object KeyX : QWERTYVariation() {
         override val tap: Char get() = 'x'
         override val capChar: Char get() = 'X'
-        override val variations: List<Char> get() = listOf('"', 'X')
+        override val variations: List<Char> get() = listOf('"')
         override val capVariations: List<Char> get() = listOf('"')
     }
 
     object KeyY : QWERTYVariation() {
         override val tap: Char get() = 'y'
         override val capChar: Char get() = 'Y'
-        override val variations: List<Char> get() = listOf('6', 'Y')
+        override val variations: List<Char> get() = listOf('6')
         override val capVariations: List<Char> get() = listOf('6')
     }
 
     object KeyZ : QWERTYVariation() {
         override val tap: Char get() = 'z'
         override val capChar: Char get() = 'Z'
-        override val variations: List<Char> get() = listOf('*', 'Z')
+        override val variations: List<Char> get() = listOf('*')
         override val capVariations: List<Char> get() = listOf('*')
     }
 


### PR DESCRIPTION
QWERTYレイアウトにて数字キーを表示せず上フリックを有効にした設定のとき，
`e`や`i`などの母音キーで上フリック時に数字以外の入力が行われる状態でした

これは`QWERTYKeyInfo.kt`のvariationsの配列の先頭が，`QWERTYKeyboardView`にて定義されているキーマップと一致していないためだと思うので
variations内の順番を整理しました
- 先頭はキーマップの表示と一致させる
- 小文字のキーの場合は2番目に大文字を配置する

KeyAにのみ`A`が定義されていたので他キーにも大文字を適用させましたが，
一律不要でしたら削除する形とします