### PR TITLE
zenz の推論結果で短いものが後から上書きされるバグの修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 614
-        versionName "1.4.493"
+        versionCode 623
+        versionName "1.4.502"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/candidate/CandidateTemp.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/candidate/CandidateTemp.kt
@@ -1,8 +1,0 @@
-package com.kazumaproject.markdownhelperkeyboard.converter.candidate
-
-data class CandidateTemp(
-    val string: String,
-    val wordCost: Int,
-    val leftId: Short? = null,
-    val rightId: Short? = null,
-)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/candidate/ZenzCandidate.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/candidate/ZenzCandidate.kt
@@ -1,0 +1,11 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.candidate
+
+data class ZenzCandidate(
+    val string: String,
+    val type: Byte,
+    val length: UByte,
+    val score: Int,
+    val originalString: String,
+    val leftId: Short? = null,
+    val rightId: Short? = null
+)


### PR DESCRIPTION
## 概要
zenz の推論で使用した入力の文字列と実際に suggestionAdapter に書き込む際に値を比較するように修正