### PR TITLE
片手モードの際に左右のマージンを追加する

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 653
-        versionName "1.4.532"
+        versionCode 654
+        versionName "1.4.533"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -445,6 +445,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var qwertyLandScapePositionPreferenceValue: Boolean? = true
     private var qwertyLandScapeBottomMarginPreferenceValue: Int? = 0
 
+    private var tenkeyStartMarginPreferenceValue: Int? = 0
+    private var tenkeyEndMarginPreferenceValue: Int? = 0
+    private var qwertyStartMarginPreferenceValue: Int? = 0
+    private var qwertyEndMarginPreferenceValue: Int? = 0
+
+    private var tenkeyLandScapeStartMarginPreferenceValue: Int? = 0
+    private var tenkeyLandScapeEndMarginPreferenceValue: Int? = 0
+    private var qwertyLandScapeStartMarginPreferenceValue: Int? = 0
+    private var qwertyLandScapeEndMarginPreferenceValue: Int? = 0
+
     private var zenzEnableStatePreference: Boolean? = false
     private var zenzProfilePreference: String? = ""
     private var zenzEnableLongPressConversionPreference: Boolean? = false
@@ -904,6 +914,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             tenkeyBottomMarginPreferenceValue = keyboard_vertical_margin_bottom ?: 0
             qwertyPositionPreferenceValue = qwerty_keyboard_position ?: true
             qwertyBottomMarginPreferenceValue = qwerty_keyboard_vertical_margin_bottom ?: 0
+
+            tenkeyStartMarginPreferenceValue = keyboard_margin_start_dp ?: 0
+            tenkeyEndMarginPreferenceValue = keyboard_margin_end_dp ?: 0
+            qwertyStartMarginPreferenceValue = qwerty_keyboard_margin_start_dp ?: 0
+            qwertyEndMarginPreferenceValue = qwerty_keyboard_margin_end_dp ?: 0
+
+            tenkeyLandScapeStartMarginPreferenceValue = keyboard_margin_start_dp_landscape
+            tenkeyLandScapeEndMarginPreferenceValue = keyboard_margin_end_dp_landscape
+            qwertyLandScapeStartMarginPreferenceValue = qwerty_keyboard_margin_start_dp_landscape
+            qwertyLandScapeEndMarginPreferenceValue = qwerty_keyboard_margin_end_dp_landscape
 
             tenkeyHeightLandScapePreferenceValue = keyboard_height_landscape ?: 280
             tenkeyWidthLandScapePreferenceValue = keyboard_width_landscape ?: 100
@@ -1504,6 +1524,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         tenkeyBottomMarginPreferenceValue = null
         qwertyPositionPreferenceValue = null
         qwertyBottomMarginPreferenceValue = null
+
+        tenkeyStartMarginPreferenceValue = null
+        tenkeyEndMarginPreferenceValue = null
+        qwertyStartMarginPreferenceValue = null
+        qwertyEndMarginPreferenceValue = null
+
+        tenkeyLandScapeStartMarginPreferenceValue = null
+        tenkeyLandScapeEndMarginPreferenceValue = null
+        qwertyLandScapeStartMarginPreferenceValue = null
+        qwertyLandScapeEndMarginPreferenceValue = null
 
         tenkeyHeightLandScapePreferenceValue = null
         tenkeyWidthLandScapePreferenceValue = null
@@ -6914,7 +6944,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         val qwertyHeightPref: Int,
         val qwertyWidthPref: Int,
         val qwertyBottomMargin: Int,
-        val qwertyPositionIsEnd: Boolean
+        val qwertyPositionIsEnd: Boolean,
+        val keyboardMarginStart: Int,
+        val keyboardMarginEnd: Int,
+        val qwertyMarginStart: Int,
+        val qwertyMarginEnd: Int,
     )
 
     private fun getKeyboardSizePreferences(): KeyboardSizePreferences {
@@ -6929,7 +6963,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 qwertyHeightPref = qwertyHeightPreferenceValue ?: 280,
                 qwertyWidthPref = qwertyWidthPreferenceValue ?: 100,
                 qwertyBottomMargin = qwertyBottomMarginPreferenceValue ?: 0,
-                qwertyPositionIsEnd = qwertyPositionPreferenceValue ?: true
+                qwertyPositionIsEnd = qwertyPositionPreferenceValue ?: true,
+                keyboardMarginStart = tenkeyStartMarginPreferenceValue ?: 0,
+                keyboardMarginEnd = tenkeyEndMarginPreferenceValue ?: 0,
+                qwertyMarginStart = qwertyStartMarginPreferenceValue ?: 0,
+                qwertyMarginEnd = qwertyEndMarginPreferenceValue ?: 0
             )
         } else {
             KeyboardSizePreferences(
@@ -6941,7 +6979,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 qwertyHeightPref = qwertyHeightLandScapePreferenceValue ?: 280,
                 qwertyWidthPref = qwertyWidthLandScapePreferenceValue ?: 100,
                 qwertyBottomMargin = qwertyLandScapeBottomMarginPreferenceValue ?: 0,
-                qwertyPositionIsEnd = qwertyLandScapePositionPreferenceValue ?: true
+                qwertyPositionIsEnd = qwertyLandScapePositionPreferenceValue ?: true,
+                keyboardMarginStart = tenkeyLandScapeStartMarginPreferenceValue ?: 0,
+                keyboardMarginEnd = tenkeyLandScapeEndMarginPreferenceValue ?: 0,
+                qwertyMarginStart = qwertyLandScapeStartMarginPreferenceValue ?: 0,
+                qwertyMarginEnd = qwertyLandScapeEndMarginPreferenceValue ?: 0
             )
         }
     }
@@ -7029,6 +7071,20 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 widthPx
             }
 
+        val finalStartMargin =
+            if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY || qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTYRomaji) {
+                dpToPx(prefs.qwertyMarginStart)
+            } else {
+                dpToPx(prefs.keyboardMarginStart)
+            }
+
+        val finalEndMargin =
+            if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY || qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTYRomaji) {
+                dpToPx(prefs.qwertyMarginEnd)
+            } else {
+                dpToPx(prefs.keyboardMarginEnd)
+            }
+
         val finalBottomMargin =
             if (qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY || qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTYRomaji) {
                 prefs.qwertyBottomMargin
@@ -7047,7 +7103,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
         // 4. レイアウトパラメータの適用
         applyKeyboardLayoutParameters(
-            mainView, heightPx, finalKeyboardHeight, finalKeyboardWidth, gravity, finalBottomMargin
+            mainView = mainView,
+            heightPx = heightPx,
+            finalKeyboardHeight = finalKeyboardHeight,
+            finalKeyboardWidth = finalKeyboardWidth,
+            gravity = gravity,
+            finalBottomMargin = finalBottomMargin,
+            finalStartMargin = finalStartMargin,
+            finalEndMargin = finalEndMargin
         )
 
         if (isSymbol) {
@@ -7082,7 +7145,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         finalKeyboardHeight: Int,
         finalKeyboardWidth: Int,
         gravity: Int,
-        finalBottomMargin: Int
+        finalBottomMargin: Int,
+        finalStartMargin: Int,
+        finalEndMargin: Int
     ) {
         if (shortcutTollbarVisibility == true) {
             (mainView.shortcutToolbarRecyclerview.layoutParams as? FrameLayout.LayoutParams)?.let { param ->
@@ -7113,6 +7178,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             params.height = finalKeyboardHeight
             params.width = finalKeyboardWidth
             params.bottomMargin = finalBottomMargin
+            params.leftMargin = finalStartMargin
+            params.rightMargin = finalEndMargin
             params.gravity = gravity
             mainView.root.layoutParams = params
         }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -287,7 +287,23 @@ object AppPreference {
     private val PREF_UP_RIGHT_START = Pair("circular_flick_up_right_start", 90f)
     private val PREF_UP_RIGHT_SWEEP = Pair("circular_flick_up_right_sweep", 72f)
 
-    private val QWERTY_SWITCH_NUMBER_KEY_WITHOUT_NUMBER_PREFERENCE = Pair("qwerty_switch_number_key_without_number_preference", false)
+    private val QWERTY_SWITCH_NUMBER_KEY_WITHOUT_NUMBER_PREFERENCE =
+        Pair("qwerty_switch_number_key_without_number_preference", false)
+
+    private val KEYBOARD_MARGIN_START_DP = Pair("keyboard_margin_start_dp_preference", 0)
+    private val KEYBOARD_MARGIN_END_DP = Pair("keyboard_margin_end_dp_preference", 0)
+    private val QWERTY_KEYBOARD_MARGIN_START_DP =
+        Pair("qwerty_keyboard_margin_start_dp_preference", 0)
+    private val QWERTY_KEYBOARD_MARGIN_END_DP = Pair("qwerty_keyboard_margin_end_dp_preference", 0)
+
+    private val KEYBOARD_MARGIN_START_DP_LANDSCAPE =
+        Pair("keyboard_margin_start_dp_landscape_preference", 0)
+    private val KEYBOARD_MARGIN_END_DP_LANDSCAPE =
+        Pair("keyboard_margin_end_dp_landscape_preference", 0)
+    private val QWERTY_KEYBOARD_MARGIN_START_DP_LANDSCAPE =
+        Pair("qwerty_keyboard_margin_start_dp_landscape_preference", 0)
+    private val QWERTY_KEYBOARD_MARGIN_END_DP_LANDSCAPE =
+        Pair("qwerty_keyboard_margin_end_dp_landscape_preference", 0)
 
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
@@ -1338,8 +1354,88 @@ object AppPreference {
             QWERTY_SWITCH_NUMBER_KEY_WITHOUT_NUMBER_PREFERENCE.first,
             QWERTY_SWITCH_NUMBER_KEY_WITHOUT_NUMBER_PREFERENCE.second
         )
-        set(value) = preferences.edit { it.putBoolean(QWERTY_SWITCH_NUMBER_KEY_WITHOUT_NUMBER_PREFERENCE.first, value) }
+        set(value) = preferences.edit {
+            it.putBoolean(
+                QWERTY_SWITCH_NUMBER_KEY_WITHOUT_NUMBER_PREFERENCE.first,
+                value
+            )
+        }
 
+
+    var keyboard_margin_start_dp: Int?
+        get() = preferences.getInt(KEYBOARD_MARGIN_START_DP.first, KEYBOARD_MARGIN_START_DP.second)
+        set(value) = preferences.edit { it.putInt(KEYBOARD_MARGIN_START_DP.first, value ?: 0) }
+
+    var keyboard_margin_end_dp: Int?
+        get() = preferences.getInt(KEYBOARD_MARGIN_END_DP.first, KEYBOARD_MARGIN_END_DP.second)
+        set(value) = preferences.edit { it.putInt(KEYBOARD_MARGIN_END_DP.first, value ?: 0) }
+
+    var qwerty_keyboard_margin_start_dp: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_MARGIN_START_DP.first,
+            QWERTY_KEYBOARD_MARGIN_START_DP.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                QWERTY_KEYBOARD_MARGIN_START_DP.first,
+                value ?: 0
+            )
+        }
+
+    var qwerty_keyboard_margin_end_dp: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_MARGIN_END_DP.first,
+            QWERTY_KEYBOARD_MARGIN_END_DP.second
+        )
+        set(value) = preferences.edit { it.putInt(QWERTY_KEYBOARD_MARGIN_END_DP.first, value ?: 0) }
+
+    var keyboard_margin_start_dp_landscape: Int?
+        get() = preferences.getInt(
+            KEYBOARD_MARGIN_START_DP_LANDSCAPE.first,
+            KEYBOARD_MARGIN_START_DP_LANDSCAPE.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                KEYBOARD_MARGIN_START_DP_LANDSCAPE.first,
+                value ?: 0
+            )
+        }
+
+    var keyboard_margin_end_dp_landscape: Int?
+        get() = preferences.getInt(
+            KEYBOARD_MARGIN_END_DP_LANDSCAPE.first,
+            KEYBOARD_MARGIN_END_DP_LANDSCAPE.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                KEYBOARD_MARGIN_END_DP_LANDSCAPE.first,
+                value ?: 0
+            )
+        }
+
+    var qwerty_keyboard_margin_start_dp_landscape: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_MARGIN_START_DP_LANDSCAPE.first,
+            QWERTY_KEYBOARD_MARGIN_START_DP_LANDSCAPE.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                QWERTY_KEYBOARD_MARGIN_START_DP_LANDSCAPE.first,
+                value ?: 0
+            )
+        }
+
+    var qwerty_keyboard_margin_end_dp_landscape: Int?
+        get() = preferences.getInt(
+            QWERTY_KEYBOARD_MARGIN_END_DP_LANDSCAPE.first,
+            QWERTY_KEYBOARD_MARGIN_END_DP_LANDSCAPE.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                QWERTY_KEYBOARD_MARGIN_END_DP_LANDSCAPE.first,
+                value ?: 0
+            )
+        }
 
     /**
      * キーボード側で使用するためのマップ取得メソッド
@@ -1354,7 +1450,8 @@ object AppPreference {
         )
 
         if (circularFlick5DirectionsEnable) {
-            baseMap[FlickDirection.UP_RIGHT] = Pair(circularFlickUpRightStart, circularFlickUpRightSweep)
+            baseMap[FlickDirection.UP_RIGHT] =
+                Pair(circularFlickUpRightStart, circularFlickUpRightSweep)
         }
 
         return baseMap

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_landscape_setting/KeyboardSizeLandscapeFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_landscape_setting/KeyboardSizeLandscapeFragment.kt
@@ -62,6 +62,7 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         applyCurrentPageDimensions()
         setupKeyboardPositionButton()
         setupResetButton()
+
         updateKeyboardAlignment()
         setupResizeHandles()
         setupMoveHandle()
@@ -107,22 +108,30 @@ class KeyboardSizeLandscapeFragment : Fragment() {
 
     private fun applyCurrentPageDimensions() {
         val position = binding.keyboardViewPager.currentItem
+
         val heightPref: Int
         val widthPref: Int
         val marginBottomPref: Int
         val positionPref: Boolean
+        val marginStartDpPref: Int
+        val marginEndDpPref: Int
 
         if (position == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
             heightPref = appPreference.keyboard_height_landscape ?: 220
             widthPref = appPreference.keyboard_width_landscape ?: 100
             marginBottomPref = appPreference.keyboard_vertical_margin_bottom_landscape ?: 0
             positionPref = appPreference.keyboard_position_landscape ?: true
-        } else { // QWERTY
+            marginStartDpPref = appPreference.keyboard_margin_start_dp_landscape ?: 0
+            marginEndDpPref = appPreference.keyboard_margin_end_dp_landscape ?: 0
+        } else {
             heightPref = appPreference.qwerty_keyboard_height_landscape ?: 220
             widthPref = appPreference.qwerty_keyboard_width_landscape ?: 100
             marginBottomPref = appPreference.qwerty_keyboard_vertical_margin_bottom_landscape ?: 0
             positionPref = appPreference.qwerty_keyboard_position_landscape ?: true
+            marginStartDpPref = appPreference.qwerty_keyboard_margin_start_dp_landscape ?: 0
+            marginEndDpPref = appPreference.qwerty_keyboard_margin_end_dp_landscape ?: 0
         }
+
         isRightAligned = positionPref
 
         val density = resources.displayMetrics.density
@@ -131,6 +140,7 @@ class KeyboardSizeLandscapeFragment : Fragment() {
 
         val screenWidth = WindowMetricsCalculator.getOrCreate()
             .computeCurrentWindowMetrics(requireActivity()).bounds.width()
+
         val widthInPx = if (widthPref >= 98) {
             ViewGroup.LayoutParams.MATCH_PARENT
         } else {
@@ -141,7 +151,40 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         layoutParams.height = heightInPx
         layoutParams.width = widthInPx
         layoutParams.bottomMargin = marginBottomInPx
+
+        val marginStartPx = (marginStartDpPref * density).toInt()
+        val marginEndPx = (marginEndDpPref * density).toInt()
+
+        if (isRightAligned) {
+            layoutParams.marginEnd = marginEndPx
+        } else {
+            layoutParams.marginStart = marginStartPx
+        }
+
         binding.keyboardContainer.layoutParams = layoutParams
+
+        clampHorizontalMarginToBounds()
+    }
+
+    private fun clampHorizontalMarginToBounds() {
+        val parent = binding.keyboardSettingConstraint
+        val container = binding.keyboardContainer
+        val lp = container.layoutParams as ConstraintLayout.LayoutParams
+
+        val availableWidth = (parent.width - parent.paddingLeft - parent.paddingRight).toFloat()
+        if (availableWidth <= 0f) return
+
+        val containerWidth = container.width.toFloat()
+        if (containerWidth <= 0f) return
+
+        val maxMargin = (availableWidth - containerWidth).coerceAtLeast(0f).toInt()
+
+        if (isRightAligned) {
+            lp.marginEnd = lp.marginEnd.coerceIn(0, maxMargin)
+        } else {
+            lp.marginStart = lp.marginStart.coerceIn(0, maxMargin)
+        }
+        container.layoutParams = lp
     }
 
     private fun setupMenu() {
@@ -173,39 +216,86 @@ class KeyboardSizeLandscapeFragment : Fragment() {
 
     @SuppressLint("ClickableViewAccessibility")
     private fun setupMoveHandle() {
+        var initialX = 0f
         var initialY = 0f
-        var initialBottomMargin = 0
+
+        var initialBottomMarginPx = 0
+        var initialMarginStartPx = 0
+        var initialMarginEndPx = 0
+
         val density = resources.displayMetrics.density
 
         binding.handleMove.setOnTouchListener { _, event ->
-            val layoutParams =
-                binding.keyboardContainer.layoutParams as ConstraintLayout.LayoutParams
+            val lp = binding.keyboardContainer.layoutParams as ConstraintLayout.LayoutParams
+
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
+                    initialX = event.rawX
                     initialY = event.rawY
-                    initialBottomMargin = layoutParams.bottomMargin
+                    initialBottomMarginPx = lp.bottomMargin
+                    initialMarginStartPx = lp.marginStart
+                    initialMarginEndPx = lp.marginEnd
                     true
                 }
 
                 MotionEvent.ACTION_MOVE -> {
+                    val parent = binding.keyboardSettingConstraint
+                    val availableWidth =
+                        (parent.width - parent.paddingLeft - parent.paddingRight).toFloat()
+                    if (availableWidth <= 0f) return@setOnTouchListener true
+
+                    val containerWidth = binding.keyboardContainer.width.toFloat()
+                    if (containerWidth <= 0f) return@setOnTouchListener true
+
+                    val maxHorizontalMarginPx = (availableWidth - containerWidth).coerceAtLeast(0f)
+
+                    val deltaX = event.rawX - initialX
                     val deltaY = event.rawY - initialY
-                    val newBottomMargin = initialBottomMargin - deltaY
-                    layoutParams.bottomMargin = newBottomMargin.toInt().coerceAtLeast(0)
+
+                    val newBottomMargin = (initialBottomMarginPx - deltaY).toInt().coerceAtLeast(0)
+                    lp.bottomMargin = newBottomMargin
+
+                    if (isRightAligned) {
+                        val newEnd = (initialMarginEndPx - deltaX).toInt()
+                            .coerceIn(0, maxHorizontalMarginPx.toInt())
+                        lp.marginEnd = newEnd
+                    } else {
+                        val newStart = (initialMarginStartPx + deltaX).toInt()
+                            .coerceIn(0, maxHorizontalMarginPx.toInt())
+                        lp.marginStart = newStart
+                    }
+
+                    binding.keyboardContainer.layoutParams = lp
                     binding.keyboardContainer.requestLayout()
                     true
                 }
 
                 MotionEvent.ACTION_UP -> {
-                    val finalMarginDp = (layoutParams.bottomMargin / density).roundToInt()
-                    val currentPage = binding.keyboardViewPager.currentItem
+                    val finalBottomDp = (lp.bottomMargin / density).roundToInt()
+                    val finalStartDp = (lp.marginStart / density).roundToInt()
+                    val finalEndDp = (lp.marginEnd / density).roundToInt()
 
+                    val currentPage = binding.keyboardViewPager.currentItem
                     if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
-                        appPreference.keyboard_vertical_margin_bottom_landscape = finalMarginDp
-                    } else { // QWERTY
+                        appPreference.keyboard_vertical_margin_bottom_landscape = finalBottomDp
+                        if (isRightAligned) {
+                            appPreference.keyboard_margin_end_dp_landscape = finalEndDp
+                        } else {
+                            appPreference.keyboard_margin_start_dp_landscape = finalStartDp
+                        }
+                    } else {
                         appPreference.qwerty_keyboard_vertical_margin_bottom_landscape =
-                            finalMarginDp
+                            finalBottomDp
+                        if (isRightAligned) {
+                            appPreference.qwerty_keyboard_margin_end_dp_landscape = finalEndDp
+                        } else {
+                            appPreference.qwerty_keyboard_margin_start_dp_landscape = finalStartDp
+                        }
                     }
-                    Timber.d("Saved landscape vertical margin for page $currentPage: $finalMarginDp dp")
+
+                    Timber.d(
+                        "Saved landscape move: page=$currentPage bottom=$finalBottomDp dp start=$finalStartDp dp end=$finalEndDp dp alignedRight=$isRightAligned"
+                    )
                     true
                 }
 
@@ -224,6 +314,7 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         val density = resources.displayMetrics.density
         val screenWidth = WindowMetricsCalculator.getOrCreate()
             .computeCurrentWindowMetrics(requireActivity()).bounds.width()
+
         val minHeightPx = minHeightDp * density
         val maxHeightPx = maxHeightDp * density
         val minWidthPx = screenWidth * (minWidthPercent / 100f)
@@ -233,7 +324,7 @@ class KeyboardSizeLandscapeFragment : Fragment() {
             val currentPage = binding.keyboardViewPager.currentItem
             if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
                 appPreference.keyboard_height_landscape = finalHeightDp
-            } else { // QWERTY
+            } else {
                 appPreference.qwerty_keyboard_height_landscape = finalHeightDp
             }
             Timber.d("Saved landscape Height for page $currentPage: $finalHeightDp dp")
@@ -243,23 +334,29 @@ class KeyboardSizeLandscapeFragment : Fragment() {
             val parentView = binding.keyboardSettingConstraint
             val availableWidth =
                 (parentView.width - parentView.paddingLeft - parentView.paddingRight).toFloat()
-            if (availableWidth <= 0) return
+
+            if (availableWidth <= 0f) return
+
             val currentWidth = binding.keyboardContainer.width.toFloat()
             val finalWidthPercent = ((currentWidth / availableWidth) * 100).roundToInt()
             val finalWidthValue = if (finalWidthPercent >= 98) 100 else finalWidthPercent
+
             val currentPage = binding.keyboardViewPager.currentItem
             if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
                 appPreference.keyboard_width_landscape = finalWidthValue
-            } else { // QWERTY
+            } else {
                 appPreference.qwerty_keyboard_width_landscape = finalWidthValue
             }
             Timber.d("Saved landscape Width for page $currentPage: $finalWidthValue %")
+
+            clampHorizontalMarginToBounds()
         }
 
         binding.handleTop.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialY = event.rawY; initialHeight = binding.keyboardContainer.height
+                    initialY = event.rawY
+                    initialHeight = binding.keyboardContainer.height
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -277,7 +374,8 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         binding.handleBottom.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialY = event.rawY; initialHeight = binding.keyboardContainer.height
+                    initialY = event.rawY
+                    initialHeight = binding.keyboardContainer.height
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -295,7 +393,8 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         binding.handleLeft.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialX = event.rawX; initialWidth = binding.keyboardContainer.width
+                    initialX = event.rawX
+                    initialWidth = binding.keyboardContainer.width
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -314,7 +413,8 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         binding.handleRight.setOnTouchListener { _, event ->
             when (event.action) {
                 MotionEvent.ACTION_DOWN -> {
-                    initialX = event.rawX; initialWidth = binding.keyboardContainer.width
+                    initialX = event.rawX
+                    initialWidth = binding.keyboardContainer.width
                 }
 
                 MotionEvent.ACTION_MOVE -> {
@@ -346,11 +446,19 @@ class KeyboardSizeLandscapeFragment : Fragment() {
                 appPreference.keyboard_width_landscape = 100
                 appPreference.keyboard_vertical_margin_bottom_landscape = 0
                 appPreference.keyboard_position_landscape = true
+
+                // 追加: 左右 margin も reset
+                appPreference.keyboard_margin_start_dp_landscape = 0
+                appPreference.keyboard_margin_end_dp_landscape = 0
             } else {
                 appPreference.qwerty_keyboard_height_landscape = 220
                 appPreference.qwerty_keyboard_width_landscape = 100
                 appPreference.qwerty_keyboard_vertical_margin_bottom_landscape = 0
                 appPreference.qwerty_keyboard_position_landscape = true
+
+                // 追加: 左右 margin も reset
+                appPreference.qwerty_keyboard_margin_start_dp_landscape = 0
+                appPreference.qwerty_keyboard_margin_end_dp_landscape = 0
             }
             applyCurrentPageDimensions()
             updateKeyboardAlignment()
@@ -377,11 +485,22 @@ class KeyboardSizeLandscapeFragment : Fragment() {
                 ConstraintSet.END
             )
             constraintSet.clear(binding.keyboardContainer.id, ConstraintSet.START)
+
             binding.keyboardPositionButton.setBackgroundColor(
                 ContextCompat.getColor(requireContext(), com.kazumaproject.core.R.color.blue)
             )
             binding.keyboardPositionButton.text =
                 getString(R.string.key_size_position_button_text_right)
+
+            val endDp = if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                appPreference.keyboard_margin_end_dp_landscape ?: 0
+            } else {
+                appPreference.qwerty_keyboard_margin_end_dp_landscape ?: 0
+            }
+            val lp = binding.keyboardContainer.layoutParams as ConstraintLayout.LayoutParams
+            lp.marginEnd = (endDp * resources.displayMetrics.density).toInt()
+            binding.keyboardContainer.layoutParams = lp
+
         } else {
             constraintSet.connect(
                 binding.keyboardContainer.id,
@@ -390,6 +509,7 @@ class KeyboardSizeLandscapeFragment : Fragment() {
                 ConstraintSet.START
             )
             constraintSet.clear(binding.keyboardContainer.id, ConstraintSet.END)
+
             binding.keyboardPositionButton.setBackgroundColor(
                 ContextCompat.getColor(
                     requireContext(),
@@ -398,8 +518,19 @@ class KeyboardSizeLandscapeFragment : Fragment() {
             )
             binding.keyboardPositionButton.text =
                 getString(R.string.key_size_position_button_text_left)
+
+            val startDp = if (currentPage == KeyboardViewPagerAdapter.TEN_KEY_PAGE_POSITION) {
+                appPreference.keyboard_margin_start_dp_landscape ?: 0
+            } else {
+                appPreference.qwerty_keyboard_margin_start_dp_landscape ?: 0
+            }
+            val lp = binding.keyboardContainer.layoutParams as ConstraintLayout.LayoutParams
+            lp.marginStart = (startDp * resources.displayMetrics.density).toInt()
+            binding.keyboardContainer.layoutParams = lp
         }
+
         constraintSet.applyTo(constraintLayout)
+        clampHorizontalMarginToBounds()
     }
 
     private fun updateTooltipUI(selectedPosition: Int) {


### PR DESCRIPTION
## Issue
#586 

## 概要
キーボードの位置を上下左右に移動できるようにして片手モードの時にキーボードの位置を端だけでなく自由に定義できるようにした。