### PR TITLE
右側の文脈を考慮した zenz の設定の追加

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 659
-        versionName "1.4.538"
+        versionCode 660
+        versionName "1.4.539"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -310,6 +310,9 @@ object AppPreference {
     private val SAVE_LAST_USED_KEYBOARD = Pair("save_last_used_keyboard", false)
     private val SAVE_LAST_USED_KEYBOARD_POSITION = Pair("save_last_used_keyboard_int", 0)
 
+    private val ENABLE_ZENZ_RIGHT_CONTEXT_PREFERENCE =
+        Pair("enable_zenz_right_context_preference", false)
+
     fun init(context: Context) {
         preferences = PreferenceManager.getDefaultSharedPreferences(context)
     }
@@ -1467,6 +1470,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putInt(SAVE_LAST_USED_KEYBOARD_POSITION.first, value)
+        }
+
+    var enable_zenz_right_context_preference: Boolean
+        get() = preferences.getBoolean(
+            ENABLE_ZENZ_RIGHT_CONTEXT_PREFERENCE.first,
+            ENABLE_ZENZ_RIGHT_CONTEXT_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(ENABLE_ZENZ_RIGHT_CONTEXT_PREFERENCE.first, value)
         }
 
     /**

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -433,4 +433,6 @@
     <string name="drag_item">drag item</string>
     <string name="save_last_used_keyboard_title">最後に使ったキーボードを表示</string>
     <string name="save_last_used_keyboard_summey">アプリ再起動時に、前回使用したキーボードを自動で表示します</string>
+    <string name="enable_zenz_right_context_preference_title">右側の文脈を利用する</string>
+    <string name="enable_zenz_right_context_preference_summary">カーソルの左側に文がない場合、右側の文脈も考慮して変換候補を表示します</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -435,4 +435,6 @@
     <string name="drag_item">drag item</string>
     <string name="save_last_used_keyboard_title">Show last used keyboard</string>
     <string name="save_last_used_keyboard_summey">Automatically shows the keyboard you used last time when the app restarts.</string>
+    <string name="enable_zenz_right_context_preference_title">Use right-side context</string>
+    <string name="enable_zenz_right_context_preference_summary">If there is no text to the left of the cursor, conversion candidates are generated using the context on the right.</string>
 </resources>

--- a/app/src/main/res/xml/pref_zenz.xml
+++ b/app/src/main/res/xml/pref_zenz.xml
@@ -20,6 +20,12 @@
             app:defaultValue=""
             app:summary="@string/zenz_profile_preference_summary" />
 
+        <SwitchPreferenceCompat
+            android:key="enable_zenz_right_context_preference"
+            app:defaultValue="false"
+            android:title="@string/enable_zenz_right_context_preference_title"
+            app:summary="@string/enable_zenz_right_context_preference_summary"/>
+
         <SeekBarPreference
             android:defaultValue="300"
             android:key="zenz_debounce_time_preference"

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -4726,7 +4726,8 @@ object KeyboardDefaultLayouts {
                         ), TfbiFlickDirection.UP to mapOf(
                             TfbiFlickDirection.TAP to "あ",
                             TfbiFlickDirection.UP to "う",
-                            TfbiFlickDirection.UP_LEFT to "ぅ"
+                            TfbiFlickDirection.UP_LEFT to "ぅ",
+                            TfbiFlickDirection.UP_RIGHT to "ゔ",
                         ), TfbiFlickDirection.RIGHT to mapOf(
                             TfbiFlickDirection.TAP to "あ",
                             TfbiFlickDirection.RIGHT to "え",
@@ -6431,7 +6432,8 @@ object KeyboardDefaultLayouts {
                         ), TfbiFlickDirection.UP to mapOf(
                             TfbiFlickDirection.TAP to "あ",
                             TfbiFlickDirection.UP to "う",
-                            TfbiFlickDirection.UP_LEFT to "ぅ"
+                            TfbiFlickDirection.UP_LEFT to "ぅ",
+                            TfbiFlickDirection.UP_RIGHT to "ゔ"
                         ), TfbiFlickDirection.RIGHT to mapOf(
                             TfbiFlickDirection.TAP to "あ",
                             TfbiFlickDirection.RIGHT to "え",
@@ -8477,7 +8479,8 @@ object KeyboardDefaultLayouts {
                         ), TfbiFlickDirection.UP to mapOf(
                             TfbiFlickDirection.TAP to "あ",
                             TfbiFlickDirection.UP to "う",
-                            TfbiFlickDirection.UP_LEFT to "ぅ"
+                            TfbiFlickDirection.UP_LEFT to "ぅ",
+                            TfbiFlickDirection.UP_RIGHT to "ゔ"
                         ), TfbiFlickDirection.RIGHT to mapOf(
                             TfbiFlickDirection.TAP to "あ",
                             TfbiFlickDirection.RIGHT to "え",
@@ -9603,7 +9606,8 @@ object KeyboardDefaultLayouts {
         )
         val subMenu_A_U = mapOf(
             TfbiFlickDirection.UP to TfbiFlickNode.Input("う"),
-            TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input("ぅ")
+            TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input("ぅ"),
+            TfbiFlickDirection.UP_RIGHT to TfbiFlickNode.Input("ゔ")
         )
         val subMenu_A_E = mapOf(
             TfbiFlickDirection.RIGHT to TfbiFlickNode.Input("え"),


### PR DESCRIPTION
## Issue
#534 

## 概要
カーソルより左側にテキストが存在しない場合、右側の文脈を考慮する設定の追加