### PR TITLE
特定のアプリでエンターキーで送信ではなく、改行となるバグの修正

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -605,6 +605,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         )
     }
 
+    private val cachedSendDrawable: Drawable? by lazy {
+        ContextCompat.getDrawable(
+            applicationContext, com.kazumaproject.core.R.drawable.send_24px
+        )
+    }
+
     private val cachedReturnDrawable: Drawable? by lazy {
         ContextCompat.getDrawable(
             applicationContext, com.kazumaproject.core.R.drawable.baseline_keyboard_return_24
@@ -8012,6 +8018,15 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             )
                         }
 
+                        InputTypeForIME.TextSend -> {
+                            currentInputMode.set(InputMode.ModeJapanese)
+                            setInputModeSwitchState()
+                            setSideKeyPreviousState(true)
+                            this.setSideKeyEnterDrawable(
+                                cachedSendDrawable
+                            )
+                        }
+
                         InputTypeForIME.TextMultiLine,
                         InputTypeForIME.TextImeMultiLine,
                         InputTypeForIME.TextShortMessage,
@@ -8150,6 +8165,15 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             setFirstKeyboardType()
                         }
 
+                        InputTypeForIME.TextSend -> {
+                            setCurrentMode(InputMode.ModeJapanese)
+                            setSideKeyPreviousState(true)
+                            this.setSideKeyEnterDrawable(
+                                cachedSendDrawable
+                            )
+                            setFirstKeyboardType()
+                        }
+
                         InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
                             setCurrentMode(InputMode.ModeJapanese)
                             setSideKeyPreviousState(true)
@@ -8248,6 +8272,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             setSideKeyPreviousState(true)
                             this.setSideKeyEnterDrawable(
                                 cachedCheckDrawable
+                            )
+                        }
+
+                        InputTypeForIME.TextSend -> {
+                            setCurrentMode(InputMode.ModeJapanese)
+                            setSideKeyPreviousState(true)
+                            this.setSideKeyEnterDrawable(
+                                cachedSendDrawable
                             )
                         }
 
@@ -11062,6 +11094,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             InputTypeForIME.TextWebPassword,
             InputTypeForIME.TextNotCursorUpdate,
             InputTypeForIME.TextEditTextInWebView,
+            InputTypeForIME.TextSend
                 -> {
                 Timber.d("Enter key: called 3\n")
                 sendDownUpKeyEvents(KeyEvent.KEYCODE_ENTER)
@@ -11588,6 +11621,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 cachedCheckDrawable
             }
 
+            InputTypeForIME.TextSend -> {
+                cachedSendDrawable
+            }
+
             else -> {
                 cachedArrowRightDrawable
             }
@@ -11615,6 +11652,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             InputTypeForIME.TextDone -> {
                 cachedCheckDrawable
+            }
+
+            InputTypeForIME.TextSend -> {
+                cachedSendDrawable
             }
 
             else -> {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeExtension.kt
@@ -215,6 +215,7 @@ private fun getTextRelatedInputType(editorInfo: EditorInfo): InputTypeForIME {
     when (imeAction) {
         EditorInfo.IME_ACTION_SEARCH -> return InputTypeForIME.TextSearchView
         EditorInfo.IME_ACTION_GO -> return InputTypeForIME.TextUri // ブラウザのURLバーなど
+        EditorInfo.IME_ACTION_SEND -> return InputTypeForIME.TextSend
     }
 
     // 優先度3: 複数行の判定（最重要）
@@ -235,7 +236,6 @@ private fun getTextRelatedInputType(editorInfo: EditorInfo): InputTypeForIME {
     when (imeAction) {
         EditorInfo.IME_ACTION_NEXT -> return InputTypeForIME.TextNextLine
         EditorInfo.IME_ACTION_DONE -> return InputTypeForIME.TextDone
-        EditorInfo.IME_ACTION_SEND -> return InputTypeForIME.TextDone
     }
 
     // 優先度5: フォールバック

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeForIME.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/InputTypeForIME.kt
@@ -35,6 +35,10 @@ fun InputTypeForIME.getQWERTYReturnTextInJp(): String {
             "確定"
         }
 
+        InputTypeForIME.TextSend -> {
+            "送信"
+        }
+
         InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
             "検索"
         }
@@ -98,7 +102,11 @@ fun InputTypeForIME.getQWERTYReturnTextInEn(): String {
         }
 
         InputTypeForIME.TextDone -> {
-            "return"
+            "done"
+        }
+
+        InputTypeForIME.TextSend -> {
+            "send"
         }
 
         InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
@@ -163,10 +171,6 @@ fun InputTypeForIME.getEnterKeyIndexSumire(): Int {
             4
         }
 
-        InputTypeForIME.TextDone -> {
-            1
-        }
-
         InputTypeForIME.TextWebSearchView, InputTypeForIME.TextWebSearchViewFireFox, InputTypeForIME.TextSearchView -> {
             3
         }
@@ -196,6 +200,14 @@ fun InputTypeForIME.getEnterKeyIndexSumire(): Int {
         InputTypeForIME.Time,
             -> {
             1
+        }
+
+        InputTypeForIME.TextDone ->{
+            5
+        }
+
+        InputTypeForIME.TextSend -> {
+            6
         }
 
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/state/InputTypeForIME.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/state/InputTypeForIME.kt
@@ -31,6 +31,8 @@ sealed class InputTypeForIME {
     data object TextWebPassword : InputTypeForIME()
     data object TextWebSearchView : InputTypeForIME()
 
+    data object TextSend: InputTypeForIME()
+
     data object TextSearchView : InputTypeForIME()
     data object TextEditTextInWebView : InputTypeForIME()
     data object TextWebSearchViewFireFox : InputTypeForIME()

--- a/core/src/main/res/drawable/send_24px.xml
+++ b/core/src/main/res/drawable/send_24px.xml
@@ -1,0 +1,11 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:autoMirrored="true"
+    android:tint="@color/keyboard_icon_color"
+    android:viewportWidth="960"
+    android:viewportHeight="960">
+    <path
+        android:fillColor="@color/keyboard_icon_color"
+        android:pathData="M120,800L120,160L880,480L120,800ZM200,680L674,480L200,280L200,420L440,480L200,540L200,680ZM200,680L200,480L200,280L200,420L200,420L200,540L200,540L200,680Z" />
+</vector>

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -150,7 +150,11 @@ object KeyboardDefaultLayouts {
         ), FlickAction.Action(
             KeyAction.Enter, "検索",
         ), FlickAction.Action(KeyAction.Enter, "次"),
-        FlickAction.Action(KeyAction.Enter, "確定")
+        FlickAction.Action(KeyAction.Enter, "確定"),
+        FlickAction.Action(
+            KeyAction.Enter,
+            drawableResId = com.kazumaproject.core.R.drawable.send_24px
+        )
     )
 
     private val dakutenToggleStates = listOf(
@@ -201,13 +205,20 @@ object KeyboardDefaultLayouts {
         FlickAction.Action(
             KeyAction.Confirm,
             drawableResId = com.kazumaproject.core.R.drawable.baseline_arrow_right_alt_24
-        ), FlickAction.Action(
+        ),
+        FlickAction.Action(
             KeyAction.Enter,
             drawableResId = com.kazumaproject.core.R.drawable.baseline_keyboard_return_24,
-        ), FlickAction.Action(
+        ),
+        FlickAction.Action(
             KeyAction.Enter, "Go",
-        ), FlickAction.Action(KeyAction.Enter, "Next"),
-        FlickAction.Action(KeyAction.Enter, "確定")
+        ),
+        FlickAction.Action(KeyAction.Enter, "Next"),
+        FlickAction.Action(KeyAction.Enter, "確定"),
+        FlickAction.Action(
+            KeyAction.Enter,
+            drawableResId = com.kazumaproject.core.R.drawable.send_24px
+        )
     )
 
     /**


### PR DESCRIPTION
## 概要
特定のアプリにおいてエンターキーの挙動が送信のアクションでなく改行になってしまうバグの修正。

不具合の報告を受けたアプリ： `Yantra Launcher`