### PR TITLE
エンターキーで改行を行う挙動の修正

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 681
-        versionName "1.5.7"
+        versionCode 682
+        versionName "1.5.8"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -18,7 +18,6 @@ import android.os.Build
 import android.os.Bundle
 import android.os.CombinedVibration
 import android.os.Handler
-import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.os.VibratorManager
@@ -11056,29 +11055,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         lastFlickConvertedNextHiragana.set(true)
     }
 
-    private fun sendShiftEnter() {
-        val ic = currentInputConnection ?: return
-        val now = SystemClock.uptimeMillis()
-
-        // 1) SHIFT down
-        ic.sendKeyEvent(
-            KeyEvent(now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_SHIFT_LEFT, 0, 0)
-        )
-
-        // 2) ENTER down/up with SHIFT meta
-        ic.sendKeyEvent(
-            KeyEvent(now, now, KeyEvent.ACTION_DOWN, KeyEvent.KEYCODE_ENTER, 0, KeyEvent.META_SHIFT_ON)
-        )
-        ic.sendKeyEvent(
-            KeyEvent(now, now, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_ENTER, 0, KeyEvent.META_SHIFT_ON)
-        )
-
-        // 3) SHIFT up
-        ic.sendKeyEvent(
-            KeyEvent(now, now, KeyEvent.ACTION_UP, KeyEvent.KEYCODE_SHIFT_LEFT, 0, 0)
-        )
-    }
-
     private fun setEnterKeyPress() {
         Timber.d("setEnterKeyPress: $currentInputType")
         when (currentInputType) {
@@ -11087,7 +11063,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             InputTypeForIME.TextShortMessage,
             InputTypeForIME.TextLongMessage,
                 -> {
-                sendShiftEnter()
+                commitText("\n", 1)
             }
 
             InputTypeForIME.None,


### PR DESCRIPTION
## 概要
改行の挙動を `Shift + Enter` を送信する方針で修正をしたのだが、 ChatGPT ではうまく動かなかった。
`commitText("\n", 1)` では一部の WebView でうまく改行できなかったが Gboard も同様に改行ができないため、一部のエディタは `\n` で送信してしまうみたいだ。
IME 側で修正しようとすると他に影響が出る可能性があるため、元に戻した。