### PR TITLE
zenzai に相当する機能の実装

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -29,8 +29,8 @@ android {
         applicationId "com.kazumaproject.markdownhelperkeyboard"
         minSdk 24
         targetSdk 36
-        versionCode 683
-        versionName "1.5.9"
+        versionCode 684
+        versionName "1.6.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -512,10 +512,16 @@ class SuggestionAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
             /** 漢数字 **/
             (32).toByte() -> ""
             /** Zenz **/
-            (33).toByte() -> "[AI]"
+            (33).toByte() -> "[z]"
             (34).toByte() -> "[履歴]"
             /** Typo Correction QWERTY **/
             (35).toByte() -> "[修正]"
+
+            (36).toByte() -> ""
+            (37).toByte() -> "[Z]"
+            (38).toByte() -> ""
+            (39).toByte() -> ""
+            (40).toByte() -> "[Z]"
             else -> ""
         }
         holder.itemView.isPressed = position == highlightedPosition

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/models/CandidateEvaluationResult.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/models/CandidateEvaluationResult.kt
@@ -1,0 +1,47 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.models
+
+sealed class CandidateEvaluationResult {
+    /** エラーが発生した場合 */
+    data object Error : CandidateEvaluationResult()
+
+    /** 候補がモデルの予測と一致した場合 */
+    data class Pass(val score: Float) : CandidateEvaluationResult()
+
+    /** 候補がモデルの予測と一致しなかった場合。prefixは一致した接頭辞 + モデルが予測したトークン */
+    data class FixRequired(val prefix: String) : CandidateEvaluationResult()
+
+    /** EOSが先に出現した場合。resultはその位置までの結果 */
+    data class WholeResult(val result: String) : CandidateEvaluationResult()
+
+    companion object {
+        /**
+         * JNI から返された文字列を解析して CandidateEvaluationResult に変換する
+         * フォーマット:
+         * - "PASS:<score>"
+         * - "FIX:<prefix>"
+         * - "WHOLE:<result>"
+         * - "ERROR"
+         */
+        fun parse(raw: String?): CandidateEvaluationResult {
+            return when {
+                null == raw -> Error
+                raw.startsWith("PASS:") -> {
+                    val score = raw.removePrefix("PASS:").toFloatOrNull() ?: 0f
+                    Pass(score)
+                }
+
+                raw.startsWith("FIX:") -> {
+                    val prefix = raw.removePrefix("FIX:")
+                    FixRequired(prefix)
+                }
+
+                raw.startsWith("WHOLE:") -> {
+                    val result = raw.removePrefix("WHOLE:")
+                    WholeResult(result)
+                }
+
+                else -> Error
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -216,6 +216,9 @@ object AppPreference {
     private val ENABLE_ZENZ_PREFERENCE =
         Pair("enable_ai_conversion_zenz_preference", false)
 
+    private val ENABLE_ZENZAI_PREFERENCE =
+        Pair("enable_ai_conversion_zenzai_preference", false)
+
     private val ZENZ_PROFILE_PREFERENCE =
         Pair("zenz_profile_string_preference", "")
 
@@ -1083,6 +1086,15 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(ENABLE_ZENZ_PREFERENCE.first, value)
+        }
+
+    var enable_zenzai_preference: Boolean
+        get() = preferences.getBoolean(
+            ENABLE_ZENZAI_PREFERENCE.first,
+            ENABLE_ZENZAI_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(ENABLE_ZENZAI_PREFERENCE.first, value)
         }
 
     var zenz_profile_preference: String

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -440,4 +440,6 @@
     <string name="enable_typo_correction_japanese_flick_keyboard_preference_sumary">フリック入力でミスを検知した場合、補正した変換候補を表示します。</string>
     <string name="enable_typo_correction_qwerty_english_keyboard_preference_title">QWERTY（英語）</string>
     <string name="enable_typo_correction_qwerty_english_keyboard_preference_summary">QWERTY入力でミスを検知した場合、補正した候補を表示します。</string>
+    <string name="enable_zenzai_preference_title">zenzai を有効にする</string>
+    <string name="enable_ai_conversion_zenz_preference_summary">zenz の結果と変換候補を再評価する（zanzai 相当）機能を有効にします。</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -442,4 +442,6 @@
     <string name="enable_typo_correction_japanese_flick_keyboard_preference_sumary">If a typo is detected while using flick input, corrected conversion candidates are shown.</string>
     <string name="enable_typo_correction_qwerty_english_keyboard_preference_title">QWERTY（English）</string>
     <string name="enable_typo_correction_qwerty_english_keyboard_preference_summary">If a typo is detected while using a QWERTY keyboard, corrected candidates are shown.</string>
+    <string name="enable_zenzai_preference_title">Enable Zenzai</string>
+    <string name="enable_ai_conversion_zenz_preference_summary">Enables zenzai (zanzai-equivalent) re-ranking for zenz output and conversion candidates.</string>
 </resources>

--- a/app/src/main/res/xml/pref_zenz.xml
+++ b/app/src/main/res/xml/pref_zenz.xml
@@ -9,6 +9,13 @@
             android:title="@string/enable_ai_preference_title"
             app:summary="@string/enable_ai_preference_summary" />
 
+        <SwitchPreferenceCompat
+            android:key="enable_ai_conversion_zenzai_preference"
+            android:dependency="enable_ai_conversion_zenz_preference"
+            android:summary="@string/enable_ai_conversion_zenz_preference_summary"
+            android:title="@string/enable_zenzai_preference_title"
+            app:defaultValue="false" />
+
         <Preference
             android:key="zenz_model_select_preference"
             android:title="モデルの読み込み元"
@@ -22,9 +29,9 @@
 
         <SwitchPreferenceCompat
             android:key="enable_zenz_right_context_preference"
-            app:defaultValue="false"
             android:title="@string/enable_zenz_right_context_preference_title"
-            app:summary="@string/enable_zenz_right_context_preference_summary"/>
+            app:defaultValue="false"
+            app:summary="@string/enable_zenz_right_context_preference_summary" />
 
         <SeekBarPreference
             android:defaultValue="300"

--- a/core/src/main/java/com/kazumaproject/core/domain/extensions/String.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/extensions/String.kt
@@ -485,3 +485,34 @@ fun String.toZenkaku(): String {
     }
     return sb.toString()
 }
+
+fun String.kanjiCount(): Int {
+    var c = 0
+    for (ch in this) {
+        val block = Character.UnicodeBlock.of(ch)
+        if (block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS ||
+            block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_A ||
+            block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_B ||
+            block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_C ||
+            block == Character.UnicodeBlock.CJK_UNIFIED_IDEOGRAPHS_EXTENSION_D ||
+            block == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS ||
+            block == Character.UnicodeBlock.CJK_COMPATIBILITY_IDEOGRAPHS_SUPPLEMENT
+        ) {
+            c++
+        }
+    }
+    return c
+}
+
+fun String.duplicateCharCount(): Int {
+    // 2回目以降の総数（重複が多いほど大きい）
+    val counts = this.groupingBy { it }.eachCount()
+    return counts.values.sumOf { (it - 1).coerceAtLeast(0) }
+}
+
+// もし「同じ文字が連続しているのが嫌」なら、こちらも併用できます
+fun String.maxCharFrequency(): Int {
+    // 1文字が最大何回出現するか（小さいほど偏りが少ない）
+    val counts = this.groupingBy { it }.eachCount()
+    return counts.values.maxOrNull() ?: 0
+}

--- a/zenz/src/main/cpp/zenz_bridge.cpp
+++ b/zenz/src/main/cpp/zenz_bridge.cpp
@@ -1,7 +1,9 @@
 #include <jni.h>
 #include <string>
 #include <vector>
-#include <mutex>        // ★ 追加
+#include <mutex>
+#include <cstdint>
+#include <cmath>
 #include <android/log.h>
 #include "llama.h"
 
@@ -14,11 +16,115 @@ static llama_model *g_model = nullptr;
 static const llama_vocab *g_vocab = nullptr;
 
 // ランタイム設定用パラメータ（Kotlin から変更可能）
-static int g_param_n_ctx           = 512;
-static int g_param_n_threads       = 4;
+static int g_param_n_ctx = 512;
+static int g_param_n_threads = 4;
 static int g_param_n_threads_batch = 4;
-static int g_param_n_batch         = 512;
+static int g_param_n_batch = 512;
 static std::mutex g_param_mutex;   // 設定値の読み書き用
+
+// 候補評価の結果タイプ
+enum class CandidateEvaluationResultType {
+    ERROR,
+    PASS,
+    FIX_REQUIRED,
+    WHOLE_RESULT
+};
+
+// 候補評価の結果
+struct CandidateEvaluationResult {
+    CandidateEvaluationResultType type;
+    float score;                // PASS の場合のスコア
+    std::string prefix;         // FIX_REQUIRED の場合の接頭辞
+    std::string whole_result;   // WHOLE_RESULT の場合の結果
+};
+
+// ------- JNI文字列変換（重要） -------
+// llama_token_to_piece() が返すバイト列は不正UTF-8になり得るため、NewStringUTFは禁止。
+// UTF-8(不正あり得る) -> UTF-16(不正は U+FFFD 置換) -> NewString で返す。
+
+static inline void append_u16(std::u16string &out, uint32_t cp) {
+    if (cp <= 0xFFFF) {
+        out.push_back(static_cast<char16_t>(cp));
+    } else {
+        cp -= 0x10000;
+        out.push_back(static_cast<char16_t>(0xD800 + (cp >> 10)));
+        out.push_back(static_cast<char16_t>(0xDC00 + (cp & 0x3FF)));
+    }
+}
+
+static std::u16string utf8_to_utf16_lossy(const uint8_t *s, size_t n) {
+    std::u16string out;
+    out.reserve(n);
+
+    size_t i = 0;
+    while (i < n) {
+        uint8_t b0 = s[i];
+
+        // ASCII
+        if (b0 <= 0x7F) {
+            out.push_back(static_cast<char16_t>(b0));
+            i += 1;
+            continue;
+        }
+
+        int len = 0;
+        uint32_t cp = 0;
+        if ((b0 & 0xE0) == 0xC0) { len = 2; cp = b0 & 0x1F; }
+        else if ((b0 & 0xF0) == 0xE0) { len = 3; cp = b0 & 0x0F; }
+        else if ((b0 & 0xF8) == 0xF0) { len = 4; cp = b0 & 0x07; }
+        else {
+            out.push_back(u'\uFFFD');
+            i += 1;
+            continue;
+        }
+
+        if (i + static_cast<size_t>(len) > n) {
+            out.push_back(u'\uFFFD');
+            break;
+        }
+
+        bool ok = true;
+        for (int k = 1; k < len; ++k) {
+            uint8_t bx = s[i + k];
+            if ((bx & 0xC0) != 0x80) { ok = false; break; }
+            cp = (cp << 6) | (bx & 0x3F);
+        }
+
+        if (ok) {
+            // overlong
+            if (len == 2 && cp < 0x80) ok = false;
+            if (len == 3 && cp < 0x800) ok = false;
+            if (len == 4 && cp < 0x10000) ok = false;
+
+            // surrogate / range
+            if (cp >= 0xD800 && cp <= 0xDFFF) ok = false;
+            if (cp > 0x10FFFF) ok = false;
+        }
+
+        if (!ok) {
+            out.push_back(u'\uFFFD');
+            i += 1; // resync
+            continue;
+        }
+
+        append_u16(out, cp);
+        i += static_cast<size_t>(len);
+    }
+
+    return out;
+}
+
+static jstring toJString(JNIEnv *env, const std::string &bytes) {
+    const auto *p = reinterpret_cast<const uint8_t *>(bytes.data());
+    std::u16string u16 = utf8_to_utf16_lossy(p, bytes.size());
+    return env->NewString(reinterpret_cast<const jchar *>(u16.data()),
+                          static_cast<jsize>(u16.size()));
+}
+
+static jstring toJString(JNIEnv *env, const char *cstr) {
+    if (!cstr) return env->NewString(reinterpret_cast<const jchar *>(u""), 0);
+    return toJString(env, std::string(cstr));
+}
 
 // ------- 共通ヘルパー -------
 
@@ -31,10 +137,8 @@ static std::string preprocess_text(const std::string &text) {
 
     for (unsigned char c: text) {
         if (c == ' ') {
-            // UTF-8 の全角スペース U+3000
             out.append(u8"\u3000");
         } else if (c == '\n' || c == '\r') {
-            // 捨てる
             continue;
         } else {
             out.push_back(static_cast<char>(c));
@@ -67,7 +171,6 @@ static std::vector<llama_token> tokenize_text(const std::string &text, bool add_
             /*parse_special=*/false);
 
     if (n_tokens < 0) {
-        // -n_tokens が必要な長さ
         n_max = -n_tokens;
         tokens.resize(n_max);
         n_tokens = llama_tokenize(
@@ -94,12 +197,11 @@ static std::vector<llama_token> tokenize_text(const std::string &text, bool add_
     return tokens;
 }
 
-// 1トークン -> UTF-8 文字列
+// 1トークン -> UTF-8 文字列（不正UTF-8が混ざり得る）
 static std::string token_to_piece_str(llama_token token) {
     std::string out;
     if (!g_vocab) return out;
 
-    // 最初は 8 バイト確保
     int32_t buf_size = 8;
     std::vector<char> buf(buf_size);
 
@@ -138,12 +240,11 @@ static llama_context *create_context() {
     llama_context_params cparams = llama_context_default_params();
 
     {
-        // 設定値の読み取り時のみロック（ごく短時間）
         std::lock_guard<std::mutex> lock(g_param_mutex);
-        cparams.n_ctx           = g_param_n_ctx;
-        cparams.n_threads       = g_param_n_threads;
+        cparams.n_ctx = g_param_n_ctx;
+        cparams.n_threads = g_param_n_threads;
         cparams.n_threads_batch = g_param_n_threads_batch;
-        cparams.n_batch         = g_param_n_batch;
+        cparams.n_batch = g_param_n_batch;
     }
 
     llama_context *ctx = llama_init_from_model(g_model, cparams);
@@ -157,7 +258,6 @@ static llama_context *create_context() {
 }
 
 // Swift の pure_greedy_decoding 相当
-// ※ここで毎回コンテキストを生成・破棄する
 static std::string pure_greedy_decoding(const std::string &leftSideContext, int maxCount) {
     if (!g_model || !g_vocab) {
         return "[error] model not initialized";
@@ -168,7 +268,6 @@ static std::string pure_greedy_decoding(const std::string &leftSideContext, int 
         return "[error] failed to create context";
     }
 
-    // 1. 前処理 & トークナイズ (BOS なし, EOS なし)
     std::string pre = preprocess_text(leftSideContext);
     auto prompt_tokens = tokenize_text(pre, /*add_bos=*/false, /*add_eos=*/false);
     if (prompt_tokens.empty()) {
@@ -176,7 +275,6 @@ static std::string pure_greedy_decoding(const std::string &leftSideContext, int 
         return "";
     }
 
-    // 2. プロンプトを一度まとめて decode
     {
         llama_batch batch = llama_batch_get_one(
                 prompt_tokens.data(),
@@ -190,7 +288,6 @@ static std::string pure_greedy_decoding(const std::string &leftSideContext, int 
         }
     }
 
-    // 3. greedy で maxCount トークンまで生成
     std::vector<llama_token> generated;
     generated.reserve(maxCount);
 
@@ -198,14 +295,12 @@ static std::string pure_greedy_decoding(const std::string &leftSideContext, int 
     const int32_t n_vocab = llama_vocab_n_tokens(g_vocab);
 
     for (int i = 0; i < maxCount; ++i) {
-        // 直近トークンの logits
         float *logits = llama_get_logits_ith(ctx, -1);
         if (!logits) {
             LOGE("logits is null");
             break;
         }
 
-        // argmax を取る (softmax 不要：logits の大小だけ見れば OK)
         int best_id = 0;
         float best_logit = logits[0];
         for (int32_t tid = 1; tid < n_vocab; ++tid) {
@@ -222,7 +317,6 @@ static std::string pure_greedy_decoding(const std::string &leftSideContext, int 
 
         generated.push_back(next);
 
-        // 次トークンを decode に食わせて、状態を進める
         llama_batch next_batch = llama_batch_get_one(&next, 1);
         int rc = llama_decode(ctx, next_batch);
         if (rc != 0) {
@@ -231,20 +325,164 @@ static std::string pure_greedy_decoding(const std::string &leftSideContext, int 
         }
     }
 
-    // 4. 生成トークン列を detokenize
     std::string out;
     for (auto t: generated) {
         if (llama_vocab_is_control(g_vocab, t)) {
-            // 制御トークンは表示しない
             continue;
         }
         out += token_to_piece_str(t);
     }
 
-    // ★最後にコンテキストを破棄
     llama_free(ctx);
-
     return out;
+}
+
+// Swift の evaluate_candidate 相当
+static CandidateEvaluationResult
+candidate_evaluate(const std::string &prompt, const std::string &candidate_text) {
+    CandidateEvaluationResult result;
+    result.type = CandidateEvaluationResultType::ERROR;
+    result.score = 0.0f;
+
+    if (!g_model || !g_vocab) {
+        LOGE("candidate_evaluate: model not initialized");
+        return result;
+    }
+
+    llama_context *ctx = create_context();
+    if (!ctx) {
+        LOGE("candidate_evaluate: failed to create context");
+        return result;
+    }
+
+    std::string pre_prompt = preprocess_text(prompt);
+    std::string pre_candidate = preprocess_text(candidate_text);
+
+    auto prompt_tokens = tokenize_text(pre_prompt, /*add_bos=*/false, /*add_eos=*/false);
+    auto candidate_tokens = tokenize_text(pre_candidate, /*add_bos=*/false, /*add_eos=*/false);
+
+    if (prompt_tokens.empty()) {
+        LOGE("candidate_evaluate: prompt tokens empty");
+        llama_free(ctx);
+        return result;
+    }
+
+    std::vector<llama_token> all_tokens = prompt_tokens;
+    all_tokens.insert(all_tokens.end(), candidate_tokens.begin(), candidate_tokens.end());
+
+    // ★ 512固定だと長文で overflow するので必要量で確保
+    const int32_t cap = (int32_t) all_tokens.size();
+    llama_batch batch = llama_batch_init(cap, 0, 1);
+
+    // プロンプト部分: logits不要（最後のトークンを除く）
+    for (size_t i = 0; i + 1 < prompt_tokens.size(); ++i) {
+        batch.token[batch.n_tokens] = prompt_tokens[i];
+        batch.pos[batch.n_tokens] = (llama_pos) i;
+        batch.n_seq_id[batch.n_tokens] = 1;
+        batch.seq_id[batch.n_tokens][0] = 0;
+        batch.logits[batch.n_tokens] = 0;
+        batch.n_tokens++;
+    }
+
+    // プロンプトの最後のトークンから候補の最後のトークンまで: logits必要
+    size_t logits_start_pos = prompt_tokens.size() - 1;
+    for (size_t i = logits_start_pos; i < all_tokens.size(); ++i) {
+        batch.token[batch.n_tokens] = all_tokens[i];
+        batch.pos[batch.n_tokens] = (llama_pos) i;
+        batch.n_seq_id[batch.n_tokens] = 1;
+        batch.seq_id[batch.n_tokens][0] = 0;
+        batch.logits[batch.n_tokens] = 1;
+        batch.n_tokens++;
+    }
+
+    int rc = llama_decode(ctx, batch);
+    if (rc != 0) {
+        LOGE("candidate_evaluate: llama_decode failed: %d", rc);
+        llama_batch_free(batch);
+        llama_free(ctx);
+        return result;
+    }
+
+    const llama_token eos = llama_vocab_eos(g_vocab);
+    const int32_t n_vocab = llama_vocab_n_tokens(g_vocab);
+
+    float *all_logits = llama_get_logits(ctx);
+    if (!all_logits) {
+        LOGE("candidate_evaluate: all_logits is null");
+        llama_batch_free(batch);
+        llama_free(ctx);
+        return result;
+    }
+
+    float total_score = 0.0f;
+
+    for (size_t i = prompt_tokens.size(); i < all_tokens.size(); ++i) {
+        llama_token expected_token = all_tokens[i];
+
+        size_t logits_offset = (i - 1 - logits_start_pos) * (size_t) n_vocab;
+        float *logits = all_logits + logits_offset;
+
+        int32_t max_id = 0;
+        float max_logit = logits[0];
+        for (int32_t tid = 1; tid < n_vocab; ++tid) {
+            if (logits[tid] > max_logit) {
+                max_logit = logits[tid];
+                max_id = tid;
+            }
+        }
+
+        llama_token max_token = (llama_token) max_id;
+
+        float sum_exp = 0.0f;
+        for (int32_t tid = 0; tid < n_vocab; ++tid) {
+            sum_exp += expf(logits[tid] - max_logit);
+        }
+        float log_prob = logits[expected_token] - max_logit - logf(sum_exp);
+        total_score += log_prob;
+
+        if (max_token != expected_token) {
+            if (max_token == eos) {
+                std::string partial;
+                for (size_t j = prompt_tokens.size(); j < i; ++j) {
+                    llama_token t = all_tokens[j];
+                    if (!llama_vocab_is_control(g_vocab, t)) {
+                        partial += token_to_piece_str(t);
+                    }
+                }
+                result.type = CandidateEvaluationResultType::WHOLE_RESULT;
+                result.whole_result = partial;
+                LOGI("candidate_evaluate: WHOLE_RESULT at pos %zu, result=%s", i, partial.c_str());
+                llama_batch_free(batch);
+                llama_free(ctx);
+                return result;
+            } else {
+                std::string prefix;
+                for (size_t j = prompt_tokens.size(); j < i; ++j) {
+                    llama_token t = all_tokens[j];
+                    if (!llama_vocab_is_control(g_vocab, t)) {
+                        prefix += token_to_piece_str(t);
+                    }
+                }
+                if (!llama_vocab_is_control(g_vocab, max_token)) {
+                    prefix += token_to_piece_str(max_token);
+                }
+                result.type = CandidateEvaluationResultType::FIX_REQUIRED;
+                result.prefix = prefix;
+                LOGI("candidate_evaluate: FIX_REQUIRED at pos %zu, prefix=%s", i, prefix.c_str());
+                llama_batch_free(batch);
+                llama_free(ctx);
+                return result;
+            }
+        }
+    }
+
+    result.type = CandidateEvaluationResultType::PASS;
+    result.score = total_score;
+    LOGI("candidate_evaluate: PASS, score=%f", total_score);
+
+    llama_batch_free(batch);
+    llama_free(ctx);
+    return result;
 }
 
 // ------- JNI: モデル初期化 -------
@@ -260,7 +498,6 @@ Java_com_kazumaproject_zenz_ZenzEngine_initModel(
     const char *c_model_path = env->GetStringUTFChars(jModelPath, nullptr);
     LOGI("initModel: %s", c_model_path);
 
-    // 再 init 時のクリーンアップ
     if (g_model) {
         llama_model_free(g_model);
         g_model = nullptr;
@@ -270,7 +507,7 @@ Java_com_kazumaproject_zenz_ZenzEngine_initModel(
     llama_backend_init();
 
     llama_model_params mparams = llama_model_default_params();
-    mparams.n_gpu_layers = 0;   // Android は CPU 前提
+    mparams.n_gpu_layers = 0;
     mparams.use_mmap = true;
 
     g_model = llama_model_load_from_file(c_model_path, mparams);
@@ -293,7 +530,6 @@ Java_com_kazumaproject_zenz_ZenzEngine_initModel(
 }
 
 // ------- JNI: ランタイム設定 (n_ctx / n_threads) -------
-// Kotlin: external fun setRuntimeConfig(nCtx: Int, nThreads: Int)
 
 extern "C"
 JNIEXPORT void JNICALL
@@ -305,20 +541,19 @@ Java_com_kazumaproject_zenz_ZenzEngine_setRuntimeConfig(
 ) {
     std::lock_guard<std::mutex> lock(g_param_mutex);
 
-    int n_ctx     = jNCtx     > 0 ? jNCtx     : 512;
+    int n_ctx = jNCtx > 0 ? jNCtx : 512;
     int n_threads = jNThreads > 0 ? jNThreads : 4;
 
-    // 適当に下限・上限
-    if (n_ctx < 128)   n_ctx = 128;
-    if (n_ctx > 4096)  n_ctx = 4096;
+    if (n_ctx < 128) n_ctx = 128;
+    if (n_ctx > 4096) n_ctx = 4096;
 
     if (n_threads < 1) n_threads = 1;
     if (n_threads > 8) n_threads = 8;
 
-    g_param_n_ctx           = n_ctx;
-    g_param_n_threads       = n_threads;
+    g_param_n_ctx = n_ctx;
+    g_param_n_threads = n_threads;
     g_param_n_threads_batch = n_threads;
-    g_param_n_batch         = n_ctx;   // シンプルに n_ctx に合わせる
+    g_param_n_batch = n_ctx;
 
     LOGI("setRuntimeConfig: n_ctx=%d, n_threads=%d", n_ctx, n_threads);
 }
@@ -334,20 +569,20 @@ Java_com_kazumaproject_zenz_ZenzEngine_generate(
         jint maxTokens
 ) {
     if (!g_model || !g_vocab) {
-        return env->NewStringUTF("Model not initialized");
+        return toJString(env, "Model not initialized");
     }
 
     const char *c_prompt = env->GetStringUTFChars(jPrompt, nullptr);
-    std::string prompt(c_prompt);
+    std::string prompt(c_prompt ? c_prompt : "");
     env->ReleaseStringUTFChars(jPrompt, c_prompt);
 
-    // prompt は Kotlin 側で \uEE00 + 入力 + \uEE01 の形で組み立てたものを想定
     std::string result = pure_greedy_decoding(prompt, /*maxCount=*/maxTokens);
 
-    return env->NewStringUTF(result.c_str());
+    // ★ NewStringUTFは禁止（不正UTF-8の可能性）
+    return toJString(env, result);
 }
 
-// ------- JNI: 文脈 + 読み で変換（v3 っぽい） -------
+// ------- JNI: 文脈 + 読み で変換 -------
 
 extern "C"
 JNIEXPORT jstring JNICALL
@@ -359,10 +594,9 @@ Java_com_kazumaproject_zenz_ZenzEngine_generateWithContext(
         jint maxTokens
 ) {
     if (!g_model || !g_vocab) {
-        return env->NewStringUTF("Model not initialized");
+        return toJString(env, "Model not initialized");
     }
 
-    // JNI 文字列を取得
     const char *c_left = env->GetStringUTFChars(jLeftContext, nullptr);
     const char *c_input = env->GetStringUTFChars(jInput, nullptr);
 
@@ -372,28 +606,22 @@ Java_com_kazumaproject_zenz_ZenzEngine_generateWithContext(
     env->ReleaseStringUTFChars(jLeftContext, c_left);
     env->ReleaseStringUTFChars(jInput, c_input);
 
-    // Zenz v3 っぽい形:
-    //   conditions(今回はなし) + contextTag + left + inputTag + input + outputTag
     const std::string inputTag = u8"\uEE00";
     const std::string contextTag = u8"\uEE02";
     const std::string outputTag = u8"\uEE01";
 
     std::string prompt;
     if (!left.empty()) {
-        // 文脈あり
         prompt = contextTag + left + inputTag + input + outputTag;
     } else {
-        // 文脈なし（従来の v1 と同じ形）
         prompt = inputTag + input + outputTag;
     }
 
-    // ここで pure_greedy_decoding が毎回コンテキストを作って破棄してくれる
     std::string result = pure_greedy_decoding(prompt, /*maxCount=*/maxTokens);
-
-    return env->NewStringUTF(result.c_str());
+    return toJString(env, result);
 }
 
-// ------- JNI: 条件 + 文脈 + 読み で変換（v3 条件つき）-------
+// ------- JNI: 条件 + 文脈 + 読み で変換 -------
 
 extern "C"
 JNIEXPORT jstring JNICALL
@@ -409,10 +637,9 @@ Java_com_kazumaproject_zenz_ZenzEngine_generateWithContextAndConditions(
         jint maxTokens
 ) {
     if (!g_model || !g_vocab) {
-        return env->NewStringUTF("Model not initialized");
+        return toJString(env, "Model not initialized");
     }
 
-    // JNI 文字列を取得（null 許容）
     const char *c_profile = jProfile ? env->GetStringUTFChars(jProfile, nullptr) : nullptr;
     const char *c_topic = jTopic ? env->GetStringUTFChars(jTopic, nullptr) : nullptr;
     const char *c_style = jStyle ? env->GetStringUTFChars(jStyle, nullptr) : nullptr;
@@ -434,7 +661,6 @@ Java_com_kazumaproject_zenz_ZenzEngine_generateWithContextAndConditions(
     if (c_left) env->ReleaseStringUTFChars(jLeftContext, c_left);
     if (c_input) env->ReleaseStringUTFChars(jInput, c_input);
 
-    // Zenz v3 で使われるタグ
     const std::string inputTag = u8"\uEE00";
     const std::string contextTag = u8"\uEE02";
     const std::string profileTag = u8"\uEE03";
@@ -443,32 +669,109 @@ Java_com_kazumaproject_zenz_ZenzEngine_generateWithContextAndConditions(
     const std::string preferenceTag = u8"\uEE06";
     const std::string outputTag = u8"\uEE01";
 
-    // conditions を連結
     std::string conditions;
-    if (!profile.empty()) {
-        conditions += profileTag + profile;
-    }
-    if (!topic.empty()) {
-        conditions += topicTag + topic;
-    }
-    if (!style.empty()) {
-        conditions += styleTag + style;
-    }
-    if (!preference.empty()) {
-        conditions += preferenceTag + preference;
-    }
+    if (!profile.empty()) conditions += profileTag + profile;
+    if (!topic.empty()) conditions += topicTag + topic;
+    if (!style.empty()) conditions += styleTag + style;
+    if (!preference.empty()) conditions += preferenceTag + preference;
 
-    // プロンプト構築
     std::string prompt;
     if (!left.empty()) {
-        // 文脈あり: conditions + contextTag + left + inputTag + input + outputTag
         prompt = conditions + contextTag + left + inputTag + input + outputTag;
     } else {
-        // 文脈なし: conditions + inputTag + input + outputTag
         prompt = conditions + inputTag + input + outputTag;
     }
 
     std::string result = pure_greedy_decoding(prompt, /*maxCount=*/maxTokens);
+    return toJString(env, result);
+}
 
-    return env->NewStringUTF(result.c_str());
+// ------- JNI: 投機的デコーディングによる候補評価 -------
+
+extern "C"
+JNIEXPORT jstring JNICALL
+Java_com_kazumaproject_zenz_ZenzEngine_candidateEvaluate(
+        JNIEnv *env,
+        jobject /* thiz */,
+        jstring jProfile,
+        jstring jTopic,
+        jstring jStyle,
+        jstring jPreference,
+        jstring jLeftContext,
+        jstring jInput,
+        jstring jCandidate
+) {
+    if (!g_model || !g_vocab) {
+        return toJString(env, "ERROR");
+    }
+
+    const char *c_profile = jProfile ? env->GetStringUTFChars(jProfile, nullptr) : nullptr;
+    const char *c_topic = jTopic ? env->GetStringUTFChars(jTopic, nullptr) : nullptr;
+    const char *c_style = jStyle ? env->GetStringUTFChars(jStyle, nullptr) : nullptr;
+    const char *c_preference = jPreference ? env->GetStringUTFChars(jPreference, nullptr) : nullptr;
+    const char *c_left = jLeftContext ? env->GetStringUTFChars(jLeftContext, nullptr) : nullptr;
+    const char *c_input = jInput ? env->GetStringUTFChars(jInput, nullptr) : nullptr;
+    const char *c_candidate = jCandidate ? env->GetStringUTFChars(jCandidate, nullptr) : nullptr;
+
+    std::string profile = c_profile ? c_profile : "";
+    std::string topic = c_topic ? c_topic : "";
+    std::string style = c_style ? c_style : "";
+    std::string preference = c_preference ? c_preference : "";
+    std::string left = c_left ? c_left : "";
+    std::string input = c_input ? c_input : "";
+    std::string candidate = c_candidate ? c_candidate : "";
+
+    if (c_profile) env->ReleaseStringUTFChars(jProfile, c_profile);
+    if (c_topic) env->ReleaseStringUTFChars(jTopic, c_topic);
+    if (c_style) env->ReleaseStringUTFChars(jStyle, c_style);
+    if (c_preference) env->ReleaseStringUTFChars(jPreference, c_preference);
+    if (c_left) env->ReleaseStringUTFChars(jLeftContext, c_left);
+    if (c_input) env->ReleaseStringUTFChars(jInput, c_input);
+    if (c_candidate) env->ReleaseStringUTFChars(jCandidate, c_candidate);
+
+    if (candidate.empty()) {
+        return toJString(env, "ERROR");
+    }
+
+    const std::string inputTag = u8"\uEE00";
+    const std::string contextTag = u8"\uEE02";
+    const std::string profileTag = u8"\uEE03";
+    const std::string topicTag = u8"\uEE04";
+    const std::string styleTag = u8"\uEE05";
+    const std::string preferenceTag = u8"\uEE06";
+    const std::string outputTag = u8"\uEE01";
+
+    std::string conditions;
+    if (!profile.empty()) conditions += profileTag + profile;
+    if (!topic.empty()) conditions += topicTag + topic;
+    if (!style.empty()) conditions += styleTag + style;
+    if (!preference.empty()) conditions += preferenceTag + preference;
+
+    std::string prompt;
+    if (!left.empty()) {
+        prompt = conditions + contextTag + left + inputTag + input + outputTag;
+    } else {
+        prompt = conditions + inputTag + input + outputTag;
+    }
+
+    CandidateEvaluationResult eval_result = candidate_evaluate(prompt, candidate);
+
+    std::string result_str;
+    switch (eval_result.type) {
+        case CandidateEvaluationResultType::PASS:
+            result_str = "PASS:" + std::to_string(eval_result.score);
+            break;
+        case CandidateEvaluationResultType::FIX_REQUIRED:
+            result_str = "FIX:" + eval_result.prefix;          // ここも不正UTF-8が混ざり得るので toJString 必須
+            break;
+        case CandidateEvaluationResultType::WHOLE_RESULT:
+            result_str = "WHOLE:" + eval_result.whole_result;  // 同上
+            break;
+        case CandidateEvaluationResultType::ERROR:
+        default:
+            result_str = "ERROR";
+            break;
+    }
+
+    return toJString(env, result_str);
 }

--- a/zenz/src/main/java/com/kazumaproject/zenz/ZenzEngine.kt
+++ b/zenz/src/main/java/com/kazumaproject/zenz/ZenzEngine.kt
@@ -12,6 +12,7 @@ object ZenzEngine {
         nCtx: Int,
         nThreads: Int
     )
+
     external fun generate(
         prompt: String,
         maxTokens: Int
@@ -31,5 +32,15 @@ object ZenzEngine {
         leftContext: String,
         input: String,
         maxTokens: Int
+    ): String
+
+    external fun candidateEvaluate(
+        profile: String?,
+        topic: String?,
+        style: String?,
+        preference: String?,
+        leftContext: String?,
+        input: String,
+        candidate: String
     ): String
 }


### PR DESCRIPTION
## 概要

https://github.com/KazumaProject/Zenz-Android-Demo/pull/7

投機的デコーディングの実装により Prefix を取得できるようになった。
そこで、既存のかな漢字変換エンジンが生成する変換候補を Prefix を使って並び替えるように実装した。