### PR TITLE
Launchable setting alias; unsigned builds

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,10 +18,12 @@ android {
 
     signingConfigs {
         release {
-            storeFile file(localProperties['KEYSTORE_FILE'])
-            storePassword localProperties['KEYSTORE_PASSWORD']
-            keyAlias localProperties['KEY_ALIAS']
-            keyPassword localProperties['KEY_PASSWORD']
+            if (localProperties['KEYSTORE_FILE']) {
+                storeFile file(localProperties['KEYSTORE_FILE'])
+                storePassword localProperties['KEYSTORE_PASSWORD']
+                keyAlias localProperties['KEY_ALIAS']
+                keyPassword localProperties['KEY_PASSWORD']
+            }
         }
     }
 
@@ -49,10 +51,17 @@ android {
 
     buildTypes {
         release {
-            signingConfig signingConfigs.release
+            if (signingConfigs.release.storeFile) {
+                signingConfig signingConfigs.release
+            }
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+        releaseUnsigned {
+            initWith release
+            signingConfig null
+            matchingFallbacks = ['release']
         }
     }
     compileOptions {
@@ -82,6 +91,11 @@ android {
                     }
                     output.outputFileName = "app-${abi}-${variant.buildType.name}.apk"
                 }
+            }
+
+            // Override name specifically for releaseUnsigned
+            if (variant.buildType.name == "releaseUnsigned") {
+                output.outputFileName = "app-release-unsigned.apk"
             }
         }
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -28,12 +28,18 @@
         <activity
             android:name=".setting_activity.MainActivity"
             android:exported="true"
+            android:label="@string/title_activity_main" />
+
+        <activity-alias
+            android:name=".setting_activity.LaunchableMainActivity"
+            android:targetActivity=".setting_activity.MainActivity"
+            android:exported="true"
             android:label="@string/title_activity_main">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
+        </activity-alias>
 
         <service
             android:name=".ime_service.IMEService"


### PR DESCRIPTION
This change has 3 components:

## 1. Separate main setting activity from the launch activity

I would like to be able to disable the settings launcher icon, while still allowing the user to reach settings through Settings > System > Keyboard > On-screen keyboard. We have very high-level users, and prefer to keep the set of launchable apps small. However, if we disable:
```
com.kazumaproject.markdownhelperkeyboard/.setting_activity.MainActivity
```
it disables both the launch icon, and settings. To fix this, split the setting activity into two components:
- Existing setting activity, with the launch filter removed.
- Launchable activity alias, targeting the setting activity.

To disable the launcher icon, disable the launchable setting alias. This has no effect on any existing intents that target to the setting activity. By default, any home app will still find the launchable setting activity "launchable", and include in its app launcher.

## 2. Fix release signing config.

It's a bit of a chicken and egg problem. If you have no intention of building a signed release, you'd like to load the project and change the build variant to "debug". However, since the build config is invalid without defining `KEYSTORE_FILE`, it can't even be loaded.

Modify the release build configuration to gracefully handle missing `KEYSTORE_FILE`, and other signing tokens. If not defined, the signing config for the release build is left undefined.

## 3. Add unsigned release

Signing must be part of the build process. You must defined `KEYSTORE_FILE`, etc. at build time. It's common to build unsigned artifacts, then have a separate signing process using `apksigner`.  This keeps a better separation between the OSS project and whatever proprietary signing process one might have. Also, `KEYSTORE_FILE`, etc. are quite generic names, so it's likely to clash with other projects using the same tokens.

Add an `unsignedRelease` target. This is the same as `release`, minus the signing config.

The artifact name change isn't strictly necessary, but without it, the name ends up "app-release-unsignedRelease.apk".

Since we did (2) above, executing "release" without defining `KEYSTORE_FILE` is essentially the same thing as executing `unsignedRelease`. `unsignedRelease` however makes it more explicit what's happening.


# Testing

## 1. Separate main setting activity from the launch activity

Install the app. Ensure the launchable alias can be resolved as launchable:
```
$ adb shell cmd package resolve-activity -c android.intent.category.LAUNCHER "com.kazumaproject.markdownhelperkeyboard"
priority=0 preferredOrder=0 match=0x108000 specificIndex=-1 isDefault=false
ActivityInfo:
  name=com.kazumaproject.markdownhelperkeyboard.setting_activity.LaunchableMainActivity
...
```

Disable the launchable alias.
```
$ adb shell pm disable "com.kazumaproject.markdownhelperkeyboard/.setting_activity.LaunchableMainActivity"
Component {com.kazumaproject.markdownhelperkeyboard/com.kazumaproject.markdownhelperkeyboard.setting_activity.LaunchableMainActivity} new state: disabled
```

Ensure it **cannot** be resolved as launchable:
```
$ adb shell cmd package resolve-activity -c android.intent.category.LAUNCHER "com.kazumaproject.markdownhelperkeyboard"
No activity found
```

Ensure the main setting activity can still be launched via intent:
```
adb shell am start -n "com.kazumaproject.markdownhelperkeyboard/.setting_activity.MainActivity"
```

On device, navigate to: Settings > System > Keyboard > On-screen keyboard. Tap "Sumire...". Ensure it launches the settings page for this IME.

## 2. Fix release signing config.

Do not defined `KEYSTORE_FILE`. Load the project in Android Studio. Ensure it loads correctly.

## 3. Add unsigned release

Build:
```
./gradlew clean assembleUnsignedRelease
...
```

Ensure that the unsigned artifact is built:
```
$ find . -name \*.apk
./app/build/outputs/apk/releaseUnsigned/app-release-unsigned.apk
```

Ensure it's unsigned:
```
$ apksigner verify -verbose ./app/build/outputs/apk/releaseUnsigned/app-release-unsigned.apk
DOES NOT VERIFY
ERROR: Missing META-INF/MANIFEST.MF
```