### PR TITLE
GUIでキーボード高さを低く設定すると、実際のキーボードの高さが変動するバグを修正。

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -7930,7 +7930,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTY || qwertyMode.value == TenKeyQWERTYMode.TenKeyQWERTYRomaji -> {
                 val clampedHeight = if (isPortrait) {
-                    prefs.qwertyHeightPref.coerceIn(180, 420)
+                    prefs.qwertyHeightPref.coerceIn(100, 420)
                 } else if (isFloating) {
                     prefs.qwertyHeightPref
                 } else {
@@ -7941,11 +7941,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             else -> {
                 val clampedHeight = if (isPortrait) {
-                    prefs.heightPref.coerceIn(180, 420)
+                    prefs.heightPref.coerceIn(100, 420)
                 } else if (isFloating) {
                     prefs.heightPref
                 } else {
-                    prefs.heightPref.coerceIn(60, 420)
+                    prefs.heightPref.coerceIn(100, 420)
                 }
                 (clampedHeight * density).toInt()
             }


### PR DESCRIPTION
## バグの再現

1. アプリの設定から「位置とサイズの設定(縦画面)」を開く
2. キーボードの高さが最小になるようにドラッグする。これで設定は完了。
3. メモ帳アプリなどを起動し、キーボードを開く。するとGUIで設定した高さより高いキーボードが出現する。
4. なにかキーをタップすると、GUIで設定した高さどおりの高さに戻る。

この手順3 の挙動を改善しました。

## 原因

`setKeyboardHeightWithAdditionalOriginal` 関数と `updateKeyboardLayout`が混在していました。
また、高さの最小値制限が不統一でした。

## 修正内容
1. `setKeyboardHeightWithAdditional` 関数を統一された `updateKeyboardLayout` に変更
2. キーボード高さの最小値をGUI設定値（100dp）に統一