### PR TITLE
CROSS_FLICK 特殊キーの長押し処理を復旧

### DIFF
--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/GridFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/GridFlickInputController.kt
@@ -33,6 +33,8 @@ class GridFlickInputController(
     interface GridFlickListener {
         fun onPress(action: FlickAction)
         fun onFlick(action: FlickAction, isFlick: Boolean)
+        fun onLongPress(action: FlickAction)
+        fun onUpAfterLongPress(action: FlickAction, isFlick: Boolean)
     }
 
     var listener: GridFlickListener? = null
@@ -45,6 +47,8 @@ class GridFlickInputController(
     private var initialTouchY = 0f
     private var originalKeyText: CharSequence? = null
     private var longPressTimeout: Long = ViewConfiguration.getLongPressTimeout().toLong()
+    private var isLongPressTriggered = false
+    private var longPressAction: FlickAction? = null
 
     // 各方向に対応するPopupWindowを保持するMap
     private val popupMap: MutableMap<FlickDirection, PopupWindow> = mutableMapOf()
@@ -261,6 +265,8 @@ class GridFlickInputController(
                 initialTouchX = event.rawX
                 initialTouchY = event.rawY
                 isLongPressModeActive = false
+                isLongPressTriggered = false
+                longPressAction = null
 
                 (anchorView as? Button)?.let { button ->
                     originalKeyText = button.text
@@ -275,11 +281,20 @@ class GridFlickInputController(
 
                 showPopupForDirection(FlickDirection.TAP)
 
+                longPressJob?.cancel()
                 longPressJob = controllerScope.launch {
                     delay(longPressTimeout)
                     isLongPressModeActive = true
+                    val tapAction = characterMap[FlickDirection.TAP] as? FlickAction.Action
+                    if (tapAction != null) {
+                        isLongPressTriggered = true
+                        longPressAction = tapAction
+                    }
                     dismissAllPopups() // 方向ポップアップを消す
                     showGridPopup()
+                    if (tapAction != null) {
+                        listener?.onLongPress(tapAction)
+                    }
                 }
                 return true
             }
@@ -316,10 +331,25 @@ class GridFlickInputController(
 
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 longPressJob?.cancel()
-                if (event.action == MotionEvent.ACTION_UP) {
+                longPressJob = null
+                val finalDirection = if (event.action == MotionEvent.ACTION_UP) {
                     val dx = event.rawX - initialTouchX
                     val dy = event.rawY - initialTouchY
-                    val finalDirection = calculateDirection(dx, dy)
+                    calculateDirection(dx, dy)
+                } else {
+                    FlickDirection.TAP
+                }
+
+                if (isLongPressTriggered) {
+                    val finalAction = characterMap[finalDirection] as? FlickAction.Action
+                        ?: longPressAction
+                    finalAction?.let {
+                        listener?.onUpAfterLongPress(
+                            it,
+                            isFlick = finalDirection != FlickDirection.TAP
+                        )
+                    }
+                } else if (event.action == MotionEvent.ACTION_UP) {
                     characterMap[finalDirection]?.let {
                         listener?.onFlick(
                             it, isFlick = finalDirection != FlickDirection.TAP
@@ -330,6 +360,8 @@ class GridFlickInputController(
                     button.text = originalKeyText
                 }
                 originalKeyText = null
+                isLongPressTriggered = false
+                longPressAction = null
                 dismissAllPopups()
                 return true
             }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -994,6 +994,7 @@ class FlickKeyboardView @JvmOverloads constructor(
                 val flickActionMap = rawFlickActionMap?.let { normalizeDirectionsForCrossFlick(it) }
                 if (flickActionMap != null) {
                     val controller = GridFlickInputController(context, flickSensitivity).apply {
+                        setLongPressTimeout(longPressTimeout)
                         val isDarkTheme = context.isDarkThemeOn()
                         val secondaryColor =
                             context.getColorFromAttr(R.attr.colorSecondaryContainer)
@@ -1078,6 +1079,26 @@ class FlickKeyboardView @JvmOverloads constructor(
                                     keyAction,
                                     isFlick = isFlick
                                 )
+                            }
+
+                            override fun onLongPress(action: FlickAction) {
+                                if (action is FlickAction.Action) {
+                                    this@FlickKeyboardView.listener?.onFlickActionLongPress(
+                                        action.action
+                                    )
+                                }
+                            }
+
+                            override fun onUpAfterLongPress(
+                                action: FlickAction,
+                                isFlick: Boolean
+                            ) {
+                                if (action is FlickAction.Action) {
+                                    this@FlickKeyboardView.listener?.onFlickActionUpAfterLongPress(
+                                        action.action,
+                                        isFlick
+                                    )
+                                }
                             }
                         }
 


### PR DESCRIPTION
## Summary
- `GridFlickInputController` に長押し開始/解除の callback を追加
- `FlickKeyboardView` で `FlickAction.Action` の長押しを既存の `onFlickActionLongPress` / `onFlickActionUpAfterLongPress` に橋渡し
- `CROSS_FLICK` キーにも設定済みの `longPressTimeout` を反映

## Fixed
- Sumire キーボードの削除キー・矢印キーなど、`CROSS_FLICK` の特殊キーで長押しが効かない問題
- カスタムキーボードの特殊フリックキーで長押し処理が IME 側に届かない問題

## Verification
- `./gradlew :custom_keyboard:compileDebugKotlin :app:compileFullStandardDebugKotlin`
- Sumire キーボードで削除キー・矢印キーの長押し動作を確認
