### PR TITLE
特定のカスタムキーボードに遷移するアクションの追加

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/data/CustomKeyboardLayout.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/data/CustomKeyboardLayout.kt
@@ -2,6 +2,7 @@ package com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import java.util.UUID
 
 /**
  * ユーザーが作成したキーボードレイアウトの全体設定を保存するエンティティ
@@ -15,5 +16,6 @@ data class CustomKeyboardLayout(
     val rowCount: Int,        // 行数
     val isRomaji: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(), // 作成日時
-    val sortOrder: Int = 0
+    val sortOrder: Int = 0,
+    val stableId: String = UUID.randomUUID().toString()
 )

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/data/DataConverterExtensions.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/data/DataConverterExtensions.kt
@@ -10,6 +10,7 @@ private fun KeyAction.circularLabel(actionValue: String?): String? {
             actionValue ?: CircularFlickSlotActionMapper.SWITCH_MAP_LABEL
         KeyAction.ShowEmojiKeyboard ->
             actionValue ?: CircularFlickSlotActionMapper.EMOJI_KEYBOARD_LABEL
+        is KeyAction.MoveToCustomKeyboard -> null
         else -> actionValue
     }
 }
@@ -46,6 +47,9 @@ fun FlickMapping.toFlickAction(): FlickAction {
         "VoiceInput" -> KeyAction.VoiceInput
         "ShiftKey" -> KeyAction.ShiftKey
         "MoveCustomKeyboardTab" -> KeyAction.MoveCustomKeyboardTab
+        "MoveToCustomKeyboard" -> this.actionValue
+            ?.takeIf { it.isNotBlank() }
+            ?.let { KeyAction.MoveToCustomKeyboard(it) }
         else -> null
     }
     return if (action != null) {
@@ -87,6 +91,9 @@ fun CircularFlickMapping.toFlickAction(): FlickAction {
         "VoiceInput" -> KeyAction.VoiceInput
         "ShiftKey" -> KeyAction.ShiftKey
         "MoveCustomKeyboardTab" -> KeyAction.MoveCustomKeyboardTab
+        "MoveToCustomKeyboard" -> this.actionValue
+            ?.takeIf { it.isNotBlank() }
+            ?.let { KeyAction.MoveToCustomKeyboard(it) }
         else -> null
     }
     return if (action != null) {
@@ -133,6 +140,7 @@ fun FlickAction.toDbStrings(): Pair<String, String?> {
             KeyAction.VoiceInput -> "VoiceInput" to null
             KeyAction.ShiftKey -> "ShiftKey" to null
             KeyAction.MoveCustomKeyboardTab -> "MoveCustomKeyboardTab" to CircularFlickSlotActionMapper.SWITCH_MAP_LABEL
+            is KeyAction.MoveToCustomKeyboard -> "MoveToCustomKeyboard" to action.stableId
             else -> "UNKNOWN" to null // 未対応のアクション
         }
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/database/KeyboardLayoutDao.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/database/KeyboardLayoutDao.kt
@@ -170,6 +170,9 @@ interface KeyboardLayoutDao {
     @Query("SELECT * FROM keyboard_layouts WHERE name = :name LIMIT 1")
     suspend fun findLayoutByName(name: String): CustomKeyboardLayout?
 
+    @Query("SELECT * FROM keyboard_layouts WHERE stableId = :stableId LIMIT 1")
+    suspend fun findLayoutByStableId(stableId: String): CustomKeyboardLayout?
+
     @Transaction
     @Query("SELECT * FROM keyboard_layouts")
     fun getAllFullLayouts(): Flow<List<FullKeyboardLayout>>

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyEditorFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyEditorFragment.kt
@@ -33,6 +33,7 @@ import com.kazumaproject.custom_keyboard.data.toCircularFlickMap
 import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CircularFlickSlotActionMapper
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.FlickDirectionMapper
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.TwoStepMappingItem
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.ui.adapter.CircularFlickMappingAdapter
@@ -54,6 +55,12 @@ private enum class OutputEditMode {
     NORMAL,
     LONG_PRESS
 }
+
+private data class CustomKeyboardTargetOption(
+    val label: String,
+    val stableId: String,
+    val isValid: Boolean
+)
 
 @AndroidEntryPoint
 class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
@@ -85,11 +92,16 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
     private var currentCellMode: CellMode? = null
 
     private lateinit var keyActionAdapter: ArrayAdapter<String>
+    private lateinit var customKeyboardTargetAdapter: ArrayAdapter<String>
     private lateinit var circularFlickAdapter: CircularFlickMappingAdapter
     private lateinit var circularMapAdapter: ArrayAdapter<String>
 
     // NEW: UI-friendly display actions (avoids depending on unknown internal display type)
     private lateinit var displayActions: List<DisplayActionUi>
+    private lateinit var specialFlickDisplayActions: List<DisplayActionUi>
+    private var customKeyboardTargets: List<CustomKeyboardLayout> = emptyList()
+    private var customKeyboardTargetOptions: List<CustomKeyboardTargetOption> = emptyList()
+    private var selectedTargetCustomKeyboardStableId: String? = null
 
     private var currentColSpan: Int = 1
     private var currentRowSpan: Int = 1
@@ -120,6 +132,8 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
         // Convert KeyActionMapper display actions into stable UI list
         val raw = KeyActionMapper.getDisplayActions(requireContext())
         displayActions = raw.map { DisplayActionUi(it.displayName, it.action, it.iconResId) }
+        specialFlickDisplayActions = displayActions
+            .filterNot { it.action is KeyAction.MoveToCustomKeyboard }
 
         val actionDisplayNames = displayActions.map { it.displayName }
         keyActionAdapter = ArrayAdapter(
@@ -130,13 +144,22 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
         binding.keyActionSpinner.setAdapter(keyActionAdapter)
 
         // 特殊フリック用アクションスピナー（セル選択後に表示）
-        val specialActionNames = mutableListOf("").apply { addAll(actionDisplayNames) }
+        val specialActionNames = mutableListOf("").apply {
+            addAll(specialFlickDisplayActions.map { it.displayName })
+        }
         val specialActionAdapter = ArrayAdapter(
             requireContext(),
             android.R.layout.simple_spinner_dropdown_item,
             specialActionNames
         )
         binding.specialFlickMappingsRecyclerView.setAdapter(specialActionAdapter)
+
+        customKeyboardTargetAdapter = ArrayAdapter(
+            requireContext(),
+            android.R.layout.simple_spinner_dropdown_item,
+            mutableListOf<String>()
+        )
+        binding.customKeyboardTargetSpinner.setAdapter(customKeyboardTargetAdapter)
 
         circularFlickAdapter = CircularFlickMappingAdapter { updated ->
             val currentMap = currentCircularFlickMaps.getOrNull(currentCircularMapIndex)
@@ -195,11 +218,11 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
         // 特殊フリック用アクション選択コールバック
         binding.specialFlickMappingsRecyclerView.setOnItemClickListener { _, _, idx, _ ->
             val mode = currentCellMode as? CellMode.SpecialFlick ?: return@setOnItemClickListener
-            val selectedAction = if (idx == 0) null else displayActions[idx - 1].action
+            val selectedAction = if (idx == 0) null else specialFlickDisplayActions[idx - 1].action
             val itemIdx = currentSpecialFlickItems.indexOfFirst { it.direction == mode.direction }
             if (itemIdx != -1) {
                 currentSpecialFlickItems[itemIdx] = currentSpecialFlickItems[itemIdx].copy(action = selectedAction)
-                val displayAction = selectedAction?.let { act -> displayActions.firstOrNull { it.action == act } }
+                val displayAction = selectedAction?.let { act -> displayActionForAction(act) }
                 binding.flickGridEditorView.updateCellIcon(
                     mode,
                     displayAction?.iconResId,
@@ -245,6 +268,7 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
             } else {
                 // hide special editors
                 binding.keyActionLayout.isVisible = false
+                binding.customKeyboardTargetLayout.isVisible = false
                 binding.specialFlickEditorGroup.isVisible = false
 
                 // normal key: input style controls which editor is visible
@@ -329,6 +353,15 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
         }
 
         binding.keyActionSpinner.doAfterTextChanged {
+            updateCustomKeyboardTargetVisibility()
+            updateDoneButtonState()
+        }
+
+        binding.customKeyboardTargetSpinner.setOnItemClickListener { _, _, position, _ ->
+            val option = customKeyboardTargetOptions.getOrNull(position)
+            selectedTargetCustomKeyboardStableId = option
+                ?.takeIf { it.isValid }
+                ?.stableId
             updateDoneButtonState()
         }
 
@@ -363,6 +396,7 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
 
         binding.keyLabelLayout.isVisible = false
         binding.keyActionLayout.isVisible = !isFlick
+        binding.customKeyboardTargetLayout.isVisible = false
         binding.flickGridEditorView.isVisible = isFlick
         binding.specialFlickEditorGroup.isVisible = false
         binding.textSelectedDirection.isVisible = false
@@ -377,9 +411,11 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
             }
             binding.flickGridEditorView.setSpecialFlickContent(
                 currentSpecialFlickItems.toList(),
-                displayActions
+                specialFlickDisplayActions
             )
             binding.flickGridEditorView.selectInitialCell()
+        } else {
+            updateCustomKeyboardTargetVisibility()
         }
     }
 
@@ -393,6 +429,7 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
         }
 
         binding.keyLabelLayout.isVisible = true
+        binding.customKeyboardTargetLayout.isVisible = false
         binding.flickGridEditorView.isVisible = true
         binding.circularFlickEditorGroup.isVisible = false
         binding.textSelectedDirection.isVisible = false
@@ -548,7 +585,7 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
                 val currentAction = currentSpecialFlickItems
                     .firstOrNull { it.direction == mode.direction }?.action
                 val currentName = currentAction?.let { act ->
-                    displayActions.firstOrNull { it.action == act }?.displayName
+                    specialFlickDisplayActions.firstOrNull { it.action == act }?.displayName
                 }.orEmpty()
                 binding.textCharInputLayout.isVisible = false
                 binding.specialFlickEditorGroup.isVisible = true
@@ -626,13 +663,124 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
         }, viewLifecycleOwner, Lifecycle.State.RESUMED)
     }
 
+    private fun displayActionForAction(action: KeyAction): DisplayActionUi? {
+        return when (action) {
+            is KeyAction.MoveToCustomKeyboard ->
+                displayActions.firstOrNull { it.action is KeyAction.MoveToCustomKeyboard }
+
+            else -> displayActions.firstOrNull { it.action == action }
+        }
+    }
+
+    private fun selectedSingleDisplayAction(): DisplayActionUi? {
+        val selectedText = binding.keyActionSpinner.text.toString()
+        return displayActions.firstOrNull { it.displayName == selectedText }
+    }
+
+    private fun isMoveToCustomKeyboardSelected(): Boolean {
+        return selectedSingleDisplayAction()?.action is KeyAction.MoveToCustomKeyboard
+    }
+
+    private fun buildTargetOptions(
+        targets: List<CustomKeyboardLayout>,
+        deletedStableId: String? = null
+    ): List<CustomKeyboardTargetOption> {
+        val totalByName = targets.groupingBy { it.name }.eachCount()
+        val seenByName = mutableMapOf<String, Int>()
+        val validOptions = targets.map { layout ->
+            val seenCount = (seenByName[layout.name] ?: 0) + 1
+            seenByName[layout.name] = seenCount
+            val label = if ((totalByName[layout.name] ?: 0) > 1) {
+                "${layout.name} ($seenCount)"
+            } else {
+                layout.name
+            }
+            CustomKeyboardTargetOption(
+                label = label,
+                stableId = layout.stableId,
+                isValid = true
+            )
+        }
+
+        val deletedOption = deletedStableId
+            ?.takeIf { it.isNotBlank() && validOptions.none { option -> option.stableId == it } }
+            ?.let {
+                CustomKeyboardTargetOption(
+                    label = getString(R.string.deleted_custom_keyboard_target),
+                    stableId = it,
+                    isValid = false
+                )
+            }
+
+        return if (deletedOption != null) validOptions + deletedOption else validOptions
+    }
+
+    private suspend fun loadCustomKeyboardTargets() {
+        customKeyboardTargets = keyboardRepository.getLayoutsNotFlowEnsuringStableIds()
+        refreshCustomKeyboardTargetOptions()
+    }
+
+    private fun refreshCustomKeyboardTargetOptions(deletedStableId: String? = null) {
+        customKeyboardTargetOptions = buildTargetOptions(customKeyboardTargets, deletedStableId)
+        customKeyboardTargetAdapter.clear()
+        customKeyboardTargetAdapter.addAll(customKeyboardTargetOptions.map { it.label })
+        customKeyboardTargetAdapter.notifyDataSetChanged()
+    }
+
+    private fun selectTargetCustomKeyboard(stableId: String?) {
+        val id = stableId.orEmpty()
+        if (id.isBlank()) {
+            selectedTargetCustomKeyboardStableId = null
+            binding.customKeyboardTargetSpinner.setText("", false)
+            return
+        }
+
+        var option = customKeyboardTargetOptions.firstOrNull { it.stableId == id }
+        if (option == null) {
+            refreshCustomKeyboardTargetOptions(deletedStableId = id)
+            option = customKeyboardTargetOptions.firstOrNull { it.stableId == id }
+        }
+
+        selectedTargetCustomKeyboardStableId = option
+            ?.takeIf { it.isValid }
+            ?.stableId
+        binding.customKeyboardTargetSpinner.setText(option?.label.orEmpty(), false)
+    }
+
+    private fun updateCustomKeyboardTargetVisibility() {
+        val shouldShow = binding.keyTypeChipGroup.checkedChipId == R.id.chip_special &&
+                binding.specialCategoryChipGroup.checkedChipId == R.id.chip_special_single &&
+                isMoveToCustomKeyboardSelected()
+
+        binding.customKeyboardTargetLayout.isVisible = shouldShow
+        if (!shouldShow) {
+            return
+        }
+
+        if (selectedTargetCustomKeyboardStableId.isNullOrBlank()) {
+            val firstValid = customKeyboardTargetOptions.firstOrNull { it.isValid }
+            if (firstValid != null && binding.customKeyboardTargetSpinner.text.isNullOrEmpty()) {
+                selectedTargetCustomKeyboardStableId = firstValid.stableId
+                binding.customKeyboardTargetSpinner.setText(firstValid.label, false)
+            }
+        }
+    }
+
     private fun updateDoneButtonState() {
         val isEnabled = when (binding.keyTypeChipGroup.checkedChipId) {
             R.id.chip_special -> {
                 val isFlick =
                     binding.specialCategoryChipGroup.checkedChipId == R.id.chip_special_flick
                 if (!isFlick) {
-                    binding.keyActionSpinner.text.isNotEmpty()
+                    if (isMoveToCustomKeyboardSelected()) {
+                        selectedTargetCustomKeyboardStableId
+                            ?.takeIf { stableId ->
+                                customKeyboardTargets.any { it.stableId == stableId }
+                            }
+                            ?.isNotBlank() == true
+                    } else {
+                        binding.keyActionSpinner.text.isNotEmpty()
+                    }
                 } else {
                     // Special flick: TAP must be selected
                     val tapAction = currentSpecialFlickItems
@@ -664,6 +812,7 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
 
     private fun setupInitialState() {
         viewLifecycleOwner.lifecycleScope.launch {
+            loadCustomKeyboardTargets()
             val state = viewModel.uiState.filterNotNull().first()
 
             currentKeyData =
@@ -711,10 +860,14 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
                     handleSpecialCategoryUi()
 
                     key.action?.let { currentAction ->
-                        val displayAction = displayActions.find { it.action == currentAction }
+                        val displayAction = displayActionForAction(currentAction)
                         if (displayAction != null) {
                             binding.keyActionSpinner.setText(displayAction.displayName, false)
                         }
+                        if (currentAction is KeyAction.MoveToCustomKeyboard) {
+                            selectTargetCustomKeyboard(currentAction.stableId)
+                        }
+                        updateCustomKeyboardTargetVisibility()
                     }
                 }
 
@@ -866,11 +1019,16 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
                     // Special: SINGLE (existing behavior)
                     newKeyType = KeyType.NORMAL
 
-                    val selectedText = binding.keyActionSpinner.text.toString()
-                    val selectedDisplayAction =
-                        displayActions.firstOrNull { it.displayName == selectedText }
+                    val selectedDisplayAction = selectedSingleDisplayAction()
 
-                    newAction = selectedDisplayAction?.action
+                    newAction = if (selectedDisplayAction?.action is KeyAction.MoveToCustomKeyboard) {
+                        val stableId = selectedTargetCustomKeyboardStableId
+                            ?.takeIf { id -> customKeyboardTargets.any { it.stableId == id } }
+                            ?: return
+                        KeyAction.MoveToCustomKeyboard(stableId)
+                    } else {
+                        selectedDisplayAction?.action
+                    }
                     newDrawableResId = selectedDisplayAction?.iconResId
                     newLabel =
                         if (newDrawableResId != null) "" else selectedDisplayAction?.displayName

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/database/AppDatabase.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/database/AppDatabase.kt
@@ -68,7 +68,7 @@ import com.kazumaproject.markdownhelperkeyboard.user_template.database.UserTempl
         DeleteKeyFlickDeleteTarget::class,
         PhysicalKeyboardShortcutItem::class,
     ],
-    version = 26,
+    version = 27,
     exportSchema = false
 )
 @TypeConverters(
@@ -693,6 +693,12 @@ abstract class AppDatabase : RoomDatabase() {
                     )
                     """.trimIndent()
                 )
+            }
+        }
+
+        val MIGRATION_26_27 = object : Migration(26, 27) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE `keyboard_layouts` ADD COLUMN `stableId` TEXT NOT NULL DEFAULT ''")
             }
         }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolver.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolver.kt
@@ -1,0 +1,22 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
+
+fun resolveCustomKeyboardIndexByStableId(
+    layouts: List<CustomKeyboardLayout>,
+    stableId: String
+): Int? {
+    if (stableId.isBlank()) return null
+    return layouts.indexOfFirst { it.stableId == stableId }
+        .takeIf { it >= 0 }
+}
+
+fun resolveInitialCustomKeyboardIndex(
+    layouts: List<CustomKeyboardLayout>,
+    rememberLast: Boolean,
+    savedStableId: String?
+): Int? {
+    if (layouts.isEmpty()) return null
+    if (!rememberLast) return 0
+    return resolveCustomKeyboardIndexByStableId(layouts, savedStableId.orEmpty()) ?: 0
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolver.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolver.kt
@@ -2,6 +2,19 @@ package com.kazumaproject.markdownhelperkeyboard.ime_service
 
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
 
+enum class CustomKeyboardSelectionReason {
+    InitialRestore,
+    InitialDefault,
+    UserTabClick,
+    UserNextTab,
+    MoveToStableId
+}
+
+data class InitialCustomKeyboardSelection(
+    val index: Int,
+    val reason: CustomKeyboardSelectionReason
+)
+
 fun resolveCustomKeyboardIndexByStableId(
     layouts: List<CustomKeyboardLayout>,
     stableId: String
@@ -16,7 +29,43 @@ fun resolveInitialCustomKeyboardIndex(
     rememberLast: Boolean,
     savedStableId: String?
 ): Int? {
+    return resolveInitialCustomKeyboardSelection(
+        layouts = layouts,
+        rememberLast = rememberLast,
+        savedStableId = savedStableId
+    )?.index
+}
+
+fun resolveInitialCustomKeyboardSelection(
+    layouts: List<CustomKeyboardLayout>,
+    rememberLast: Boolean,
+    savedStableId: String?
+): InitialCustomKeyboardSelection? {
     if (layouts.isEmpty()) return null
-    if (!rememberLast) return 0
-    return resolveCustomKeyboardIndexByStableId(layouts, savedStableId.orEmpty()) ?: 0
+    if (rememberLast && !savedStableId.isNullOrBlank()) {
+        val savedIndex = resolveCustomKeyboardIndexByStableId(layouts, savedStableId)
+        if (savedIndex != null) {
+            return InitialCustomKeyboardSelection(
+                index = savedIndex,
+                reason = CustomKeyboardSelectionReason.InitialRestore
+            )
+        }
+    }
+    return InitialCustomKeyboardSelection(
+        index = 0,
+        reason = CustomKeyboardSelectionReason.InitialDefault
+    )
+}
+
+fun shouldPersistCustomKeyboardSelection(
+    layout: CustomKeyboardLayout,
+    rememberLast: Boolean,
+    reason: CustomKeyboardSelectionReason
+): Boolean {
+    if (!rememberLast) return false
+    if (layout.stableId.isBlank()) return false
+
+    return reason == CustomKeyboardSelectionReason.UserTabClick ||
+        reason == CustomKeyboardSelectionReason.UserNextTab ||
+        reason == CustomKeyboardSelectionReason.MoveToStableId
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1105,7 +1105,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             goToNextPageForFloatingCandidate()
         }
         ioScope.launch {
-            customLayouts = keyboardRepository.getLayoutsNotFlow()
+            customLayouts = keyboardRepository.getLayoutsNotFlowEnsuringStableIds()
             shortCurRepository.initDefaultShortcutsIfNeeded()
             physicalKeyboardShortcutRepository.ensureDefaultShortcuts()
         }
@@ -7281,40 +7281,27 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private fun setInitialKeyboardTab() {
         Timber.d("setInitialKeyboardTab")
-        scope.launch(Dispatchers.IO) {
-            if (customLayouts.isEmpty()) {
-                return@launch
-            }
-            val id = customLayouts[0].layoutId
-            val dbLayout = keyboardRepository.getFullLayout(id).first()
-            val finalLayout = keyboardRepository.convertLayout(dbLayout)
-
-            isCustomLayoutRomajiMode = finalLayout.isRomaji
-            withContext(Dispatchers.Main) {
-                setCustomLayoutOnActiveSurface(finalLayout)
-            }
-        }
+        val targetIndex = resolveInitialCustomKeyboardIndex(
+            layouts = customLayouts,
+            rememberLast = appPreference.remember_last_custom_keyboard_preference == true,
+            savedStableId = appPreference.last_used_custom_keyboard_stable_id
+        ) ?: return
+        setKeyboardTab(targetIndex)
     }
 
     private fun setKeyboardTab(pos: Int) {
+        val layout = customLayouts.getOrNull(pos) ?: run {
+            Timber.d("setKeyboardTab: invalid position=$pos, size=${customLayouts.size}")
+            return
+        }
         currentCustomKeyboardPosition = pos
+        if (appPreference.remember_last_custom_keyboard_preference == true &&
+            layout.stableId.isNotBlank()
+        ) {
+            appPreference.last_used_custom_keyboard_stable_id = layout.stableId
+        }
         scope.launch(Dispatchers.IO) {
-            if (customLayouts.isEmpty()) {
-                Timber.d("setKeyboardTab: customLayouts.isEmpty()")
-                if (customLayouts.isNotEmpty()) {
-                    val id = customLayouts[pos].layoutId
-                    val dbLayout = keyboardRepository.getFullLayout(id).first()
-                    Timber.d("setKeyboardTab: $id $dbLayout")
-                    val finalLayout = keyboardRepository.convertLayout(dbLayout)
-                    Timber.d("setKeyboardTab: ${dbLayout.isRomaji} ${finalLayout.isRomaji}")
-                    isCustomLayoutRomajiMode = finalLayout.isRomaji
-                    withContext(Dispatchers.Main) {
-                        setCustomLayoutOnActiveSurface(finalLayout)
-                    }
-                }
-                return@launch
-            }
-            val id = customLayouts[pos].layoutId
+            val id = layout.layoutId
             val dbLayout = keyboardRepository.getFullLayout(id).first()
             Timber.d("setKeyboardTab: $id $dbLayout")
             val finalLayout = keyboardRepository.convertLayout(dbLayout)
@@ -7324,6 +7311,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 setCustomLayoutOnActiveSurface(finalLayout)
             }
         }
+    }
+
+    private fun moveToCustomKeyboardByStableId(stableId: String) {
+        val targetIndex = resolveCustomKeyboardIndexByStableId(customLayouts, stableId) ?: return
+        setKeyboardTab(targetIndex)
     }
 
     /**
@@ -7618,6 +7610,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     KeyAction.ShiftKey -> {}
                     KeyAction.MoveCustomKeyboardTab -> {}
+                    is KeyAction.MoveToCustomKeyboard -> {}
                     KeyAction.ToggleKatakana -> {}
                     KeyAction.DeleteUntilSymbol -> {}
                     KeyAction.MoveCursorDown -> {
@@ -7681,6 +7674,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     KeyAction.SwitchToNumberLayout -> {}
                     KeyAction.ShiftKey -> {}
                     KeyAction.MoveCustomKeyboardTab -> {}
+                    is KeyAction.MoveToCustomKeyboard -> {}
                     KeyAction.ToggleKatakana -> {}
                     KeyAction.DeleteUntilSymbol -> {}
                     KeyAction.MoveCursorDown -> {}
@@ -7809,6 +7803,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     KeyAction.SwitchToNumberLayout -> {}
                     KeyAction.ShiftKey -> {}
                     KeyAction.MoveCustomKeyboardTab -> {}
+                    is KeyAction.MoveToCustomKeyboard -> {}
                     KeyAction.ToggleKatakana -> {}
                     KeyAction.DeleteUntilSymbol -> {}
                     KeyAction.MoveCursorDown -> {
@@ -7931,6 +7926,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     KeyAction.SwitchToNumberLayout -> {}
                     KeyAction.ShiftKey -> {}
                     KeyAction.MoveCustomKeyboardTab -> {}
+                    is KeyAction.MoveToCustomKeyboard -> {}
                     KeyAction.ToggleKatakana -> {}
                     KeyAction.DeleteUntilSymbol -> {
                         if (isDeleteLeftFlickPreference == true) {
@@ -8327,6 +8323,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 setKeyboardTab(position)
                             }
                         }
+                    }
+
+                    is KeyAction.MoveToCustomKeyboard -> {
+                        moveToCustomKeyboardByStableId(action.stableId)
                     }
 
                     KeyAction.ToggleKatakana -> {
@@ -9548,7 +9548,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
         launch {
             keyboardRepository.getLayouts().distinctUntilChanged().collectLatest { layouts ->
-                customLayouts = layouts
+                customLayouts = if (layouts.any { it.stableId.isBlank() }) {
+                    keyboardRepository.ensureStableIds()
+                    keyboardRepository.getLayoutsNotFlow()
+                } else {
+                    layouts
+                }
             }
         }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -7081,8 +7081,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                 KeyboardType.CUSTOM -> {
                     Timber.d("updateKeyboardLayout CUSTOM: $isFlickOnlyMode $sumireInputKeyType")
-                    setInitialKeyboardTab()
-                    setKeyboardTab(0)
+                    selectInitialCustomKeyboardTab()
                     if (qwertyMode.value != TenKeyQWERTYMode.Number) {
                         _tenKeyQWERTYMode.update { TenKeyQWERTYMode.Custom }
                     } else {
@@ -7105,9 +7104,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun updateKeyboardLayout() {
         Timber.d("updateKeyboardLayout: ${qwertyMode.value} $currentEnterKeyIndex")
         when (qwertyMode.value) {
-            TenKeyQWERTYMode.Custom -> {
-                //setInitialKeyboardTab()
-            }
+            TenKeyQWERTYMode.Custom -> {}
 
             TenKeyQWERTYMode.Default -> {}
             TenKeyQWERTYMode.TenKeyQWERTY -> {}
@@ -7144,8 +7141,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 when (customKeyboardMode) {
                     KeyboardInputMode.HIRAGANA -> {
                         mainLayoutBinding?.let { mainView ->
-                            setInitialKeyboardTab()
-                            setKeyboardTab(0)
+                            selectInitialCustomKeyboardTab()
                             mainView.customLayoutDefault.isVisible = true
                             setCurrentInputModeForSession(InputMode.ModeJapanese)
                             mainView.qwertyView.isVisible = false
@@ -7279,33 +7275,46 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private var isCustomLayoutRomajiMode = false
 
-    private fun setInitialKeyboardTab() {
-        Timber.d("setInitialKeyboardTab")
-        val targetIndex = resolveInitialCustomKeyboardIndex(
+    private fun selectInitialCustomKeyboardTab() {
+        Timber.d("selectInitialCustomKeyboardTab")
+        val initialSelection = resolveInitialCustomKeyboardSelection(
             layouts = customLayouts,
             rememberLast = appPreference.remember_last_custom_keyboard_preference == true,
             savedStableId = appPreference.last_used_custom_keyboard_stable_id
         ) ?: return
-        setKeyboardTab(targetIndex)
+        selectCustomKeyboardTab(
+            index = initialSelection.index,
+            reason = initialSelection.reason
+        )
     }
 
-    private fun setKeyboardTab(pos: Int) {
-        val layout = customLayouts.getOrNull(pos) ?: run {
-            Timber.d("setKeyboardTab: invalid position=$pos, size=${customLayouts.size}")
+    private fun selectCustomKeyboardTab(
+        index: Int,
+        reason: CustomKeyboardSelectionReason
+    ) {
+        val layout = customLayouts.getOrNull(index) ?: run {
+            Timber.d("selectCustomKeyboardTab: invalid index=$index, size=${customLayouts.size}, reason=$reason")
             return
         }
-        currentCustomKeyboardPosition = pos
-        if (appPreference.remember_last_custom_keyboard_preference == true &&
-            layout.stableId.isNotBlank()
+        currentCustomKeyboardPosition = index
+        if (shouldPersistCustomKeyboardSelection(
+                layout = layout,
+                rememberLast = appPreference.remember_last_custom_keyboard_preference == true,
+                reason = reason
+            )
         ) {
             appPreference.last_used_custom_keyboard_stable_id = layout.stableId
         }
+        renderCustomKeyboardLayout(layout)
+    }
+
+    private fun renderCustomKeyboardLayout(layout: CustomKeyboardLayout) {
         scope.launch(Dispatchers.IO) {
             val id = layout.layoutId
             val dbLayout = keyboardRepository.getFullLayout(id).first()
-            Timber.d("setKeyboardTab: $id $dbLayout")
+            Timber.d("renderCustomKeyboardLayout: $id $dbLayout")
             val finalLayout = keyboardRepository.convertLayout(dbLayout)
-            Timber.d("setKeyboardTab: ${dbLayout.isRomaji} ${finalLayout.isRomaji}")
+            Timber.d("renderCustomKeyboardLayout: ${dbLayout.isRomaji} ${finalLayout.isRomaji}")
             isCustomLayoutRomajiMode = finalLayout.isRomaji
             withContext(Dispatchers.Main) {
                 setCustomLayoutOnActiveSurface(finalLayout)
@@ -7314,8 +7323,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun moveToCustomKeyboardByStableId(stableId: String) {
-        val targetIndex = resolveCustomKeyboardIndexByStableId(customLayouts, stableId) ?: return
-        setKeyboardTab(targetIndex)
+        val targetIndex = resolveCustomKeyboardIndexByStableId(customLayouts, stableId) ?: run {
+            Timber.d("moveToCustomKeyboardByStableId: target not found stableId=$stableId")
+            return
+        }
+        selectCustomKeyboardTab(
+            index = targetIndex,
+            reason = CustomKeyboardSelectionReason.MoveToStableId
+        )
     }
 
     /**
@@ -8320,7 +8335,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             if (customLayouts.isNotEmpty()) {
                                 val position =
                                     (currentCustomKeyboardPosition + 1) % customLayouts.size
-                                setKeyboardTab(position)
+                                selectCustomKeyboardTab(
+                                    index = position,
+                                    reason = CustomKeyboardSelectionReason.UserNextTab
+                                )
                             }
                         }
                     }
@@ -12289,7 +12307,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 }
             }
             adapter.setOnCustomLayoutItemClickListener { position ->
-                setKeyboardTab(position)
+                selectCustomKeyboardTab(
+                    index = position,
+                    reason = CustomKeyboardSelectionReason.UserTabClick
+                )
             }
         }
         suggestionAdapterFull?.let { adapter ->

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/di/AppModule.kt
@@ -35,6 +35,7 @@ import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.M
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_23_24
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_24_25
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_25_26
+import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_26_27
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_2_3
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_3_4
 import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase.Companion.MIGRATION_4_5
@@ -112,6 +113,7 @@ object AppModule {
             MIGRATION_23_24,
             MIGRATION_24_25,
             MIGRATION_25_26,
+            MIGRATION_26_27,
         )
         .build()
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/KeyboardRepository.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/KeyboardRepository.kt
@@ -1,8 +1,8 @@
 package com.kazumaproject.markdownhelperkeyboard.repository
 
+import com.kazumaproject.custom_keyboard.data.CircularFlickDirection
 import com.kazumaproject.custom_keyboard.data.FlickAction
 import com.kazumaproject.custom_keyboard.data.FlickDirection
-import com.kazumaproject.custom_keyboard.data.CircularFlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyAction
 import com.kazumaproject.custom_keyboard.data.KeyActionMapper
 import com.kazumaproject.custom_keyboard.data.KeyData
@@ -10,8 +10,8 @@ import com.kazumaproject.custom_keyboard.data.KeyType
 import com.kazumaproject.custom_keyboard.data.KeyboardLayout
 import com.kazumaproject.custom_keyboard.data.toCircularFlickDirection
 import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
-import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CircularFlickMapping
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.FlickMapping
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.FullKeyboardLayout
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.KeyDefinition
@@ -36,6 +36,19 @@ private data class DbKeyboardLayoutParts(
     val longPressFlicksMap: Map<String, List<LongPressFlickMapping>>,
     val twoStepLongPressMap: Map<String, List<TwoStepLongPressMappingEntity>>
 )
+
+fun ensureStableIdsForLayouts(
+    layouts: List<CustomKeyboardLayout>,
+    generateStableId: () -> String = { UUID.randomUUID().toString() }
+): List<CustomKeyboardLayout> {
+    return layouts.map { layout ->
+        if (layout.stableId.isBlank()) {
+            layout.copy(stableId = generateStableId())
+        } else {
+            layout
+        }
+    }
+}
 
 @Singleton
 class KeyboardRepository @Inject constructor(
@@ -71,12 +84,21 @@ class KeyboardRepository @Inject constructor(
             }
 
             currentMaxOrder += 1
+            val importedStableId = fullLayout.layout.stableId
+            val stableIdToInsert = if (importedStableId.isNullOrBlank() ||
+                dao.findLayoutByStableId(importedStableId) != null
+            ) {
+                UUID.randomUUID().toString()
+            } else {
+                importedStableId
+            }
 
             val layoutToInsert = fullLayout.layout.copy(
                 layoutId = 0,
                 name = newName,
                 createdAt = System.currentTimeMillis(),
-                sortOrder = currentMaxOrder
+                sortOrder = currentMaxOrder,
+                stableId = stableIdToInsert
             )
 
             val keysToInsert = fullLayout.keysWithFlicks.map { it.key }
@@ -140,6 +162,19 @@ class KeyboardRepository @Inject constructor(
     suspend fun getLayoutsNotFlow(): List<CustomKeyboardLayout> =
         dao.getLayoutsListNotFlow()
 
+    suspend fun ensureStableIds() {
+        val currentLayouts = dao.getLayoutsListNotFlow()
+        val ensuredLayouts = ensureStableIdsForLayouts(currentLayouts)
+        currentLayouts.zip(ensuredLayouts)
+            .filter { (current, ensured) -> current.stableId != ensured.stableId }
+            .forEach { (_, ensured) -> dao.updateLayout(ensured) }
+    }
+
+    suspend fun getLayoutsNotFlowEnsuringStableIds(): List<CustomKeyboardLayout> {
+        ensureStableIds()
+        return dao.getLayoutsListNotFlow()
+    }
+
     suspend fun getLayoutName(id: Long): String? = dao.getLayoutName(id)
 
     fun getFullLayout(id: Long): Flow<KeyboardLayout> {
@@ -193,6 +228,9 @@ class KeyboardRepository @Inject constructor(
 
         val createdAtToKeep = existing?.createdAt ?: System.currentTimeMillis()
         val sortOrderToKeep = existing?.sortOrder ?: nextTopSortOrder()
+        val stableIdToKeep = existing?.stableId
+            ?.takeIf { it.isNotBlank() }
+            ?: UUID.randomUUID().toString()
 
         val dbLayout = CustomKeyboardLayout(
             layoutId = id ?: 0,
@@ -201,7 +239,8 @@ class KeyboardRepository @Inject constructor(
             rowCount = layout.rowCount,
             isRomaji = layout.isRomaji,
             createdAt = createdAtToKeep,
-            sortOrder = sortOrderToKeep
+            sortOrder = sortOrderToKeep,
+            stableId = stableIdToKeep
         )
 
         val parts = convertToDbModel(layout)
@@ -242,7 +281,8 @@ class KeyboardRepository @Inject constructor(
             layoutId = 0,
             name = finalName,
             createdAt = System.currentTimeMillis(),
-            sortOrder = nextTopSortOrder()
+            sortOrder = nextTopSortOrder(),
+            stableId = UUID.randomUUID().toString()
         )
 
         val newKeys = originalLayout.keysWithFlicks.map { keyWithFlicks ->
@@ -476,6 +516,7 @@ class KeyboardRepository @Inject constructor(
                         KeyAction.MoveCursorLeft -> com.kazumaproject.core.R.drawable.baseline_arrow_left_24
                         KeyAction.MoveCursorRight -> com.kazumaproject.core.R.drawable.baseline_arrow_right_24
                         KeyAction.MoveCustomKeyboardTab -> com.kazumaproject.core.R.drawable.keyboard_command_key_24px
+                        is KeyAction.MoveToCustomKeyboard -> com.kazumaproject.core.R.drawable.keyboard_command_key_24px
                         KeyAction.Paste -> com.kazumaproject.core.R.drawable.content_paste_24px
                         KeyAction.SelectAll -> com.kazumaproject.core.R.drawable.text_select_start_24dp
                         KeyAction.SelectLeft -> com.kazumaproject.core.R.drawable.baseline_arrow_left_24

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/KeyboardRepository.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/repository/KeyboardRepository.kt
@@ -516,7 +516,7 @@ class KeyboardRepository @Inject constructor(
                         KeyAction.MoveCursorLeft -> com.kazumaproject.core.R.drawable.baseline_arrow_left_24
                         KeyAction.MoveCursorRight -> com.kazumaproject.core.R.drawable.baseline_arrow_right_24
                         KeyAction.MoveCustomKeyboardTab -> com.kazumaproject.core.R.drawable.keyboard_command_key_24px
-                        is KeyAction.MoveToCustomKeyboard -> com.kazumaproject.core.R.drawable.keyboard_command_key_24px
+                        is KeyAction.MoveToCustomKeyboard -> com.kazumaproject.core.R.drawable.keyboard_24px
                         KeyAction.Paste -> com.kazumaproject.core.R.drawable.content_paste_24px
                         KeyAction.SelectAll -> com.kazumaproject.core.R.drawable.text_select_start_24dp
                         KeyAction.SelectLeft -> com.kazumaproject.core.R.drawable.baseline_arrow_left_24

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -158,6 +158,10 @@ object AppPreference {
     private val DELETE_KEY_HIGH_LIGHT = Pair("henkan_delete_key_action_preference", true)
     private val CUSTOM_KEYBOARD_SUGGESTION_PREFERENCE =
         Pair("custom_keyboard_suggestion_preference", true)
+    private val REMEMBER_LAST_CUSTOM_KEYBOARD_PREFERENCE =
+        Pair("remember_last_custom_keyboard_preference", false)
+    private val LAST_USED_CUSTOM_KEYBOARD_STABLE_ID =
+        Pair("last_used_custom_keyboard_stable_id", "")
 
     private val KEYBOARD_FLOATING_POSITION_X = Pair("keyboard_floating_position_x", -1)
     private val KEYBOARD_FLOATING_POSITION_Y = Pair("keyboard_floating_position_y", -1)
@@ -1123,6 +1127,24 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(CUSTOM_KEYBOARD_SUGGESTION_PREFERENCE.first, value ?: true)
+        }
+
+    var remember_last_custom_keyboard_preference: Boolean?
+        get() = preferences.getBoolean(
+            REMEMBER_LAST_CUSTOM_KEYBOARD_PREFERENCE.first,
+            REMEMBER_LAST_CUSTOM_KEYBOARD_PREFERENCE.second
+        )
+        set(value) = preferences.edit {
+            it.putBoolean(REMEMBER_LAST_CUSTOM_KEYBOARD_PREFERENCE.first, value ?: false)
+        }
+
+    var last_used_custom_keyboard_stable_id: String?
+        get() = preferences.getString(
+            LAST_USED_CUSTOM_KEYBOARD_STABLE_ID.first,
+            LAST_USED_CUSTOM_KEYBOARD_STABLE_ID.second
+        )
+        set(value) = preferences.edit {
+            it.putString(LAST_USED_CUSTOM_KEYBOARD_STABLE_ID.first, value.orEmpty())
         }
 
     var sumire_input_selection_preference: String?

--- a/app/src/main/res/layout/fragment_key_editor.xml
+++ b/app/src/main/res/layout/fragment_key_editor.xml
@@ -268,6 +268,24 @@
                     tools:text="削除" />
             </com.google.android.material.textfield.TextInputLayout>
 
+            <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/custom_keyboard_target_layout"
+                style="@style/Widget.Material3.TextInputLayout.OutlinedBox.ExposedDropdownMenu"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:hint="@string/custom_keyboard_target_hint"
+                android:visibility="gone"
+                tools:visibility="visible">
+
+                <AutoCompleteTextView
+                    android:id="@+id/custom_keyboard_target_spinner"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="none"
+                    tools:text="My Keyboard" />
+            </com.google.android.material.textfield.TextInputLayout>
+
             <LinearLayout
                 android:id="@+id/circular_flick_editor_group"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -204,6 +204,11 @@
     <string name="custom_keyboard_suggestion_title">未入力時の表示</string>
     <string name="custom_keyboard_suggestion_summary_on">文字を入力していないときは、カスタムタブの一覧を表示します。</string>
     <string name="custom_keyboard_suggestion_summary_off">文字を入力していないときは、標準の表示（クリップボードなど）のままにします。</string>
+    <string name="remember_last_custom_keyboard_title">最後に使用したカスタムキーボードを復元</string>
+    <string name="remember_last_custom_keyboard_summary_on">カスタムキーボードを開いたとき、前回使用したカスタムキーボードを表示します</string>
+    <string name="remember_last_custom_keyboard_summary_off">カスタムキーボードを開いたとき、最初のカスタムキーボードを表示します</string>
+    <string name="custom_keyboard_target_hint">移動先カスタムキーボード</string>
+    <string name="deleted_custom_keyboard_target">削除済みのカスタムキーボード</string>
 
     <string name="clipboard_history_fragment_title">クリップボードの履歴</string>
     <string name="clipboard_history_fragment_summary">クリップボードの履歴を表示</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -202,6 +202,11 @@
     <string name="custom_keyboard_suggestion_title">Display when no text is entered</string>
     <string name="custom_keyboard_suggestion_summary_on">Show a list from the custom tab when no text is entered.</string>
     <string name="custom_keyboard_suggestion_summary_off">Keep the standard display (clipboard, etc.) when no text is entered.</string>
+    <string name="remember_last_custom_keyboard_title">Restore last used custom keyboard</string>
+    <string name="remember_last_custom_keyboard_summary_on">Shows the custom keyboard you used last when opening custom keyboards</string>
+    <string name="remember_last_custom_keyboard_summary_off">Shows the first custom keyboard when opening custom keyboards</string>
+    <string name="custom_keyboard_target_hint">Target custom keyboard</string>
+    <string name="deleted_custom_keyboard_target">Deleted custom keyboard</string>
 
     <string name="clipboard_history_fragment_title">Clipboard History</string>
     <string name="clipboard_history_fragment_summary">Show clipboard history</string>

--- a/app/src/main/res/xml/pref_custom.xml
+++ b/app/src/main/res/xml/pref_custom.xml
@@ -24,6 +24,13 @@
             android:title="@string/custom_keyboard_suggestion_title" />
 
         <SwitchPreferenceCompat
+            android:defaultValue="false"
+            android:key="remember_last_custom_keyboard_preference"
+            android:summaryOff="@string/remember_last_custom_keyboard_summary_off"
+            android:summaryOn="@string/remember_last_custom_keyboard_summary_on"
+            android:title="@string/remember_last_custom_keyboard_title" />
+
+        <SwitchPreferenceCompat
             android:key="custom_romaji_zenkaku_conversion_enable_preference"
             android:title="@string/custom_romaji_zenkaku_conversion_enable_preference_title"
             app:defaultValue="true"

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/data/DataConverterExtensionsMoveToCustomKeyboardTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/data/DataConverterExtensionsMoveToCustomKeyboardTest.kt
@@ -1,0 +1,53 @@
+package com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data
+
+import com.kazumaproject.custom_keyboard.data.FlickAction
+import com.kazumaproject.custom_keyboard.data.FlickDirection
+import com.kazumaproject.custom_keyboard.data.KeyAction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class DataConverterExtensionsMoveToCustomKeyboardTest {
+
+    @Test
+    fun moveToCustomKeyboardRoundTripsThroughDbStrings() {
+        val stableId = "stable-target"
+        val dbStrings = FlickAction.Action(KeyAction.MoveToCustomKeyboard(stableId)).toDbStrings()
+
+        assertEquals("MoveToCustomKeyboard", dbStrings.first)
+        assertEquals(stableId, dbStrings.second)
+
+        val restored = FlickMapping(
+            ownerKeyId = 1L,
+            stateIndex = 0,
+            flickDirection = FlickDirection.TAP,
+            actionType = dbStrings.first,
+            actionValue = dbStrings.second
+        ).toFlickAction()
+
+        assertEquals(FlickAction.Action(KeyAction.MoveToCustomKeyboard(stableId)), restored)
+    }
+
+    @Test
+    fun existingMoveCustomKeyboardTabStillRoundTripsThroughDbStrings() {
+        val dbStrings = FlickAction.Action(KeyAction.MoveCustomKeyboardTab).toDbStrings()
+
+        assertEquals("MoveCustomKeyboardTab", dbStrings.first)
+        assertEquals(CircularFlickSlotActionMapper.SWITCH_MAP_LABEL, dbStrings.second)
+
+        val restored = FlickMapping(
+            ownerKeyId = 1L,
+            stateIndex = 0,
+            flickDirection = FlickDirection.TAP,
+            actionType = dbStrings.first,
+            actionValue = dbStrings.second
+        ).toFlickAction()
+
+        assertEquals(
+            FlickAction.Action(
+                KeyAction.MoveCustomKeyboardTab,
+                label = CircularFlickSlotActionMapper.SWITCH_MAP_LABEL
+            ),
+            restored
+        )
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolverTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolverTest.kt
@@ -2,7 +2,9 @@ package com.kazumaproject.markdownhelperkeyboard.ime_service
 
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class CustomKeyboardIndexResolverTest {
@@ -63,6 +65,161 @@ class CustomKeyboardIndexResolverTest {
         )
 
         assertEquals(0, resolveInitialCustomKeyboardIndex(layouts, false, "stable-b"))
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardSelectionReturnsNullWhenLayoutsAreEmpty() {
+        assertNull(resolveInitialCustomKeyboardSelection(emptyList(), true, "stable-a"))
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardSelectionReturnsDefaultWhenRememberLastIsOff() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(
+            InitialCustomKeyboardSelection(
+                index = 0,
+                reason = CustomKeyboardSelectionReason.InitialDefault
+            ),
+            resolveInitialCustomKeyboardSelection(layouts, false, "stable-b")
+        )
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardSelectionReturnsSavedStableIdWhenRememberLastIsOn() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(
+            InitialCustomKeyboardSelection(
+                index = 1,
+                reason = CustomKeyboardSelectionReason.InitialRestore
+            ),
+            resolveInitialCustomKeyboardSelection(layouts, true, "stable-b")
+        )
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardSelectionReturnsDefaultWhenSavedStableIdIsNullOrBlank() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+        val expected = InitialCustomKeyboardSelection(
+            index = 0,
+            reason = CustomKeyboardSelectionReason.InitialDefault
+        )
+
+        assertEquals(expected, resolveInitialCustomKeyboardSelection(layouts, true, null))
+        assertEquals(expected, resolveInitialCustomKeyboardSelection(layouts, true, ""))
+        assertEquals(expected, resolveInitialCustomKeyboardSelection(layouts, true, "   "))
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardSelectionReturnsDefaultWhenSavedStableIdIsMissing() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(
+            InitialCustomKeyboardSelection(
+                index = 0,
+                reason = CustomKeyboardSelectionReason.InitialDefault
+            ),
+            resolveInitialCustomKeyboardSelection(layouts, true, "missing")
+        )
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardSelectionUsesStableIdAfterReorder() {
+        val reordered = listOf(
+            layout("B", "stable-b"),
+            layout("A", "stable-a"),
+            layout("C", "stable-c")
+        )
+
+        assertEquals(
+            InitialCustomKeyboardSelection(
+                index = 1,
+                reason = CustomKeyboardSelectionReason.InitialRestore
+            ),
+            resolveInitialCustomKeyboardSelection(reordered, true, "stable-a")
+        )
+    }
+
+    @Test
+    fun shouldPersistCustomKeyboardSelectionReturnsFalseWhenRememberLastIsOff() {
+        assertFalse(
+            shouldPersistCustomKeyboardSelection(
+                layout("A", "stable-a"),
+                rememberLast = false,
+                reason = CustomKeyboardSelectionReason.UserTabClick
+            )
+        )
+    }
+
+    @Test
+    fun shouldPersistCustomKeyboardSelectionReturnsFalseWhenStableIdIsBlank() {
+        assertFalse(
+            shouldPersistCustomKeyboardSelection(
+                layout("A", ""),
+                rememberLast = true,
+                reason = CustomKeyboardSelectionReason.UserTabClick
+            )
+        )
+    }
+
+    @Test
+    fun shouldPersistCustomKeyboardSelectionReturnsFalseForInitialSelections() {
+        val layout = layout("A", "stable-a")
+
+        assertFalse(
+            shouldPersistCustomKeyboardSelection(
+                layout,
+                rememberLast = true,
+                reason = CustomKeyboardSelectionReason.InitialRestore
+            )
+        )
+        assertFalse(
+            shouldPersistCustomKeyboardSelection(
+                layout,
+                rememberLast = true,
+                reason = CustomKeyboardSelectionReason.InitialDefault
+            )
+        )
+    }
+
+    @Test
+    fun shouldPersistCustomKeyboardSelectionReturnsTrueForUserSelections() {
+        val layout = layout("A", "stable-a")
+
+        assertTrue(
+            shouldPersistCustomKeyboardSelection(
+                layout,
+                rememberLast = true,
+                reason = CustomKeyboardSelectionReason.UserTabClick
+            )
+        )
+        assertTrue(
+            shouldPersistCustomKeyboardSelection(
+                layout,
+                rememberLast = true,
+                reason = CustomKeyboardSelectionReason.UserNextTab
+            )
+        )
+        assertTrue(
+            shouldPersistCustomKeyboardSelection(
+                layout,
+                rememberLast = true,
+                reason = CustomKeyboardSelectionReason.MoveToStableId
+            )
+        )
     }
 
     private fun layout(name: String, stableId: String): CustomKeyboardLayout {

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolverTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomKeyboardIndexResolverTest.kt
@@ -1,0 +1,76 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CustomKeyboardIndexResolverTest {
+
+    @Test
+    fun resolveCustomKeyboardIndexByStableIdReturnsTargetIndex() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(1, resolveCustomKeyboardIndexByStableId(layouts, "stable-b"))
+    }
+
+    @Test
+    fun resolveCustomKeyboardIndexByStableIdStillFindsTargetAfterReorder() {
+        val reordered = listOf(
+            layout("B", "stable-b"),
+            layout("A", "stable-a")
+        )
+
+        assertEquals(1, resolveCustomKeyboardIndexByStableId(reordered, "stable-a"))
+    }
+
+    @Test
+    fun resolveCustomKeyboardIndexByStableIdReturnsNullWhenMissingOrBlank() {
+        val layouts = listOf(layout("A", "stable-a"))
+
+        assertNull(resolveCustomKeyboardIndexByStableId(layouts, "missing"))
+        assertNull(resolveCustomKeyboardIndexByStableId(layouts, ""))
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardIndexUsesSavedStableIdWhenRememberLastIsOn() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(1, resolveInitialCustomKeyboardIndex(layouts, true, "stable-b"))
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardIndexFallsBackToFirstWhenSavedStableIdIsMissing() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(0, resolveInitialCustomKeyboardIndex(layouts, true, "missing"))
+    }
+
+    @Test
+    fun resolveInitialCustomKeyboardIndexReturnsFirstWhenRememberLastIsOff() {
+        val layouts = listOf(
+            layout("A", "stable-a"),
+            layout("B", "stable-b")
+        )
+
+        assertEquals(0, resolveInitialCustomKeyboardIndex(layouts, false, "stable-b"))
+    }
+
+    private fun layout(name: String, stableId: String): CustomKeyboardLayout {
+        return CustomKeyboardLayout(
+            name = name,
+            columnCount = 1,
+            rowCount = 1,
+            stableId = stableId
+        )
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/repository/KeyboardRepositoryStableIdTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/repository/KeyboardRepositoryStableIdTest.kt
@@ -1,0 +1,37 @@
+package com.kazumaproject.markdownhelperkeyboard.repository
+
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+
+class KeyboardRepositoryStableIdTest {
+
+    @Test
+    fun ensureStableIdsForLayoutsFillsBlankStableId() {
+        val layouts = listOf(layout("A", ""))
+
+        val ensured = ensureStableIdsForLayouts(layouts) { "generated-stable-id" }
+
+        assertEquals("generated-stable-id", ensured.single().stableId)
+    }
+
+    @Test
+    fun ensureStableIdsForLayoutsKeepsExistingStableId() {
+        val layouts = listOf(layout("A", "stable-a"))
+
+        val ensured = ensureStableIdsForLayouts(layouts) { "generated-stable-id" }
+
+        assertEquals("stable-a", ensured.single().stableId)
+        assertNotEquals("generated-stable-id", ensured.single().stableId)
+    }
+
+    private fun layout(name: String, stableId: String): CustomKeyboardLayout {
+        return CustomKeyboardLayout(
+            name = name,
+            columnCount = 1,
+            rowCount = 1,
+            stableId = stableId
+        )
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyActionMapper.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyActionMapper.kt
@@ -10,6 +10,7 @@ data class DisplayAction(
 )
 
 object KeyActionMapper {
+    private const val MOVE_TO_CUSTOM_KEYBOARD_PREFIX = "MoveToCustomKeyboard:"
 
     /**
      * Generates a list of DisplayAction objects using localized strings.
@@ -85,6 +86,11 @@ object KeyActionMapper {
                 com.kazumaproject.core.R.drawable.keyboard_command_key_24px
             ),
             DisplayAction(
+                KeyAction.MoveToCustomKeyboard(""),
+                context.getString(R.string.action_move_to_custom_keyboard),
+                com.kazumaproject.core.R.drawable.keyboard_command_key_24px
+            ),
+            DisplayAction(
                 KeyAction.MoveCursorLeft,
                 context.getString(R.string.action_move_cursor_left),
                 com.kazumaproject.core.R.drawable.baseline_arrow_left_24
@@ -149,6 +155,9 @@ object KeyActionMapper {
             is KeyAction.SwitchToNumberLayout -> "SwitchToNumber"
             is KeyAction.ShiftKey -> "ShiftKeyPressed"
             is KeyAction.MoveCustomKeyboardTab -> "MoveCustomKeyboardTab"
+            is KeyAction.MoveToCustomKeyboard -> keyAction.stableId
+                .takeIf { it.isNotBlank() }
+                ?.let { "$MOVE_TO_CUSTOM_KEYBOARD_PREFIX$it" }
             is KeyAction.DeleteUntilSymbol -> "DeleteUntilSymbol"
             is KeyAction.ToggleKatakana -> "SwitchKatakana"
             is KeyAction.VoiceInput -> "VoiceInput"
@@ -158,6 +167,10 @@ object KeyActionMapper {
 
     // DBから読み込んだ文字列をKeyActionオブジェクトに変換
     fun toKeyAction(actionString: String?): KeyAction? {
+        if (actionString?.startsWith(MOVE_TO_CUSTOM_KEYBOARD_PREFIX) == true) {
+            val stableId = actionString.removePrefix(MOVE_TO_CUSTOM_KEYBOARD_PREFIX)
+            return stableId.takeIf { it.isNotBlank() }?.let { KeyAction.MoveToCustomKeyboard(it) }
+        }
         return when (actionString) {
             "Delete" -> KeyAction.Delete
             "Backspace" -> KeyAction.Backspace

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KeyModels.kt
@@ -56,6 +56,7 @@ sealed class KeyAction {
     data object SwitchToNumberLayout : KeyAction()
     data object ShiftKey : KeyAction()
     data object MoveCustomKeyboardTab : KeyAction()
+    data class MoveToCustomKeyboard(val stableId: String) : KeyAction()
 
     // ひらがな・英語用
     data object ToggleDakuten : KeyAction() // 濁点・半濁点・小文字化

--- a/custom_keyboard/src/main/res/values-ja/strings.xml
+++ b/custom_keyboard/src/main/res/values-ja/strings.xml
@@ -18,6 +18,7 @@
     <string name="action_toggle_case">英語、小文字</string>
     <string name="action_shift_key">ローマ字、英語切り替え</string>
     <string name="action_move_custom_keyboard_tab">タブの変更</string>
+    <string name="action_move_to_custom_keyboard">特定のカスタムキーボードへ移動</string>
     <string name="action_move_cursor_left">カーソル左</string>
     <string name="action_move_cursor_right">カーソル右</string>
     <string name="action_select_all">すべて選択</string>

--- a/custom_keyboard/src/main/res/values/strings.xml
+++ b/custom_keyboard/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="action_toggle_case">English / Lowercase</string>
     <string name="action_shift_key">Romaji / English Switch</string>
     <string name="action_move_custom_keyboard_tab">Change Tab</string>
+    <string name="action_move_to_custom_keyboard">Move to specific custom keyboard</string>
     <string name="action_move_cursor_left">Move Cursor Left</string>
     <string name="action_move_cursor_right">Move Cursor Right</string>
     <string name="action_select_all">Select All</string>

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/data/KeyActionMapperMoveToCustomKeyboardTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/data/KeyActionMapperMoveToCustomKeyboardTest.kt
@@ -1,0 +1,36 @@
+package com.kazumaproject.custom_keyboard.data
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class KeyActionMapperMoveToCustomKeyboardTest {
+
+    @Test
+    fun moveToCustomKeyboardRoundTripsThroughString() {
+        val stableId = "stable-target"
+
+        val saved = KeyActionMapper.fromKeyAction(KeyAction.MoveToCustomKeyboard(stableId))
+
+        assertEquals("MoveToCustomKeyboard:$stableId", saved)
+        assertEquals(KeyAction.MoveToCustomKeyboard(stableId), KeyActionMapper.toKeyAction(saved))
+    }
+
+    @Test
+    fun blankMoveToCustomKeyboardIsNotSerializedOrRestored() {
+        assertNull(KeyActionMapper.fromKeyAction(KeyAction.MoveToCustomKeyboard("")))
+        assertNull(KeyActionMapper.toKeyAction("MoveToCustomKeyboard:"))
+    }
+
+    @Test
+    fun existingActionsKeepTheirStringFormat() {
+        assertEquals("MoveCustomKeyboardTab", KeyActionMapper.fromKeyAction(KeyAction.MoveCustomKeyboardTab))
+        assertEquals(KeyAction.MoveCustomKeyboardTab, KeyActionMapper.toKeyAction("MoveCustomKeyboardTab"))
+        assertEquals("^_^", KeyActionMapper.fromKeyAction(KeyAction.ShowEmojiKeyboard))
+        assertEquals(KeyAction.ShowEmojiKeyboard, KeyActionMapper.toKeyAction("^_^"))
+        assertEquals("小゛゜", KeyActionMapper.fromKeyAction(KeyAction.ToggleDakuten))
+        assertEquals(KeyAction.ToggleDakuten, KeyActionMapper.toKeyAction("小゛゜"))
+        assertEquals("a/A", KeyActionMapper.fromKeyAction(KeyAction.ToggleCase))
+        assertEquals(KeyAction.ToggleCase, KeyActionMapper.toKeyAction("a/A"))
+    }
+}


### PR DESCRIPTION
## Summary / 概要

### English

This PR adds a new custom keyboard action that allows users to switch directly to a specific custom keyboard.

Previously, custom keyboard switching only supported moving to the next custom keyboard tab. With this change, users can assign a special key action that targets a specific custom keyboard.

This is useful when users have multiple custom keyboards and want to jump directly to a frequently used one.

### 日本語

この PR では、特定のカスタムキーボードへ直接移動できる新しいアクションを追加します。

これまでは、カスタムキーボードの切り替えは「次のカスタムキーボードへ移動」のみでした。  
この変更により、ユーザーは特殊キーに対して、任意のカスタムキーボードへ直接移動するアクションを割り当てられるようになります。

複数のカスタムキーボードを利用している場合に、よく使うカスタムキーボードへ素早く移動できるようになります。

## Changes / 変更内容

### English

- Added `MoveToCustomKeyboard(stableId)` action.
- Added `stableId` to `CustomKeyboardLayout` so custom keyboards can be referenced safely even if their order or name changes.
- Added target custom keyboard selection UI to `KeyEditorFragment`.
- Stores and restores `MoveToCustomKeyboard` mappings through the existing DB conversion layer.
- Excludes `MoveToCustomKeyboard` from special flick action choices because it requires a separate target keyboard selection.
- Added logic to restore the last used custom keyboard by stable ID when the corresponding preference is enabled.
- Added resolver logic and tests for custom keyboard index selection.
- Updated the icon used for the move-to-specific-custom-keyboard action.

### 日本語

- `MoveToCustomKeyboard(stableId)` アクションを追加しました。
- カスタムキーボードの並び順や名前変更に影響されにくいように、`CustomKeyboardLayout` に `stableId` を追加しました。
- `KeyEditorFragment` に、移動先のカスタムキーボードを選択する UI を追加しました。
- 既存の DB 変換処理を通して、`MoveToCustomKeyboard` の設定を保存・復元できるようにしました。
- `MoveToCustomKeyboard` は移動先キーボードの選択が必要なため、特殊フリック用のアクション候補からは除外しました。
- 対応する設定が有効な場合、最後に使用したカスタムキーボードを stable ID で復元する処理を追加しました。
- カスタムキーボードの index 選択に関する resolver ロジックとテストを追加しました。
- 特定のカスタムキーボードへ移動するアクションのアイコンを更新しました。

## Related Issue / 関連 Issue

#647