### PR TITLE
フリック時の PopupView と文字のサイズの設定の追加

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -127,6 +127,9 @@ import com.kazumaproject.core.domain.state.GestureType
 import com.kazumaproject.core.domain.state.InputMode
 import com.kazumaproject.core.domain.state.TenKeyQWERTYMode
 import com.kazumaproject.core.domain.window.getScreenHeight
+import com.kazumaproject.core.data.popup.FlickPopupViewStyleSet
+import com.kazumaproject.core.data.popup.PopupViewStyle
+import com.kazumaproject.core.data.popup.QwertyPopupViewStyleSet
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyAction
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
@@ -2076,6 +2079,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 floatingKeyboardLayoutBinding.keyboardViewFloating.setLongPressTimeout(
                     (longPressTimeoutPreferenceValue ?: 300).toLong()
                 )
+                floatingKeyboardLayoutBinding.keyboardViewFloating.applyPopupViewStyle(
+                    currentTenKeyPopupViewStyle()
+                )
                 floatingKeyboardLayoutBinding.keyboardViewFloating.apply {
                     setOnFlickListener(object : FlickListener {
                         override fun onFlick(gestureType: GestureType, key: Key, char: Char?) {
@@ -2165,6 +2171,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 suggestionVisibility.isVisible = false
                 keyboardView.setFlickSensitivityValue(flickSensitivityPreferenceValue ?: 100)
                 keyboardView.setLongPressTimeout((longPressTimeoutPreferenceValue ?: 300).toLong())
+                keyboardView.applyPopupViewStyle(currentTenKeyPopupViewStyle())
                 val defaultLetterSize = when (currentInputModeForSession) {
                     InputMode.ModeJapanese -> 17f
                     InputMode.ModeEnglish -> 12f
@@ -2200,6 +2207,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 )
                 customLayoutDefault.setFlickGuideEnabled(flickKeymapGuidePreference ?: false)
                 qwertyView.setLongPressTimeout((longPressTimeoutPreferenceValue ?: 300).toLong())
+                qwertyView.applyPopupViewStyleSet(currentQwertyPopupViewStyleSet())
                 qwertyView.setSpecialKeyVisibility(
                     showCursors = qwertyShowCursorButtonsPreference ?: false,
                     showSwitchKey = qwertyShowIMEButtonPreference ?: true,
@@ -4774,6 +4782,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         )
         floatingKeyboardLayoutBinding.keyboardViewFloating.setLongPressTimeout(
             (longPressTimeoutPreferenceValue ?: 300).toLong()
+        )
+        floatingKeyboardLayoutBinding.keyboardViewFloating.applyPopupViewStyle(
+            currentTenKeyPopupViewStyle()
         )
         floatingKeyboardLayoutBinding.keyboardViewFloating.setFlickSensitivityValue(
             flickSensitivityPreferenceValue ?: 100
@@ -7401,6 +7412,47 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         configureFlickKeyboardView(mainView.customLayoutDefault, mainView, isFloatingView = false)
     }
 
+    private fun currentTenKeyPopupViewStyle(): PopupViewStyle {
+        return PopupViewStyle(
+            sizeScalePercent = appPreference.tenkey_popup_size_scale_percent ?: 100,
+            textSizeSp = appPreference.tenkey_popup_text_size_sp ?: 28.0f
+        )
+    }
+
+    private fun currentQwertyPopupViewStyleSet(): QwertyPopupViewStyleSet {
+        return QwertyPopupViewStyleSet(
+            keyPreview = PopupViewStyle(
+                sizeScalePercent = appPreference.qwerty_key_preview_popup_size_scale_percent ?: 100,
+                textSizeSp = appPreference.qwerty_key_preview_popup_text_size_sp ?: 28.0f
+            ),
+            variation = PopupViewStyle(
+                sizeScalePercent = appPreference.qwerty_variation_popup_size_scale_percent ?: 100,
+                textSizeSp = appPreference.qwerty_variation_popup_text_size_sp ?: 28.0f
+            )
+        )
+    }
+
+    private fun currentFlickPopupViewStyleSet(): FlickPopupViewStyleSet {
+        return FlickPopupViewStyleSet(
+            directional = PopupViewStyle(
+                sizeScalePercent = appPreference.flick_directional_popup_size_scale_percent ?: 100,
+                textSizeSp = appPreference.flick_directional_popup_text_size_sp ?: 28.0f
+            ),
+            cross = PopupViewStyle(
+                sizeScalePercent = appPreference.flick_cross_popup_size_scale_percent ?: 100,
+                textSizeSp = appPreference.flick_cross_popup_text_size_sp ?: 18.0f
+            ),
+            standard = PopupViewStyle(
+                sizeScalePercent = appPreference.flick_standard_popup_size_scale_percent ?: 100,
+                textSizeSp = appPreference.flick_standard_popup_text_size_sp ?: 19.0f
+            ),
+            tfbi = PopupViewStyle(
+                sizeScalePercent = appPreference.flick_tfbi_popup_size_scale_percent ?: 100,
+                textSizeSp = appPreference.flick_tfbi_popup_text_size_sp ?: 20.0f
+            )
+        )
+    }
+
     private fun configureFlickKeyboardView(
         flickView: FlickKeyboardView,
         mainView: MainLayoutBinding,
@@ -7455,6 +7507,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             textSizeSp = appPreference.flick_key_text_size_sp ?: 16.0f,
             specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp ?: 16.0f
         )
+        flickView.applyPopupViewStyleSet(currentFlickPopupViewStyleSet())
         flickView.setFlickGuideEnabled(flickKeymapGuidePreference ?: false)
 
         flickView.setOnKeyboardActionListener(object :
@@ -12742,6 +12795,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 borderWidth = customKeyBorderWidth ?: 1
             )
             setLongPressTimeout((longPressTimeoutPreferenceValue ?: 300).toLong())
+            applyPopupViewStyleSet(currentQwertyPopupViewStyleSet())
             setSpecialKeyVisibility(
                 showCursors = qwertyShowCursorButtonsPreference ?: false,
                 showSwitchKey = qwertyShowIMEButtonPreference ?: true,

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -105,6 +105,19 @@ object AppPreference {
 
     private val QWERTY_SHOW_POPUP_WINDOW = Pair("qwerty_show_popup_window_preference", true)
 
+    private val TENKEY_POPUP_SIZE_SCALE_PERCENT =
+        Pair("tenkey_popup_size_scale_percent_preference", 100)
+    private val TENKEY_POPUP_TEXT_SIZE_SP = Pair("tenkey_popup_text_size_sp_preference", 28.0f)
+
+    private val QWERTY_KEY_PREVIEW_POPUP_SIZE_SCALE_PERCENT =
+        Pair("qwerty_key_preview_popup_size_scale_percent_preference", 100)
+    private val QWERTY_KEY_PREVIEW_POPUP_TEXT_SIZE_SP =
+        Pair("qwerty_key_preview_popup_text_size_sp_preference", 28.0f)
+    private val QWERTY_VARIATION_POPUP_SIZE_SCALE_PERCENT =
+        Pair("qwerty_variation_popup_size_scale_percent_preference", 100)
+    private val QWERTY_VARIATION_POPUP_TEXT_SIZE_SP =
+        Pair("qwerty_variation_popup_text_size_sp_preference", 28.0f)
+
     private val CANDIDATE_IN_PASSWORD = Pair("hide_candidate_password_preference", true)
 
     private val CANDIDATE_IN_PASSWORD_COMPOSE = Pair("password_compose_preference", false)
@@ -260,6 +273,23 @@ object AppPreference {
 
     private val FLICK_SPECIAL_KEY_TEXT_SIZE_SP =
         Pair("flick_special_key_text_size_sp_preference", 12.0f)
+
+    private val FLICK_DIRECTIONAL_POPUP_SIZE_SCALE_PERCENT =
+        Pair("flick_directional_popup_size_scale_percent_preference", 100)
+    private val FLICK_DIRECTIONAL_POPUP_TEXT_SIZE_SP =
+        Pair("flick_directional_popup_text_size_sp_preference", 28.0f)
+    private val FLICK_CROSS_POPUP_SIZE_SCALE_PERCENT =
+        Pair("flick_cross_popup_size_scale_percent_preference", 100)
+    private val FLICK_CROSS_POPUP_TEXT_SIZE_SP =
+        Pair("flick_cross_popup_text_size_sp_preference", 18.0f)
+    private val FLICK_STANDARD_POPUP_SIZE_SCALE_PERCENT =
+        Pair("flick_standard_popup_size_scale_percent_preference", 100)
+    private val FLICK_STANDARD_POPUP_TEXT_SIZE_SP =
+        Pair("flick_standard_popup_text_size_sp_preference", 19.0f)
+    private val FLICK_TFBI_POPUP_SIZE_SCALE_PERCENT =
+        Pair("flick_tfbi_popup_size_scale_percent_preference", 100)
+    private val FLICK_TFBI_POPUP_TEXT_SIZE_SP =
+        Pair("flick_tfbi_popup_text_size_sp_preference", 20.0f)
 
     private val CANDIDATE_LETTER_SIZE = Pair("candidate_letter_size_preference", 14.0f)
 
@@ -1446,6 +1476,171 @@ object AppPreference {
             it.putFloat(
                 FLICK_SPECIAL_KEY_TEXT_SIZE_SP.first,
                 value ?: FLICK_SPECIAL_KEY_TEXT_SIZE_SP.second
+            )
+        }
+
+    var tenkey_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            TENKEY_POPUP_SIZE_SCALE_PERCENT.first,
+            TENKEY_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                TENKEY_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: TENKEY_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var tenkey_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            TENKEY_POPUP_TEXT_SIZE_SP.first,
+            TENKEY_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(TENKEY_POPUP_TEXT_SIZE_SP.first, value ?: TENKEY_POPUP_TEXT_SIZE_SP.second)
+        }
+
+    var qwerty_key_preview_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            QWERTY_KEY_PREVIEW_POPUP_SIZE_SCALE_PERCENT.first,
+            QWERTY_KEY_PREVIEW_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                QWERTY_KEY_PREVIEW_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: QWERTY_KEY_PREVIEW_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var qwerty_key_preview_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            QWERTY_KEY_PREVIEW_POPUP_TEXT_SIZE_SP.first,
+            QWERTY_KEY_PREVIEW_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(
+                QWERTY_KEY_PREVIEW_POPUP_TEXT_SIZE_SP.first,
+                value ?: QWERTY_KEY_PREVIEW_POPUP_TEXT_SIZE_SP.second
+            )
+        }
+
+    var qwerty_variation_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            QWERTY_VARIATION_POPUP_SIZE_SCALE_PERCENT.first,
+            QWERTY_VARIATION_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                QWERTY_VARIATION_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: QWERTY_VARIATION_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var qwerty_variation_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            QWERTY_VARIATION_POPUP_TEXT_SIZE_SP.first,
+            QWERTY_VARIATION_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(
+                QWERTY_VARIATION_POPUP_TEXT_SIZE_SP.first,
+                value ?: QWERTY_VARIATION_POPUP_TEXT_SIZE_SP.second
+            )
+        }
+
+    var flick_directional_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            FLICK_DIRECTIONAL_POPUP_SIZE_SCALE_PERCENT.first,
+            FLICK_DIRECTIONAL_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                FLICK_DIRECTIONAL_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: FLICK_DIRECTIONAL_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var flick_directional_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            FLICK_DIRECTIONAL_POPUP_TEXT_SIZE_SP.first,
+            FLICK_DIRECTIONAL_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(
+                FLICK_DIRECTIONAL_POPUP_TEXT_SIZE_SP.first,
+                value ?: FLICK_DIRECTIONAL_POPUP_TEXT_SIZE_SP.second
+            )
+        }
+
+    var flick_cross_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            FLICK_CROSS_POPUP_SIZE_SCALE_PERCENT.first,
+            FLICK_CROSS_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                FLICK_CROSS_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: FLICK_CROSS_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var flick_cross_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            FLICK_CROSS_POPUP_TEXT_SIZE_SP.first,
+            FLICK_CROSS_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(
+                FLICK_CROSS_POPUP_TEXT_SIZE_SP.first,
+                value ?: FLICK_CROSS_POPUP_TEXT_SIZE_SP.second
+            )
+        }
+
+    var flick_standard_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            FLICK_STANDARD_POPUP_SIZE_SCALE_PERCENT.first,
+            FLICK_STANDARD_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                FLICK_STANDARD_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: FLICK_STANDARD_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var flick_standard_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            FLICK_STANDARD_POPUP_TEXT_SIZE_SP.first,
+            FLICK_STANDARD_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(
+                FLICK_STANDARD_POPUP_TEXT_SIZE_SP.first,
+                value ?: FLICK_STANDARD_POPUP_TEXT_SIZE_SP.second
+            )
+        }
+
+    var flick_tfbi_popup_size_scale_percent: Int?
+        get() = preferences.getInt(
+            FLICK_TFBI_POPUP_SIZE_SCALE_PERCENT.first,
+            FLICK_TFBI_POPUP_SIZE_SCALE_PERCENT.second
+        )
+        set(value) = preferences.edit {
+            it.putInt(
+                FLICK_TFBI_POPUP_SIZE_SCALE_PERCENT.first,
+                value ?: FLICK_TFBI_POPUP_SIZE_SCALE_PERCENT.second
+            )
+        }
+
+    var flick_tfbi_popup_text_size_sp: Float?
+        get() = preferences.getFloat(
+            FLICK_TFBI_POPUP_TEXT_SIZE_SP.first,
+            FLICK_TFBI_POPUP_TEXT_SIZE_SP.second
+        )
+        set(value) = preferences.edit {
+            it.putFloat(
+                FLICK_TFBI_POPUP_TEXT_SIZE_SP.first,
+                value ?: FLICK_TFBI_POPUP_TEXT_SIZE_SP.second
             )
         }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/popup_style/PopupStyleFragments.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/popup_style/PopupStyleFragments.kt
@@ -1,0 +1,485 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.popup_style
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.LinearLayout
+import android.widget.ScrollView
+import android.widget.SeekBar
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.os.bundleOf
+import androidx.core.view.MenuProvider
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.navigation.fragment.findNavController
+import com.kazumaproject.core.data.popup.PopupViewStyle
+import com.kazumaproject.markdownhelperkeyboard.R
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+
+class TenKeyPopupStyleSettingFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        AppPreference.init(requireContext())
+        return singleStyleEditor(
+            preview = PopupStylePreviewView(requireContext()).apply { previewText = "あ" },
+            initialStyle = PopupViewStyle(
+                AppPreference.tenkey_popup_size_scale_percent ?: DEFAULT_SIZE,
+                AppPreference.tenkey_popup_text_size_sp ?: DEFAULT_TENKEY_TEXT
+            ),
+            defaultTextSize = DEFAULT_TENKEY_TEXT,
+            onChanged = {
+                AppPreference.tenkey_popup_size_scale_percent = it.sizeScalePercent
+                AppPreference.tenkey_popup_text_size_sp = it.textSizeSp
+            }
+        )
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMenu()
+    }
+
+    private fun setupMenu() {
+        (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        val menuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    android.R.id.home -> {
+                        parentFragmentManager.popBackStack()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+}
+
+class QwertyPopupStyleSettingFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        AppPreference.init(requireContext())
+        val root = editorRoot()
+        root.addView(sectionTitle("Key preview popup"))
+        root.addView(
+            styleEditorSection(
+                preview = PopupStylePreviewView(requireContext()).apply { previewText = "A" },
+                initialStyle = PopupViewStyle(
+                    AppPreference.qwerty_key_preview_popup_size_scale_percent ?: DEFAULT_SIZE,
+                    AppPreference.qwerty_key_preview_popup_text_size_sp
+                        ?: DEFAULT_QWERTY_PREVIEW_TEXT
+                ),
+                defaultTextSize = DEFAULT_QWERTY_PREVIEW_TEXT,
+                onChanged = {
+                    AppPreference.qwerty_key_preview_popup_size_scale_percent = it.sizeScalePercent
+                    AppPreference.qwerty_key_preview_popup_text_size_sp = it.textSizeSp
+                }
+            )
+        )
+        root.addView(sectionTitle("Long-press variation popup"))
+        root.addView(
+            styleEditorSection(
+                preview = PopupStylePreviewView(requireContext()).apply { previewText = "á" },
+                initialStyle = PopupViewStyle(
+                    AppPreference.qwerty_variation_popup_size_scale_percent ?: DEFAULT_SIZE,
+                    AppPreference.qwerty_variation_popup_text_size_sp
+                        ?: DEFAULT_QWERTY_VARIATION_TEXT
+                ),
+                defaultTextSize = DEFAULT_QWERTY_VARIATION_TEXT,
+                onChanged = {
+                    AppPreference.qwerty_variation_popup_size_scale_percent = it.sizeScalePercent
+                    AppPreference.qwerty_variation_popup_text_size_sp = it.textSizeSp
+                }
+            )
+        )
+        return scroll(root)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMenu()
+    }
+
+    private fun setupMenu() {
+        (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        val menuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    android.R.id.home -> {
+                        parentFragmentManager.popBackStack()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+}
+
+class FlickKeyboardPopupStyleListFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        val root = editorRoot()
+        listOf(
+            FlickTarget.DIRECTIONAL to ("Directional popup" to "方向別 popup"),
+            FlickTarget.CROSS to ("Cross / Grid popup" to "cross flick / grid popup"),
+            FlickTarget.STANDARD to ("Standard popup" to "standard flick popup"),
+            FlickTarget.TFBI to ("Two-step popup" to "two-step / sticky / hierarchical popup")
+        ).forEach { (target, texts) ->
+            root.addView(listRow(texts.first, texts.second) {
+                findNavController().navigate(
+                    R.id.action_flickKeyboardPopupStyleListFragment_to_flickKeyboardPopupStyleEditFragment,
+                    bundleOf("target" to target.name)
+                )
+            })
+        }
+        return scroll(root)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMenu()
+    }
+
+    private fun setupMenu() {
+        (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        val menuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    android.R.id.home -> {
+                        parentFragmentManager.popBackStack()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+}
+
+class FlickKeyboardPopupStyleEditFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        AppPreference.init(requireContext())
+        val target = FlickTarget.from(arguments?.getString("target"))
+        val preview = FlickPopupStylePreviewView(requireContext())
+        return singleStyleEditor(
+            preview = preview,
+            initialStyle = readStyle(target),
+            defaultTextSize = target.defaultTextSize,
+            onChanged = { writeStyle(target, it) },
+            flickTarget = target
+        )
+    }
+
+    private fun readStyle(target: FlickTarget): PopupViewStyle {
+        return when (target) {
+            FlickTarget.DIRECTIONAL -> PopupViewStyle(
+                AppPreference.flick_directional_popup_size_scale_percent ?: DEFAULT_SIZE,
+                AppPreference.flick_directional_popup_text_size_sp ?: DEFAULT_DIRECTIONAL_TEXT
+            )
+
+            FlickTarget.CROSS -> PopupViewStyle(
+                AppPreference.flick_cross_popup_size_scale_percent ?: DEFAULT_SIZE,
+                AppPreference.flick_cross_popup_text_size_sp ?: DEFAULT_CROSS_TEXT
+            )
+
+            FlickTarget.STANDARD -> PopupViewStyle(
+                AppPreference.flick_standard_popup_size_scale_percent ?: DEFAULT_SIZE,
+                AppPreference.flick_standard_popup_text_size_sp ?: DEFAULT_STANDARD_TEXT
+            )
+
+            FlickTarget.TFBI -> PopupViewStyle(
+                AppPreference.flick_tfbi_popup_size_scale_percent ?: DEFAULT_SIZE,
+                AppPreference.flick_tfbi_popup_text_size_sp ?: DEFAULT_TFBI_TEXT
+            )
+        }
+    }
+
+    private fun writeStyle(target: FlickTarget, style: PopupViewStyle) {
+        when (target) {
+            FlickTarget.DIRECTIONAL -> {
+                AppPreference.flick_directional_popup_size_scale_percent = style.sizeScalePercent
+                AppPreference.flick_directional_popup_text_size_sp = style.textSizeSp
+            }
+
+            FlickTarget.CROSS -> {
+                AppPreference.flick_cross_popup_size_scale_percent = style.sizeScalePercent
+                AppPreference.flick_cross_popup_text_size_sp = style.textSizeSp
+            }
+
+            FlickTarget.STANDARD -> {
+                AppPreference.flick_standard_popup_size_scale_percent = style.sizeScalePercent
+                AppPreference.flick_standard_popup_text_size_sp = style.textSizeSp
+            }
+
+            FlickTarget.TFBI -> {
+                AppPreference.flick_tfbi_popup_size_scale_percent = style.sizeScalePercent
+                AppPreference.flick_tfbi_popup_text_size_sp = style.textSizeSp
+            }
+        }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        setupMenu()
+    }
+
+    private fun setupMenu() {
+        (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        val menuHost = requireActivity()
+        menuHost.addMenuProvider(object : MenuProvider {
+            override fun onCreateMenu(menu: Menu, menuInflater: MenuInflater) {
+
+            }
+
+            override fun onMenuItemSelected(menuItem: MenuItem): Boolean {
+                return when (menuItem.itemId) {
+                    android.R.id.home -> {
+                        parentFragmentManager.popBackStack()
+                        true
+                    }
+
+                    else -> false
+                }
+            }
+        }, viewLifecycleOwner, Lifecycle.State.RESUMED)
+    }
+}
+
+private enum class FlickTarget(
+    val defaultTextSize: Float,
+    val previewTarget: FlickPopupStylePreviewView.Target
+) {
+    DIRECTIONAL(DEFAULT_DIRECTIONAL_TEXT, FlickPopupStylePreviewView.Target.DIRECTIONAL),
+    CROSS(DEFAULT_CROSS_TEXT, FlickPopupStylePreviewView.Target.CROSS),
+    STANDARD(DEFAULT_STANDARD_TEXT, FlickPopupStylePreviewView.Target.STANDARD),
+    TFBI(DEFAULT_TFBI_TEXT, FlickPopupStylePreviewView.Target.TFBI);
+
+    companion object {
+        fun from(value: String?): FlickTarget {
+            return entries.firstOrNull { it.name == value } ?: DIRECTIONAL
+        }
+    }
+}
+
+private fun Fragment.singleStyleEditor(
+    preview: View,
+    initialStyle: PopupViewStyle,
+    defaultTextSize: Float,
+    onChanged: (PopupViewStyle) -> Unit,
+    flickTarget: FlickTarget? = null
+): View {
+    val root = editorRoot()
+    root.addView(
+        styleEditorSection(
+            preview = preview,
+            initialStyle = initialStyle,
+            defaultTextSize = defaultTextSize,
+            onChanged = onChanged,
+            flickTarget = flickTarget
+        )
+    )
+    return scroll(root)
+}
+
+private fun Fragment.styleEditorSection(
+    preview: View,
+    initialStyle: PopupViewStyle,
+    defaultTextSize: Float,
+    onChanged: (PopupViewStyle) -> Unit,
+    flickTarget: FlickTarget? = null
+): View {
+    val context = requireContext()
+    val root = LinearLayout(context).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(0, dp(8), 0, dp(16))
+    }
+    val sizeLabel = valueLabel("Size", "${initialStyle.sizeScalePercent}%")
+    val textLabel = valueLabel("Text size", String.format("%.1fsp", initialStyle.textSizeSp))
+    val sizeSeek = SeekBar(context).apply {
+        max = MAX_SIZE - MIN_SIZE
+        progress = initialStyle.sizeScalePercent.coerceIn(MIN_SIZE, MAX_SIZE) - MIN_SIZE
+    }
+    val textSeek = SeekBar(context).apply {
+        max = (MAX_TEXT - MIN_TEXT).toInt()
+        progress = (initialStyle.textSizeSp.coerceIn(MIN_TEXT, MAX_TEXT) - MIN_TEXT).toInt()
+    }
+
+    fun currentStyle(): PopupViewStyle {
+        return PopupViewStyle(
+            MIN_SIZE + sizeSeek.progress,
+            MIN_TEXT + textSeek.progress
+        )
+    }
+
+    fun render() {
+        val style = currentStyle()
+        sizeLabel.second.text = "${style.sizeScalePercent}%"
+        textLabel.second.text = String.format("%.1fsp", style.textSizeSp)
+        when (preview) {
+            is PopupStylePreviewView -> preview.applyStyle(style)
+            is FlickPopupStylePreviewView -> preview.applyStyle(
+                flickTarget?.previewTarget ?: FlickPopupStylePreviewView.Target.DIRECTIONAL,
+                style
+            )
+        }
+        onChanged(style)
+    }
+
+    val listener = object : SeekBar.OnSeekBarChangeListener {
+        override fun onProgressChanged(seekBar: SeekBar?, progress: Int, fromUser: Boolean) {
+            render()
+        }
+
+        override fun onStartTrackingTouch(seekBar: SeekBar?) = Unit
+        override fun onStopTrackingTouch(seekBar: SeekBar?) = Unit
+    }
+    sizeSeek.setOnSeekBarChangeListener(listener)
+    textSeek.setOnSeekBarChangeListener(listener)
+
+    preview.layoutParams = LinearLayout.LayoutParams(
+        ViewGroup.LayoutParams.MATCH_PARENT,
+        ViewGroup.LayoutParams.WRAP_CONTENT
+    )
+    root.addView(preview)
+    root.addView(sizeLabel.first)
+    root.addView(sizeSeek)
+    root.addView(textLabel.first)
+    root.addView(textSeek)
+    root.addView(Button(context).apply {
+        text = "デフォルトに戻す"
+        setOnClickListener {
+            sizeSeek.progress = DEFAULT_SIZE - MIN_SIZE
+            textSeek.progress = (defaultTextSize - MIN_TEXT).toInt()
+            render()
+        }
+    })
+    render()
+    return root
+}
+
+private fun Fragment.editorRoot(): LinearLayout {
+    return LinearLayout(requireContext()).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(dp(16), dp(16), dp(16), dp(16))
+    }
+}
+
+private fun Fragment.scroll(child: View): View {
+    return ScrollView(requireContext()).apply {
+        addView(child)
+    }
+}
+
+private fun Fragment.sectionTitle(text: String): TextView {
+    return TextView(requireContext()).apply {
+        this.text = text
+        textSize = 18f
+        setPadding(0, dp(16), 0, dp(4))
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+    }
+}
+
+private fun Fragment.valueLabel(title: String, value: String): Pair<LinearLayout, TextView> {
+    val valueView = TextView(requireContext()).apply {
+        text = value
+        textSize = 16f
+    }
+    val row = LinearLayout(requireContext()).apply {
+        orientation = LinearLayout.HORIZONTAL
+        setPadding(0, dp(12), 0, 0)
+        addView(TextView(requireContext()).apply {
+            text = title
+            textSize = 16f
+            layoutParams = LinearLayout.LayoutParams(0, ViewGroup.LayoutParams.WRAP_CONTENT, 1f)
+        })
+        addView(valueView)
+    }
+    return row to valueView
+}
+
+private fun Fragment.listRow(title: String, summary: String, onClick: () -> Unit): View {
+    return LinearLayout(requireContext()).apply {
+        orientation = LinearLayout.VERTICAL
+        setPadding(0, dp(14), 0, dp(14))
+        isClickable = true
+        isFocusable = true
+        setOnClickListener { onClick() }
+        addView(TextView(requireContext()).apply {
+            text = title
+            textSize = 17f
+        })
+        addView(TextView(requireContext()).apply {
+            text = summary
+            textSize = 14f
+            setTextColor(ColorCompat.secondaryText(requireContext()))
+            setPadding(0, dp(4), 0, 0)
+        })
+    }
+}
+
+private fun Fragment.dp(value: Int): Int {
+    return (value * resources.displayMetrics.density).toInt()
+}
+
+private object ColorCompat {
+    fun secondaryText(context: android.content.Context): Int {
+        val typedValue = android.util.TypedValue()
+        context.theme.resolveAttribute(android.R.attr.textColorSecondary, typedValue, true)
+        return if (typedValue.resourceId != 0) context.getColor(typedValue.resourceId) else typedValue.data
+    }
+}
+
+private const val MIN_SIZE = 50
+private const val MAX_SIZE = 200
+private const val DEFAULT_SIZE = 100
+private const val MIN_TEXT = 8f
+private const val MAX_TEXT = 48f
+private const val DEFAULT_TENKEY_TEXT = 28f
+private const val DEFAULT_QWERTY_PREVIEW_TEXT = 28f
+private const val DEFAULT_QWERTY_VARIATION_TEXT = 28f
+private const val DEFAULT_DIRECTIONAL_TEXT = 28f
+private const val DEFAULT_CROSS_TEXT = 18f
+private const val DEFAULT_STANDARD_TEXT = 19f
+private const val DEFAULT_TFBI_TEXT = 20f

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/popup_style/PopupStyleFragments.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/popup_style/PopupStyleFragments.kt
@@ -151,10 +151,10 @@ class FlickKeyboardPopupStyleListFragment : Fragment() {
     ): View {
         val root = editorRoot()
         listOf(
-            FlickTarget.DIRECTIONAL to ("Directional popup" to "方向別 popup"),
-            FlickTarget.CROSS to ("Cross / Grid popup" to "cross flick / grid popup"),
-            FlickTarget.STANDARD to ("Standard popup" to "standard flick popup"),
-            FlickTarget.TFBI to ("Two-step popup" to "two-step / sticky / hierarchical popup")
+            FlickTarget.DIRECTIONAL to ("通常入力" to "通常入力の方向別ポップアップ"),
+            FlickTarget.CROSS to ("長押し、特殊キー" to "キーを長押し、特殊なキーをフリックしたときに表示されるポップアップ"),
+            FlickTarget.STANDARD to ("サークル入力" to "サークル入力のポップアップ"),
+            FlickTarget.TFBI to ("２段 / ３段フリック入力" to "２段フリック入力・３段フリック入力のポップアップ"),
         ).forEach { (target, texts) ->
             root.addView(listRow(texts.first, texts.second) {
                 findNavController().navigate(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/popup_style/PopupStylePreviewViews.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/popup_style/PopupStylePreviewViews.kt
@@ -1,0 +1,236 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.popup_style
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import android.graphics.RectF
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.View
+import com.kazumaproject.core.data.popup.PopupViewStyle
+
+class PopupStylePreviewView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+    private val backgroundPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(245, 247, 250)
+    }
+    private val bubblePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(55, 71, 79)
+    }
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textAlign = Paint.Align.CENTER
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+    }
+    private var style = PopupViewStyle(100, 28f)
+    var previewText: String = "あ"
+        set(value) {
+            field = value
+            invalidate()
+        }
+
+    fun applyStyle(style: PopupViewStyle) {
+        this.style = PopupViewStyle(
+            style.sizeScalePercent.coerceIn(50, 200),
+            style.textSizeSp.coerceIn(8f, 48f)
+        )
+        invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val desiredHeight = dpToPx(160f).toInt()
+        setMeasuredDimension(
+            MeasureSpec.getSize(widthMeasureSpec),
+            resolveSize(desiredHeight, heightMeasureSpec)
+        )
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.drawColor(backgroundPaint.color)
+        val scale = style.sizeScalePercent.coerceIn(50, 200) / 100f
+        val baseW = dpToPx(86f)
+        val baseH = dpToPx(92f)
+        val w = baseW * scale
+        val h = baseH * scale
+        val left = width / 2f - w / 2f
+        val top = height / 2f - h / 2f
+        val rect = RectF(left, top, left + w, top + h)
+        canvas.drawRoundRect(rect, dpToPx(18f), dpToPx(18f), bubblePaint)
+
+        textPaint.textSize = spToPx(style.textSizeSp)
+        val textY = rect.centerY() - (textPaint.descent() + textPaint.ascent()) / 2f
+        canvas.drawText(previewText, rect.centerX(), textY, textPaint)
+    }
+
+    private fun dpToPx(dp: Float): Float {
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics)
+    }
+
+    private fun spToPx(sp: Float): Float {
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics)
+    }
+}
+
+class FlickPopupStylePreviewView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null
+) : View(context, attrs) {
+
+    enum class Target {
+        DIRECTIONAL,
+        CROSS,
+        STANDARD,
+        TFBI
+    }
+
+    private val bgPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(245, 247, 250)
+    }
+    private val popupPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(69, 90, 100)
+    }
+    private val highlightPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.rgb(96, 125, 139)
+    }
+    private val strokePaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        style = Paint.Style.STROKE
+        strokeWidth = dpToPx(1f)
+    }
+    private val textPaint = Paint(Paint.ANTI_ALIAS_FLAG).apply {
+        color = Color.WHITE
+        textAlign = Paint.Align.CENTER
+        typeface = android.graphics.Typeface.DEFAULT_BOLD
+    }
+
+    private var style = PopupViewStyle(100, 28f)
+    private var target = Target.DIRECTIONAL
+
+    fun applyStyle(target: Target, style: PopupViewStyle) {
+        this.target = target
+        this.style = PopupViewStyle(
+            style.sizeScalePercent.coerceIn(50, 200),
+            style.textSizeSp.coerceIn(8f, 48f)
+        )
+        invalidate()
+    }
+
+    override fun onMeasure(widthMeasureSpec: Int, heightMeasureSpec: Int) {
+        val desiredHeight = dpToPx(190f).toInt()
+        setMeasuredDimension(
+            MeasureSpec.getSize(widthMeasureSpec),
+            resolveSize(desiredHeight, heightMeasureSpec)
+        )
+    }
+
+    override fun onDraw(canvas: Canvas) {
+        super.onDraw(canvas)
+        canvas.drawColor(bgPaint.color)
+        textPaint.textSize = spToPx(style.textSizeSp)
+        when (target) {
+            Target.DIRECTIONAL -> drawDirectionalPreview(canvas)
+            Target.CROSS -> drawCrossPreview(canvas)
+            Target.STANDARD -> drawStandardPreview(canvas)
+            Target.TFBI -> drawTfbiPreview(canvas)
+        }
+    }
+
+    private fun drawDirectionalPreview(canvas: Canvas) {
+        val scale = style.sizeScalePercent / 100f
+        val w = dpToPx(112f) * scale
+        val h = dpToPx(72f) * scale
+        val left = width / 2f - w / 2f
+        val top = height / 2f - h / 2f
+        val pointer = dpToPx(22f) * scale
+        val path = Path().apply {
+            moveTo(left + dpToPx(16f), top)
+            lineTo(left + w - pointer, top)
+            lineTo(left + w, top + h / 2f)
+            lineTo(left + w - pointer, top + h)
+            lineTo(left + dpToPx(16f), top + h)
+            quadTo(left, top + h, left, top + h - dpToPx(16f))
+            lineTo(left, top + dpToPx(16f))
+            quadTo(left, top, left + dpToPx(16f), top)
+            close()
+        }
+        canvas.drawPath(path, popupPaint)
+        canvas.drawPath(path, strokePaint)
+        drawCenteredText(canvas, "あ", RectF(left, top, left + w - pointer, top + h))
+    }
+
+    private fun drawCrossPreview(canvas: Canvas) {
+        val scale = style.sizeScalePercent / 100f
+        val cell = dpToPx(46f) * scale
+        val startX = width / 2f - cell * 1.5f
+        val startY = height / 2f - cell * 1.5f
+        val labels = mapOf(
+            1 to "上",
+            3 to "左",
+            4 to "あ",
+            5 to "右",
+            7 to "下"
+        )
+        for (row in 0..2) {
+            for (col in 0..2) {
+                val index = row * 3 + col
+                val rect = RectF(
+                    startX + col * cell,
+                    startY + row * cell,
+                    startX + (col + 1) * cell,
+                    startY + (row + 1) * cell
+                )
+                canvas.drawRoundRect(rect, dpToPx(10f), dpToPx(10f), if (index == 4) highlightPaint else popupPaint)
+                canvas.drawRoundRect(rect, dpToPx(10f), dpToPx(10f), strokePaint)
+                labels[index]?.let { drawCenteredText(canvas, it, rect) }
+            }
+        }
+    }
+
+    private fun drawStandardPreview(canvas: Canvas) {
+        val scale = style.sizeScalePercent / 100f
+        val size = dpToPx(92f) * scale
+        val rect = RectF(width / 2f - size / 2f, height / 2f - size / 2f, width / 2f + size / 2f, height / 2f + size / 2f)
+        canvas.drawOval(rect, popupPaint)
+        canvas.drawOval(rect, strokePaint)
+        drawCenteredText(canvas, "あ", rect)
+    }
+
+    private fun drawTfbiPreview(canvas: Canvas) {
+        val scale = style.sizeScalePercent / 100f
+        val cell = dpToPx(43f) * scale
+        val startX = width / 2f - cell * 1.5f
+        val startY = height / 2f - cell * 1.5f
+        for (row in 0..2) {
+            for (col in 0..2) {
+                val rect = RectF(
+                    startX + col * cell,
+                    startY + row * cell,
+                    startX + (col + 1) * cell,
+                    startY + (row + 1) * cell
+                )
+                canvas.drawRoundRect(rect, dpToPx(8f), dpToPx(8f), if (row == 1 && col == 1) highlightPaint else popupPaint)
+                canvas.drawRoundRect(rect, dpToPx(8f), dpToPx(8f), strokePaint)
+                if (row == 1 && col == 1) drawCenteredText(canvas, "あ", rect)
+            }
+        }
+    }
+
+    private fun drawCenteredText(canvas: Canvas, text: String, rect: RectF) {
+        val y = rect.centerY() - (textPaint.descent() + textPaint.ascent()) / 2f
+        canvas.drawText(text, rect.centerX(), y, textPaint)
+    }
+
+    private fun dpToPx(dp: Float): Float {
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, resources.displayMetrics)
+    }
+
+    private fun spToPx(sp: Float): Float {
+        return TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_SP, sp, resources.displayMetrics)
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/CustomKeyboardPreferenceFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/CustomKeyboardPreferenceFragment.kt
@@ -21,5 +21,12 @@ class CustomKeyboardPreferenceFragment : PreferenceFragmentCompat() {
                 true
             }
         }
+
+        findPreference<Preference>("flick_keyboard_popup_view_style_preference")?.apply {
+            setOnPreferenceClickListener {
+                navigateSafely(R.id.action_navigation_setting_to_flickKeyboardPopupStyleListFragment)
+                true
+            }
+        }
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/KanaPreferenceFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/KanaPreferenceFragment.kt
@@ -20,5 +20,12 @@ class KanaPreferenceFragment : PreferenceFragmentCompat() {
                 true
             }
         }
+
+        findPreference<Preference>("tenkey_popup_view_style_preference")?.apply {
+            setOnPreferenceClickListener {
+                navigateSafely(R.id.action_navigation_setting_to_tenKeyPopupStyleSettingFragment)
+                true
+            }
+        }
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/QwertyPreferenceFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/QwertyPreferenceFragment.kt
@@ -25,6 +25,13 @@ class QwertyPreferenceFragment : PreferenceFragmentCompat() {
             }
         }
 
+        findPreference<Preference>("qwerty_popup_view_style_preference")?.apply {
+            setOnPreferenceClickListener {
+                navigateSafely(R.id.action_navigation_setting_to_qwertyPopupStyleSettingFragment)
+                true
+            }
+        }
+
         findPreference<Preference>(QWERTY_NUMBER_KEY_FLICK_SETTING_PREFERENCE)?.apply {
             setOnPreferenceClickListener {
                 navigateSafely(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SumirePreferenceFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SumirePreferenceFragment.kt
@@ -76,6 +76,13 @@ class SumirePreferenceFragment : PreferenceFragmentCompat() {
             }
         }
 
+        findPreference<Preference>("flick_keyboard_popup_view_style_preference")?.apply {
+            setOnPreferenceClickListener {
+                navigateSafely(R.id.action_navigation_setting_to_flickKeyboardPopupStyleListFragment)
+                true
+            }
+        }
+
         sumireCustomAnglePreference?.apply {
             setOnPreferenceClickListener {
                 navigateSafely(R.id.action_navigation_setting_to_circularFlickSettingsFragment)

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -65,6 +65,15 @@
             android:id="@+id/action_navigation_setting_to_tenKeyCandidateLetterSizeFragment"
             app:destination="@id/tenKeyCandidateLetterSizeFragment" />
         <action
+            android:id="@+id/action_navigation_setting_to_tenKeyPopupStyleSettingFragment"
+            app:destination="@id/tenKeyPopupStyleSettingFragment" />
+        <action
+            android:id="@+id/action_navigation_setting_to_qwertyPopupStyleSettingFragment"
+            app:destination="@id/qwertyPopupStyleSettingFragment" />
+        <action
+            android:id="@+id/action_navigation_setting_to_flickKeyboardPopupStyleListFragment"
+            app:destination="@id/flickKeyboardPopupStyleListFragment" />
+        <action
             android:id="@+id/action_navigation_setting_to_circularFlickSettingsFragment"
             app:destination="@id/circularFlickSettingsFragment" />
         <action
@@ -251,6 +260,31 @@
         android:id="@+id/tenKeyCandidateLetterSizeFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.tenkey_letter_size_setting.TenKeyCandidateLetterSizeFragment"
         android:label="@string/tenkeycandidatelettersizefragment" />
+    <fragment
+        android:id="@+id/tenKeyPopupStyleSettingFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.popup_style.TenKeyPopupStyleSettingFragment"
+        android:label="TenKey ポップアップ表示" />
+    <fragment
+        android:id="@+id/qwertyPopupStyleSettingFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.popup_style.QwertyPopupStyleSettingFragment"
+        android:label="QWERTY ポップアップ表示" />
+    <fragment
+        android:id="@+id/flickKeyboardPopupStyleListFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.popup_style.FlickKeyboardPopupStyleListFragment"
+        android:label="FlickKeyboardView ポップアップ表示">
+        <action
+            android:id="@+id/action_flickKeyboardPopupStyleListFragment_to_flickKeyboardPopupStyleEditFragment"
+            app:destination="@id/flickKeyboardPopupStyleEditFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/flickKeyboardPopupStyleEditFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.popup_style.FlickKeyboardPopupStyleEditFragment"
+        android:label="Popup 表示編集">
+        <argument
+            android:name="target"
+            android:defaultValue="DIRECTIONAL"
+            app:argType="string" />
+    </fragment>
     <fragment
         android:id="@+id/circularFlickSettingsFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.sumire_custom_angle.CircularFlickSettingsFragment"

--- a/app/src/main/res/xml/pref_custom.xml
+++ b/app/src/main/res/xml/pref_custom.xml
@@ -9,6 +9,11 @@
             android:title="@string/custom_keyboard_size_preference_title"
             app:summary="@string/custom_keyboard_size_preference_summary" />
 
+        <Preference
+            android:key="flick_keyboard_popup_view_style_preference"
+            android:title="ポップアップ表示"
+            android:summary="FlickKeyboardView の各 popup のサイズと文字サイズを設定します" />
+
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="custom_keyboard_two_words_preference"

--- a/app/src/main/res/xml/pref_kana.xml
+++ b/app/src/main/res/xml/pref_kana.xml
@@ -7,6 +7,10 @@
             android:key="kana_keyboard_letter_size_preference"
             android:title="@string/kana_keyboard_letter_size_preference_titile"
             app:summary="@string/kana_keyboard_letter_size_preference_summary" />
+        <Preference
+            android:key="tenkey_popup_view_style_preference"
+            android:title="ポップアップ表示"
+            android:summary="TenKey のフリック時・長押し時のポップアップサイズと文字サイズを設定します" />
         <SwitchPreferenceCompat
             android:defaultValue="true"
             android:key="tenkey_show_switch_ime_button_preference"

--- a/app/src/main/res/xml/pref_qwerty.xml
+++ b/app/src/main/res/xml/pref_qwerty.xml
@@ -9,6 +9,11 @@
             android:title="キーのサイズ"
             app:summary="キー、文字、特殊キーのアイコンサイズを変更します" />
 
+        <Preference
+            android:key="qwerty_popup_view_style_preference"
+            android:title="ポップアップ表示"
+            android:summary="QWERTY のキー preview と長押し popup のサイズと文字サイズを設定します" />
+
         <SwitchPreferenceCompat
             android:defaultValue="false"
             android:key="switch_qwerty_keyboard_password_preference"

--- a/app/src/main/res/xml/pref_sumire.xml
+++ b/app/src/main/res/xml/pref_sumire.xml
@@ -12,6 +12,11 @@
             android:title="@string/sumire_keyboard_size_preference_title"
             app:summary="@string/sumire_keyboard_size_preference_summary" />
 
+        <Preference
+            android:key="flick_keyboard_popup_view_style_preference"
+            android:title="ポップアップ表示"
+            android:summary="FlickKeyboardView の各 popup のサイズと文字サイズを設定します" />
+
         <ListPreference
             android:defaultValue="toggle"
             android:dialogTitle="@string/sumire_input_method_dialog_title"

--- a/core/src/main/java/com/kazumaproject/core/data/popup/PopupViewStyle.kt
+++ b/core/src/main/java/com/kazumaproject/core/data/popup/PopupViewStyle.kt
@@ -1,0 +1,18 @@
+package com.kazumaproject.core.data.popup
+
+data class PopupViewStyle(
+    val sizeScalePercent: Int,
+    val textSizeSp: Float
+)
+
+data class QwertyPopupViewStyleSet(
+    val keyPreview: PopupViewStyle,
+    val variation: PopupViewStyle
+)
+
+data class FlickPopupViewStyleSet(
+    val directional: PopupViewStyle,
+    val cross: PopupViewStyle,
+    val standard: PopupViewStyle,
+    val tfbi: PopupViewStyle
+)

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CrossFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CrossFlickInputController.kt
@@ -12,6 +12,7 @@ import android.view.WindowManager
 import android.widget.Button
 import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.FlickAction
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.FlickPopupColorTheme
@@ -88,6 +89,8 @@ class CrossFlickInputController(
     private var longPressTimeout: Long = ViewConfiguration.getLongPressTimeout().toLong()
 
     private var popupColorTheme: FlickPopupColorTheme? = null
+    private var directionalPopupStyle = PopupViewStyle(100, 28f)
+    private var crossPopupStyle = PopupViewStyle(100, 18f)
     private val displayActionsByClass by lazy {
         KeyActionMapper.getDisplayActions(context).associateBy { it.action::class }
     }
@@ -95,6 +98,22 @@ class CrossFlickInputController(
     // 色設定。FlickPopupColorTheme をまとめて受け取り、全ポップアップに適用する。
     fun setPopupColors(theme: FlickPopupColorTheme) {
         popupColorTheme = theme
+    }
+
+    fun applyPopupViewStyleSet(
+        directional: PopupViewStyle,
+        cross: PopupViewStyle
+    ) {
+        directionalPopupStyle = PopupViewStyle(
+            sizeScalePercent = directional.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = directional.textSizeSp.coerceIn(8f, 48f)
+        )
+        crossPopupStyle = PopupViewStyle(
+            sizeScalePercent = cross.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = cross.textSizeSp.coerceIn(8f, 48f)
+        )
+        actionPopupViews.values.forEach { it.applyPopupViewStyle(crossPopupStyle) }
+        (gridPopup.contentView as? CrossFlickPopupView)?.applyPopupViewStyle(crossPopupStyle)
     }
 
     // 長押し判定までの待機時間を変更する。FlickKeyboardView から端末設定に合わせて呼ばれる。
@@ -414,12 +433,23 @@ class CrossFlickInputController(
         if (!isAnchorReady(anchor, windowAnchor)) return
 
         val popupView = CrossFlickPopupView(context).apply {
-            setCells(mapOf(direction to flickAction), anchor.width, anchor.height)
+            applyPopupViewStyle(crossPopupStyle)
+            val scale = crossPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
+            setCells(
+                mapOf(direction to flickAction),
+                (anchor.width * scale).toInt().coerceAtLeast(1),
+                (anchor.height * scale).toInt().coerceAtLeast(1)
+            )
             popupColorTheme?.let { setColors(it) }
             if (highlighted) highlightDirection(direction)
         }
 
-        val popupWindow = PopupWindow(popupView, anchor.width, anchor.height, false).apply {
+        val popupWindow = PopupWindow(
+            popupView,
+            (anchor.width * (crossPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f)).toInt().coerceAtLeast(1),
+            (anchor.height * (crossPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f)).toInt().coerceAtLeast(1),
+            false
+        ).apply {
             isClippingEnabled = false
             elevation = 8f
             animationStyle = 0
@@ -514,9 +544,11 @@ class CrossFlickInputController(
 
             val popupView = DirectionalKeyPopupView(context).apply {
                 this.text = text
+                applyPopupViewStyle(directionalPopupStyle)
                 popupColorTheme?.let { setColors(it) }
                 setFlickDirection(direction)
             }
+            val scale = directionalPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
 
             val popupHeight = when (direction) {
                 FlickDirection.UP, FlickDirection.DOWN -> {
@@ -524,7 +556,7 @@ class CrossFlickInputController(
                 }
 
                 else -> currentAnchor.height
-            }
+            }.let { (it * scale).toInt().coerceAtLeast(1) }
 
             val popupWidth = when (direction) {
                 FlickDirection.UP, FlickDirection.DOWN -> {
@@ -535,7 +567,7 @@ class CrossFlickInputController(
                 else -> {
                     currentAnchor.width + (currentAnchor.width / 2 - currentAnchor.width / 4)
                 }
-            }
+            }.let { (it * scale).toInt().coerceAtLeast(1) }
 
             directionalPopupMap[direction] = PopupWindow(
                 popupView,
@@ -634,12 +666,18 @@ class CrossFlickInputController(
         }
 
         val popupView = gridPopup.contentView as CrossFlickPopupView
+        popupView.applyPopupViewStyle(crossPopupStyle)
         popupColorTheme?.let { popupView.setColors(it) }
+        val scale = crossPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
 
         val actionMap = getLongPressDisplayMap().mapValues { (_, text) ->
             FlickAction.Input(text)
         }
-        popupView.setCells(actionMap, currentAnchor.width, currentAnchor.height)
+        popupView.setCells(
+            actionMap,
+            (currentAnchor.width * scale).toInt().coerceAtLeast(1),
+            (currentAnchor.height * scale).toInt().coerceAtLeast(1)
+        )
         popupView.highlightDirection(currentDirection)
 
         val location = getLocationRelativeToWindowAnchor(currentAnchor, windowAnchor)

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/StandardFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/StandardFlickInputController.kt
@@ -9,6 +9,7 @@ import android.view.View
 import android.view.WindowManager
 import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.FlickPopupColorTheme
 import com.kazumaproject.custom_keyboard.layout.SegmentedBackgroundDrawable
@@ -38,6 +39,7 @@ class StandardFlickInputController(context: Context) {
     private var popupBackgroundColor: Int = Color.WHITE
     private var popupTextColor: Int = Color.BLACK
     private var popupStrokeColor: Int = Color.LTGRAY
+    private var popupStyle = PopupViewStyle(100, 19f)
 
     init {
         popupWindow = PopupWindow(
@@ -59,6 +61,14 @@ class StandardFlickInputController(context: Context) {
         this.popupBackgroundColor = theme.segmentHighlightGradientStartColor
         this.popupTextColor = theme.textColor
         this.popupStrokeColor = theme.separatorColor
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        popupStyle = PopupViewStyle(
+            sizeScalePercent = style.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        )
+        popupView.applyPopupViewStyle(popupStyle)
     }
 
     fun setPopupWindowAnchorProvider(provider: (() -> View?)?) {
@@ -137,6 +147,7 @@ class StandardFlickInputController(context: Context) {
         }
 
         popupView.setColors(popupBackgroundColor, popupTextColor, popupStrokeColor)
+        popupView.applyPopupViewStyle(popupStyle)
 
         if (direction == FlickDirection.TAP) {
             popupView.updateMultiCharText(characterMap)

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
@@ -9,6 +9,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.KeyMode
 import com.kazumaproject.custom_keyboard.data.TfbiFlickNode
 import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
@@ -78,6 +79,7 @@ class TfbiHierarchicalFlickController(
     private var popupView: TfbiFlickPopupView? = null
     private var popupWindow: PopupWindow? = null
     private lateinit var gestureDetector: GestureDetector
+    private var popupStyle = PopupViewStyle(100, 20f)
 
     private var popupWindowAnchorProvider: (() -> View?)? = null
 
@@ -93,6 +95,14 @@ class TfbiHierarchicalFlickController(
         this.popupBackgroundColor = backgroundColor
         this.popupHighlightedColor = highlightedColor
         this.popupTextColor = textColor
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        popupStyle = PopupViewStyle(
+            sizeScalePercent = style.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        )
+        popupView?.applyPopupViewStyle(popupStyle)
     }
 
     fun setPopupWindowAnchorProvider(provider: (() -> View?)?) {
@@ -472,12 +482,14 @@ class TfbiHierarchicalFlickController(
             if (popupBackgroundColor != null && popupHighlightedColor != null && popupTextColor != null) {
                 setColors(popupBackgroundColor!!, popupHighlightedColor!!, popupTextColor!!)
             }
+            applyPopupViewStyle(popupStyle)
             setCharacters(tapCharacter, petalChars)
             highlightDirection(TfbiFlickDirection.TAP)
         }
 
-        val popupWidth = anchorView.width * 3
-        val popupHeight = anchorView.height * 3
+        val scale = popupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
+        val popupWidth = (anchorView.width * 3 * scale).toInt().coerceAtLeast(1)
+        val popupHeight = (anchorView.height * 3 * scale).toInt().coerceAtLeast(1)
         popupWindow = PopupWindow(popupView, popupWidth, popupHeight, false).apply {
             isTouchable = false
             isFocusable = false
@@ -487,8 +499,8 @@ class TfbiHierarchicalFlickController(
         val windowAnchor = popupWindowAnchorProvider?.invoke() ?: anchorView
         if (!isAnchorReady(anchorView, windowAnchor)) return
         val location = getLocationRelativeToWindowAnchor(anchorView, windowAnchor)
-        val offsetX = location[0] - anchorView.width
-        val offsetY = location[1] - anchorView.height
+        val offsetX = location[0] + anchorView.width / 2 - popupWidth / 2
+        val offsetY = location[1] + anchorView.height / 2 - popupHeight / 2
         runCatching {
             popupWindow?.showAtLocation(windowAnchor, Gravity.NO_GRAVITY, offsetX, offsetY)
         }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiInputController.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.controller.getLocationRelativeToWindowAnchor
 import kotlin.math.abs
 import kotlin.math.atan2
@@ -74,12 +75,21 @@ class TfbiInputController(
     private var popupBackgroundColor: Int? = null
     private var popupHighlightedColor: Int? = null
     private var popupTextColor: Int? = null
+    private var popupStyle = PopupViewStyle(100, 20f)
 
     // ▼▼▼ 追加: 色を設定するメソッド ▼▼▼
     fun setPopupColors(backgroundColor: Int, highlightedColor: Int, textColor: Int) {
         this.popupBackgroundColor = backgroundColor
         this.popupHighlightedColor = highlightedColor
         this.popupTextColor = textColor
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        popupStyle = PopupViewStyle(
+            sizeScalePercent = style.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        )
+        popupView?.applyPopupViewStyle(popupStyle)
     }
 
     fun setLongPressTimeout(timeoutMillis: Long) {
@@ -259,12 +269,14 @@ class TfbiInputController(
             if (popupBackgroundColor != null && popupHighlightedColor != null && popupTextColor != null) {
                 setColors(popupBackgroundColor!!, popupHighlightedColor!!, popupTextColor!!)
             }
+            applyPopupViewStyle(popupStyle)
 
             setCharacters(tapCharacter, petalChars)
             highlightDirection(TfbiFlickDirection.TAP)
         }
-        val popupWidth = anchorView.width * 3
-        val popupHeight = anchorView.height * 3
+        val scale = popupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
+        val popupWidth = (anchorView.width * 3 * scale).toInt().coerceAtLeast(1)
+        val popupHeight = (anchorView.height * 3 * scale).toInt().coerceAtLeast(1)
         popupWindow = PopupWindow(popupView, popupWidth, popupHeight, false).apply {
             isTouchable = false
             isFocusable = false
@@ -274,8 +286,8 @@ class TfbiInputController(
         val windowAnchor = popupWindowAnchorProvider?.invoke() ?: anchorView
         if (!isAnchorReady(anchorView, windowAnchor)) return
         val location = getLocationRelativeToWindowAnchor(anchorView, windowAnchor)
-        val offsetX = location[0] - anchorView.width
-        val offsetY = location[1] - anchorView.height
+        val offsetX = location[0] + anchorView.width / 2 - popupWidth / 2
+        val offsetY = location[1] + anchorView.height / 2 - popupHeight / 2
         runCatching {
             popupWindow?.showAtLocation(windowAnchor, Gravity.NO_GRAVITY, offsetX, offsetY)
         }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiStickyFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiStickyFlickController.kt
@@ -9,6 +9,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 import com.kazumaproject.custom_keyboard.view.TfbiFlickPopupView
 import kotlin.math.abs
@@ -49,6 +50,7 @@ class TfbiStickyFlickController(
 
     private var popupView: TfbiFlickPopupView? = null
     private var popupWindow: PopupWindow? = null
+    private var popupStyle = PopupViewStyle(100, 20f)
 
     private var popupWindowAnchorProvider: (() -> View?)? = null
 
@@ -80,6 +82,14 @@ class TfbiStickyFlickController(
 
     fun setPopupWindowAnchorProvider(provider: (() -> View?)?) {
         popupWindowAnchorProvider = provider
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        popupStyle = PopupViewStyle(
+            sizeScalePercent = style.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        )
+        popupView?.applyPopupViewStyle(popupStyle)
     }
 
     fun cancel() {
@@ -250,11 +260,13 @@ class TfbiStickyFlickController(
         }
 
         popupView = TfbiFlickPopupView(context).apply {
+            applyPopupViewStyle(popupStyle)
             setCharacters(tapCharacter, petalChars)
             highlightDirection(TfbiFlickDirection.TAP)
         }
-        val popupWidth = anchorView.width * 3
-        val popupHeight = anchorView.height * 3
+        val scale = popupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
+        val popupWidth = (anchorView.width * 3 * scale).toInt().coerceAtLeast(1)
+        val popupHeight = (anchorView.height * 3 * scale).toInt().coerceAtLeast(1)
         popupWindow = PopupWindow(popupView, popupWidth, popupHeight, false).apply {
             isTouchable = false
             isFocusable = false
@@ -264,8 +276,8 @@ class TfbiStickyFlickController(
         val windowAnchor = popupWindowAnchorProvider?.invoke() ?: anchorView
         if (!isAnchorReady(anchorView, windowAnchor)) return
         val location = getLocationRelativeToWindowAnchor(anchorView, windowAnchor)
-        val offsetX = location[0] - anchorView.width
-        val offsetY = location[1] - anchorView.height
+        val offsetX = location[0] + anchorView.width / 2 - popupWidth / 2
+        val offsetY = location[1] + anchorView.height / 2 - popupHeight / 2
         runCatching {
             popupWindow?.showAtLocation(windowAnchor, Gravity.NO_GRAVITY, offsetX, offsetY)
         }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/CrossFlickPopupView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/CrossFlickPopupView.kt
@@ -13,6 +13,7 @@ import android.widget.ImageView
 import android.widget.TextView
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.FlickAction
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.FlickPopupColorTheme
@@ -117,6 +118,10 @@ class CrossFlickPopupView(context: Context) : FrameLayout(context) {
             backgroundShape.cornerRadius = 24f
             backgroundShape.setColor(color)
         }
+
+        fun applyTextSize(textSizeSp: Float) {
+            textView.setTextSize(TypedValue.COMPLEX_UNIT_SP, textSizeSp.coerceIn(8f, 48f))
+        }
     }
 
     private val gridLayout = GridLayout(context).apply {
@@ -128,6 +133,7 @@ class CrossFlickPopupView(context: Context) : FrameLayout(context) {
     private val cells = mutableMapOf<FlickDirection, CellView>()
     private var colorTheme: FlickPopupColorTheme? = null
     private var highlightedDirection: FlickDirection? = null
+    private var popupTextSizeSp: Float = 18f
 
     init {
         addView(gridLayout, LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT))
@@ -138,6 +144,12 @@ class CrossFlickPopupView(context: Context) : FrameLayout(context) {
         cells.forEach { (dir, cell) ->
             cell.applyColors(theme, dir == highlightedDirection)
         }
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        popupTextSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        updateCellTextSizes()
+        invalidate()
     }
 
     fun setCells(map: Map<FlickDirection, FlickAction>, keyWidth: Int, keyHeight: Int) {
@@ -159,6 +171,7 @@ class CrossFlickPopupView(context: Context) : FrameLayout(context) {
 
             val cell = CellView(context).apply {
                 setContent(action)
+                applyTextSize(popupTextSizeSp)
                 val theme = colorTheme
                 if (theme != null) {
                     applyColors(theme, direction == highlightedDirection)
@@ -199,6 +212,7 @@ class CrossFlickPopupView(context: Context) : FrameLayout(context) {
             if (action != null) {
                 val cell = CellView(context).apply {
                     setContent(action)
+                    applyTextSize(popupTextSizeSp)
                     val theme = colorTheme
                     if (theme != null) {
                         applyColors(theme, direction == highlightedDirection)
@@ -227,5 +241,9 @@ class CrossFlickPopupView(context: Context) : FrameLayout(context) {
                 cell.applyFallbackColors(context, dir == direction)
             }
         }
+    }
+
+    private fun updateCellTextSizes() {
+        cells.values.forEach { it.applyTextSize(popupTextSizeSp) }
     }
 }

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/DirectionalKeyPopupView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/DirectionalKeyPopupView.kt
@@ -11,6 +11,7 @@ import android.util.TypedValue
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.graphics.toColorInt
 import androidx.core.graphics.withRotation
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.FlickPopupColorTheme
 
@@ -71,6 +72,10 @@ class DirectionalKeyPopupView(context: Context) : AppCompatTextView(context) {
             else -> 0f
         }
         invalidate()
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, style.textSizeSp.coerceIn(8f, 48f))
     }
 
     /**

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -27,6 +27,8 @@ import androidx.appcompat.widget.AppCompatImageButton
 import androidx.core.content.ContextCompat
 import androidx.core.graphics.ColorUtils
 import com.google.android.material.R
+import com.kazumaproject.core.data.popup.FlickPopupViewStyleSet
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.core.domain.extensions.isDarkThemeOn
 import com.kazumaproject.core.domain.extensions.setBorder
 import com.kazumaproject.core.domain.extensions.setDrawableAlpha
@@ -131,6 +133,12 @@ class FlickKeyboardView @JvmOverloads constructor(
     private var circularFlickDirectionCount: Int = 4
     private var borderWidth: Int = 1
     private var flickGuideEnabled: Boolean = false
+    private var popupViewStyleSet = FlickPopupViewStyleSet(
+        directional = PopupViewStyle(100, 28f),
+        cross = PopupViewStyle(100, 18f),
+        standard = PopupViewStyle(100, 19f),
+        tfbi = PopupViewStyle(100, 20f)
+    )
 
     init {
         setPadding(0, 0, 0, 0)
@@ -150,6 +158,29 @@ class FlickKeyboardView @JvmOverloads constructor(
         tfbiControllers.forEach { it.setPopupWindowAnchorProvider(provider) }
         stickyTfbiControllers.forEach { it.setPopupWindowAnchorProvider(provider) }
         hierarchicalTfbiControllers.forEach { it.setPopupWindowAnchorProvider(provider) }
+    }
+
+    fun applyPopupViewStyleSet(styleSet: FlickPopupViewStyleSet) {
+        popupViewStyleSet = FlickPopupViewStyleSet(
+            directional = clampPopupStyle(styleSet.directional),
+            cross = clampPopupStyle(styleSet.cross),
+            standard = clampPopupStyle(styleSet.standard),
+            tfbi = clampPopupStyle(styleSet.tfbi)
+        )
+        crossFlickControllers.forEach {
+            it.applyPopupViewStyleSet(popupViewStyleSet.directional, popupViewStyleSet.cross)
+        }
+        standardFlickControllers.forEach { it.applyPopupViewStyle(popupViewStyleSet.standard) }
+        tfbiControllers.forEach { it.applyPopupViewStyle(popupViewStyleSet.tfbi) }
+        stickyTfbiControllers.forEach { it.applyPopupViewStyle(popupViewStyleSet.tfbi) }
+        hierarchicalTfbiControllers.forEach { it.applyPopupViewStyle(popupViewStyleSet.tfbi) }
+    }
+
+    private fun clampPopupStyle(style: PopupViewStyle): PopupViewStyle {
+        return PopupViewStyle(
+            sizeScalePercent = style.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        )
     }
 
     fun setFlickSensitivityValue(sensitivity: Int) {
@@ -1083,6 +1114,10 @@ class FlickKeyboardView @JvmOverloads constructor(
                     val controller = CrossFlickInputController(context).apply {
                         setLongPressTimeout(longPressTimeout)
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        applyPopupViewStyleSet(
+                            popupViewStyleSet.directional,
+                            popupViewStyleSet.cross
+                        )
                         this.listener = object : CrossFlickInputController.CrossFlickListener {
                             override fun onPress(action: KeyAction) {
                                 this@FlickKeyboardView.listener?.onPress(action)
@@ -1227,6 +1262,7 @@ class FlickKeyboardView @JvmOverloads constructor(
 
                     val controller = StandardFlickInputController(context).apply {
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        applyPopupViewStyle(popupViewStyleSet.standard)
                         this.listener =
                             object : StandardFlickInputController.StandardFlickListener {
                                 override fun onPress(character: String) {
@@ -1327,6 +1363,10 @@ class FlickKeyboardView @JvmOverloads constructor(
                     val controller = CrossFlickInputController(context, flickSensitivity).apply {
                         setLongPressTimeout(longPressTimeout)
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        applyPopupViewStyleSet(
+                            popupViewStyleSet.directional,
+                            popupViewStyleSet.cross
+                        )
                         val isDarkTheme = context.isDarkThemeOn()
                         val secondaryColor =
                             context.getColorFromAttr(R.attr.colorSecondaryContainer)
@@ -1496,6 +1536,7 @@ class FlickKeyboardView @JvmOverloads constructor(
                     ).apply {
                         setLongPressTimeout(longPressTimeout)
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        applyPopupViewStyle(popupViewStyleSet.tfbi)
                         this.listener = object : TfbiInputController.TfbiListener {
                             override fun onPress(
                                 first: TfbiFlickDirection,
@@ -1571,6 +1612,7 @@ class FlickKeyboardView @JvmOverloads constructor(
                         flickSensitivity = flickSensitivity.toFloat()
                     ).apply {
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        applyPopupViewStyle(popupViewStyleSet.tfbi)
                         this.listener = object : TfbiStickyFlickController.TfbiListener {
                             override fun onPress(
                                 first: TfbiFlickDirection,
@@ -1624,6 +1666,7 @@ class FlickKeyboardView @JvmOverloads constructor(
                         flickSensitivity = flickSensitivity.toFloat()
                     ).apply {
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        applyPopupViewStyle(popupViewStyleSet.tfbi)
                         this.listener = object : TfbiHierarchicalFlickController.TfbiListener {
                             override fun onPress(character: String) {
                                 notifyTextPress(character)

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/StandardFlickPopupView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/StandardFlickPopupView.kt
@@ -18,6 +18,7 @@ import android.view.Gravity
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.graphics.toColorInt
 import androidx.core.text.inSpans
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.FlickPopupColorTheme
 import kotlin.math.roundToInt
@@ -28,7 +29,8 @@ import kotlin.math.roundToInt
  */
 class StandardFlickPopupView(context: Context) : AppCompatTextView(context) {
 
-    val viewSize = dpToPx(72) // ポップアップの直径
+    var viewSize = dpToPx(72) // ポップアップの直径
+        private set
     private val backgroundDrawable: GradientDrawable = createBackground()
 
     // 追加: テーマ保持（setPopupColors のため）
@@ -41,6 +43,7 @@ class StandardFlickPopupView(context: Context) : AppCompatTextView(context) {
     private var lastBackgroundColor: Int = "#FFFFFF".toColorInt()
     private var lastTextColor: Int = Color.BLACK
     private var lastStrokeColor: Int = Color.LTGRAY
+    private var popupTextSizeSp: Float = 19f
 
     private class YOffsetSpan(private val yOffset: Int) : ReplacementSpan() {
         override fun getSize(
@@ -130,8 +133,8 @@ class StandardFlickPopupView(context: Context) : AppCompatTextView(context) {
         val right = characters[FlickDirection.UP_RIGHT_FAR] ?: ""
         val down = characters[FlickDirection.DOWN] ?: ""
 
-        val tapSize = 19f
-        val sideSize = 11f
+        val tapSize = popupTextSizeSp.coerceIn(8f, 48f)
+        val sideSize = tapSize * 0.58f
         val verticalOffset = spToPx(-1.5f)
         val transparent = ForegroundColorSpan(Color.TRANSPARENT)
 
@@ -195,30 +198,42 @@ class StandardFlickPopupView(context: Context) : AppCompatTextView(context) {
 
     private fun createSpannableText(text: String): SpannableString {
         val spannable = SpannableString(text)
+        val primarySize = popupTextSizeSp.coerceIn(8f, 48f)
+        val secondarySize = primarySize * 0.54f
         if (text.contains("\n")) {
             val parts = text.split("\n", limit = 2)
             val primaryText = parts[0]
             spannable.setSpan(
-                AbsoluteSizeSpan(spToPx(26f)),
+                AbsoluteSizeSpan(spToPx(primarySize)),
                 0,
                 primaryText.length,
                 Spannable.SPAN_INCLUSIVE_INCLUSIVE
             )
             spannable.setSpan(
-                AbsoluteSizeSpan(spToPx(14f)),
+                AbsoluteSizeSpan(spToPx(secondarySize)),
                 primaryText.length,
                 text.length,
                 Spannable.SPAN_INCLUSIVE_INCLUSIVE
             )
         } else {
             spannable.setSpan(
-                AbsoluteSizeSpan(spToPx(26f)),
+                AbsoluteSizeSpan(spToPx(primarySize)),
                 0,
                 text.length,
                 Spannable.SPAN_INCLUSIVE_INCLUSIVE
             )
         }
         return spannable
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        val scale = style.sizeScalePercent.coerceIn(50, 200) / 100f
+        viewSize = (dpToPx(72) * scale).toInt().coerceAtLeast(1)
+        popupTextSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        width = viewSize
+        height = viewSize
+        requestLayout()
+        invalidate()
     }
 
     private fun createBackground(): GradientDrawable {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/TfbiFlickPopupView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/TfbiFlickPopupView.kt
@@ -7,6 +7,7 @@ import android.graphics.RectF
 import android.util.TypedValue
 import android.view.View
 import androidx.core.content.ContextCompat
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.core.domain.extensions.getThemeColor
 import com.kazumaproject.core.domain.extensions.isDarkThemeOn
 
@@ -81,6 +82,11 @@ class TfbiFlickPopupView(context: Context) : View(context) {
             this.highlightedDirection = direction
             invalidate()
         }
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        textPaint.textSize = spToPx(style.textSizeSp.coerceIn(8f, 48f))
+        invalidate()
     }
 
     // ===== Viewのライフサイクル =====

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -18,6 +18,7 @@ import android.text.style.StyleSpan
 import android.util.AttributeSet
 import android.util.Log
 import android.util.SparseArray
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -40,6 +41,8 @@ import androidx.core.widget.ImageViewCompat
 import com.google.android.material.color.DynamicColors
 import com.google.android.material.textview.MaterialTextView
 import com.kazumaproject.core.data.qwerty.CapsLockState
+import com.kazumaproject.core.data.popup.PopupViewStyle
+import com.kazumaproject.core.data.popup.QwertyPopupViewStyleSet
 import com.kazumaproject.core.data.qwerty.QWERTYKeys
 import com.kazumaproject.core.data.qwerty.VariationInfo
 import com.kazumaproject.core.domain.extensions.dpToPx
@@ -138,6 +141,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     private var variationPopup: PopupWindow? = null
     private var variationPopupView: VariationsPopupView? = null
     private var longPressedPointerId: Int? = null
+    private var keyPreviewPopupStyle = PopupViewStyle(100, 28f)
+    private var variationPopupStyle = PopupViewStyle(100, 28f)
 
     // ★ ポインターをロックするための変数を追加
     private var lockedPointerId: Int? = null
@@ -1793,6 +1798,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         val popupView = LayoutInflater.from(context).inflate(layoutRes, this, false)
         val tv = popupView.findViewById<TextView>(R.id.preview_text)
         val iv = popupView.findViewById<ImageView>(R.id.preview_bubble_bg)
+        tv.setTextSize(
+            TypedValue.COMPLEX_UNIT_SP,
+            keyPreviewPopupStyle.textSizeSp.coerceIn(8f, 48f)
+        )
         val isLandMode =
             (resources.configuration.orientation == Configuration.ORIENTATION_LANDSCAPE)
 
@@ -1841,14 +1850,18 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             else -> tv.text = ""
         }
 
-        val popup = PopupWindow(popupView, view.width * 2, view.height * 2 + 64, false).apply {
+        val scale = keyPreviewPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
+        val popupWidth = (view.width * 2 * scale).toInt().coerceAtLeast(1)
+        val popupHeight = ((view.height * 2 + 64) * scale).toInt().coerceAtLeast(1)
+
+        val popup = PopupWindow(popupView, popupWidth, popupHeight, false).apply {
             isTouchable = false
             isFocusable = false
             elevation = 6f
         }
 
-        val xOffset = -(view.width / 2)
-        val yOffset = -(view.height * 2 + 64)
+        val xOffset = -((popupWidth - view.width) / 2)
+        val yOffset = -popupHeight
         popup.showAsDropDown(view, xOffset, yOffset)
         keyPreviewPopup = popup
     }
@@ -1973,7 +1986,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     private fun showVariationPopup(anchorView: View, variations: List<Char>) {
         variationPopup?.dismiss()
         val context = this.context
-        variationPopupView = VariationsPopupView(context).apply { setChars(variations) }
+        variationPopupView = VariationsPopupView(context).apply {
+            applyPopupViewStyle(variationPopupStyle)
+            setChars(variations)
+        }
         when (themeMode) {
             "custom" -> {
                 variationPopupView?.setNeumorphicColors(
@@ -1988,11 +2004,12 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             }
         }
         val maxColumns = 3
-        val itemSize = 100
+        val scale = variationPopupStyle.sizeScalePercent.coerceIn(50, 200) / 100f
+        val itemSize = (100 * scale).toInt().coerceAtLeast(1)
         val cols = if (variations.size < maxColumns) variations.size else maxColumns
         val rows = kotlin.math.ceil(variations.size.toFloat() / maxColumns).toInt()
         val popupWidth = itemSize * cols
-        val popupHeight = 150 * rows
+        val popupHeight = ((150 * rows) * scale).toInt().coerceAtLeast(1)
         val popup = PopupWindow(variationPopupView, popupWidth, popupHeight, false).apply {
             isTouchable = false
         }
@@ -2004,6 +2021,18 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         val yOffset = -anchorView.height - popupHeight
         popup.showAsDropDown(anchorView, xOffset, yOffset)
         this.variationPopup = popup
+    }
+
+    fun applyPopupViewStyleSet(styleSet: QwertyPopupViewStyleSet) {
+        keyPreviewPopupStyle = PopupViewStyle(
+            sizeScalePercent = styleSet.keyPreview.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = styleSet.keyPreview.textSizeSp.coerceIn(8f, 48f)
+        )
+        variationPopupStyle = PopupViewStyle(
+            sizeScalePercent = styleSet.variation.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = styleSet.variation.textSizeSp.coerceIn(8f, 48f)
+        )
+        variationPopupView?.applyPopupViewStyle(variationPopupStyle)
     }
 
     private fun cancelLongPressForPointer(pointerId: Int) {

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/VariationsPopupView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/VariationsPopupView.kt
@@ -6,9 +6,11 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Path
 import android.graphics.RectF
+import android.util.TypedValue
 import android.view.View
 import androidx.annotation.ColorInt
 import androidx.core.content.ContextCompat
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import kotlin.math.ceil
 import kotlin.math.min
 
@@ -67,6 +69,17 @@ class VariationsPopupView(context: Context) : View(context) {
         strokeWidth = 4f
     }
     private val itemCornerRadius = 15f
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        val textSizePx = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_SP,
+            style.textSizeSp.coerceIn(8f, 48f),
+            resources.displayMetrics
+        )
+        flatTextPaint.textSize = textSizePx
+        neuTextPaint.textSize = textSizePx
+        invalidate()
+    }
 
     // ニューモーフィズム用メソッド
     fun setNeumorphicColors(

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -11,6 +11,7 @@ import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import android.util.AttributeSet
 import android.util.Log
+import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
@@ -40,6 +41,7 @@ import com.kazumaproject.core.domain.state.GestureType
 import com.kazumaproject.core.domain.state.InputMode
 import com.kazumaproject.core.domain.state.InputMode.ModeEnglish.next
 import com.kazumaproject.core.domain.state.PressedKey
+import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.core.ui.effect.Blur
 import com.kazumaproject.core.ui.input_mode_witch.InputModeSwitch
 import com.kazumaproject.core.ui.key_window.KeyWindowLayout
@@ -159,6 +161,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
     private lateinit var popTextCenter: MaterialTextView
 
     private var isFlickGuideEnabled: Boolean = false
+    private var popupViewStyle = PopupViewStyle(100, 28f)
 
     private val cachedArrowRightDrawable: Drawable? by lazy {
         ContextCompat.getDrawable(
@@ -555,6 +558,32 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
             )
             bubbleViewCenter = centerBinding.bubbleLayout
             popTextCenter = centerBinding.popupText
+        }
+        applyPopupTextSize()
+    }
+
+    fun applyPopupViewStyle(style: PopupViewStyle) {
+        popupViewStyle = PopupViewStyle(
+            sizeScalePercent = style.sizeScalePercent.coerceIn(50, 200),
+            textSizeSp = style.textSizeSp.coerceIn(8f, 48f)
+        )
+        applyPopupTextSize()
+    }
+
+    private fun applyPopupTextSize() {
+        if (!::popTextActive.isInitialized) return
+        listOf(
+            popTextActive,
+            popTextLeft,
+            popTextTop,
+            popTextRight,
+            popTextBottom,
+            popTextCenter
+        ).forEach { textView ->
+            textView.setTextSize(
+                TypedValue.COMPLEX_UNIT_SP,
+                popupViewStyle.textSizeSp.coerceIn(8f, 48f)
+            )
         }
     }
 
@@ -1983,15 +2012,15 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         popTextActive.setTextTapNumber(it.id)
                     }
                 }
-                popupWindowTop.setPopUpWindowTop(context, bubbleViewTop, it)
-                popupWindowLeft.setPopUpWindowLeft(context, bubbleViewLeft, it)
+                popupWindowTop.setPopUpWindowTop(context, bubbleViewTop, it, popupViewStyle.sizeScalePercent)
+                popupWindowLeft.setPopUpWindowLeft(context, bubbleViewLeft, it, popupViewStyle.sizeScalePercent)
                 if (popTextBottom.text.isNotEmpty()) {
-                    popupWindowBottom.setPopUpWindowBottom(context, bubbleViewBottom, it)
+                    popupWindowBottom.setPopUpWindowBottom(context, bubbleViewBottom, it, popupViewStyle.sizeScalePercent)
                 }
                 if (popTextRight.text.isNotEmpty()) {
-                    popupWindowRight.setPopUpWindowRight(context, bubbleViewRight, it)
+                    popupWindowRight.setPopUpWindowRight(context, bubbleViewRight, it, popupViewStyle.sizeScalePercent)
                 }
-                popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it)
+                popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                 Blur.applyBlurEffect(this, 8f)
             }
 
@@ -2001,11 +2030,11 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                     popTextLeft.setTextFlickLeftNumber(it.id)
                     popTextBottom.setTextFlickBottomNumber(it.id)
                     popTextRight.setTextFlickRightNumber(it.id)
-                    popupWindowTop.setPopUpWindowTop(context, bubbleViewTop, it)
-                    popupWindowLeft.setPopUpWindowLeft(context, bubbleViewLeft, it)
-                    popupWindowBottom.setPopUpWindowBottom(context, bubbleViewBottom, it)
-                    popupWindowRight.setPopUpWindowRight(context, bubbleViewRight, it)
-                    popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it)
+                    popupWindowTop.setPopUpWindowTop(context, bubbleViewTop, it, popupViewStyle.sizeScalePercent)
+                    popupWindowLeft.setPopUpWindowLeft(context, bubbleViewLeft, it, popupViewStyle.sizeScalePercent)
+                    popupWindowBottom.setPopUpWindowBottom(context, bubbleViewBottom, it, popupViewStyle.sizeScalePercent)
+                    popupWindowRight.setPopUpWindowRight(context, bubbleViewRight, it, popupViewStyle.sizeScalePercent)
+                    popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                     Blur.applyBlurEffect(this, 8f)
                 }
             }
@@ -2048,7 +2077,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                 }
 
                 if (isLongPressed) {
-                    popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it)
+                    popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                 }
             }
             if (it is AppCompatImageButton && currentInputMode.value == InputMode.ModeNumber && it == binding.keySmallLetter) {
@@ -2058,7 +2087,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                 )
                 if (isLongPressed) popTextActive.setTextTapNumber(it.id)
                 if (isLongPressed) {
-                    popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it)
+                    popupWindowActive.setPopUpWindowCenter(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                 }
             }
         }
@@ -2092,10 +2121,10 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                             }
                         }
                         if (isLongPressed) {
-                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it)
-                            popupWindowActive.setPopUpWindowLeft(context, bubbleViewActive, it)
+                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent)
+                            popupWindowActive.setPopUpWindowLeft(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         } else {
-                            popupWindowActive.setPopUpWindowFlickLeft(context, bubbleViewActive, it)
+                            popupWindowActive.setPopUpWindowFlickLeft(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         }
                     }
 
@@ -2117,10 +2146,10 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                             }
                         }
                         if (isLongPressed) {
-                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it)
-                            popupWindowActive.setPopUpWindowTop(context, bubbleViewActive, it)
+                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent)
+                            popupWindowActive.setPopUpWindowTop(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         } else {
-                            popupWindowActive.setPopUpWindowFlickTop(context, bubbleViewActive, it)
+                            popupWindowActive.setPopUpWindowFlickTop(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         }
                     }
 
@@ -2143,15 +2172,15 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         }
                         if (isLongPressed) {
                             if (popTextActive.text.isNotEmpty()) {
-                                popupWindowActive.setPopUpWindowRight(context, bubbleViewActive, it)
+                                popupWindowActive.setPopUpWindowRight(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                                 popupWindowCenter.setPopUpWindowCenter(
-                                    context, bubbleViewCenter, it
+                                    context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent
                                 )
                             }
                         } else {
                             if (popTextActive.text.isNotEmpty()) {
                                 popupWindowActive.setPopUpWindowFlickRight(
-                                    context, bubbleViewActive, it
+                                    context, bubbleViewActive, it, popupViewStyle.sizeScalePercent
                                 )
                             }
                         }
@@ -2177,16 +2206,16 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         if (isLongPressed) {
                             if (popTextActive.text.isNotEmpty()) {
                                 popupWindowActive.setPopUpWindowBottom(
-                                    context, bubbleViewActive, it
+                                    context, bubbleViewActive, it, popupViewStyle.sizeScalePercent
                                 )
                                 popupWindowCenter.setPopUpWindowCenter(
-                                    context, bubbleViewCenter, it
+                                    context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent
                                 )
                             }
                         } else {
                             if (popTextActive.text.isNotEmpty()) {
                                 popupWindowActive.setPopUpWindowFlickBottom(
-                                    context, bubbleViewActive, it
+                                    context, bubbleViewActive, it, popupViewStyle.sizeScalePercent
                                 )
                             }
                         }
@@ -2203,10 +2232,10 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         popTextActive.setTextFlickLeftNumber(it.id)
                         if (isLongPressed) popTextCenter.setTextTapNumber(it.id)
                         if (isLongPressed) {
-                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it)
-                            popupWindowActive.setPopUpWindowLeft(context, bubbleViewActive, it)
+                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent)
+                            popupWindowActive.setPopUpWindowLeft(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         } else {
-                            popupWindowActive.setPopUpWindowFlickLeft(context, bubbleViewActive, it)
+                            popupWindowActive.setPopUpWindowFlickLeft(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         }
                     }
 
@@ -2214,10 +2243,10 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         popTextActive.setTextFlickTopNumber(it.id)
                         if (isLongPressed) popTextCenter.setTextTapNumber(it.id)
                         if (isLongPressed) {
-                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it)
-                            popupWindowActive.setPopUpWindowTop(context, bubbleViewActive, it)
+                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent)
+                            popupWindowActive.setPopUpWindowTop(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         } else {
-                            popupWindowActive.setPopUpWindowFlickTop(context, bubbleViewActive, it)
+                            popupWindowActive.setPopUpWindowFlickTop(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         }
                     }
 
@@ -2225,11 +2254,11 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         popTextActive.setTextFlickRightNumber(it.id)
                         if (isLongPressed) popTextCenter.setTextTapNumber(it.id)
                         if (isLongPressed) {
-                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it)
-                            popupWindowActive.setPopUpWindowRight(context, bubbleViewActive, it)
+                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent)
+                            popupWindowActive.setPopUpWindowRight(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         } else {
                             popupWindowActive.setPopUpWindowFlickRight(
-                                context, bubbleViewActive, it
+                                context, bubbleViewActive, it, popupViewStyle.sizeScalePercent
                             )
                         }
                     }
@@ -2238,11 +2267,11 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         popTextActive.setTextFlickBottomNumber(it.id)
                         if (isLongPressed) popTextCenter.setTextTapNumber(it.id)
                         if (isLongPressed) {
-                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it)
-                            popupWindowActive.setPopUpWindowBottom(context, bubbleViewActive, it)
+                            popupWindowCenter.setPopUpWindowCenter(context, bubbleViewCenter, it, popupViewStyle.sizeScalePercent)
+                            popupWindowActive.setPopUpWindowBottom(context, bubbleViewActive, it, popupViewStyle.sizeScalePercent)
                         } else {
                             popupWindowActive.setPopUpWindowFlickBottom(
-                                context, bubbleViewActive, it
+                                context, bubbleViewActive, it, popupViewStyle.sizeScalePercent
                             )
                         }
                     }

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/extensions/PopupWindowExtension.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/extensions/PopupWindowExtension.kt
@@ -11,13 +11,21 @@ import com.kazumaproject.core.ui.key_window.ArrowDirection
 import com.kazumaproject.core.ui.key_window.KeyWindowLayout
 import com.kazumaproject.tenkey.R
 
+private fun Int.scaledPopupSize(sizeScalePercent: Int): Int {
+    val scale = sizeScalePercent.coerceIn(50, 200) / 100f
+    return (this * scale).toInt().coerceAtLeast(1)
+}
+
 fun PopupWindow.setPopUpWindowFlickRight(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width + (anchorView.width) / 2 + 24
-    this.height = anchorView.height
+    val baseWidth = anchorView.width + (anchorView.width) / 2 + 24
+    val baseHeight = anchorView.height
+    this.width = baseWidth.scaledPopupSize(sizeScalePercent)
+    this.height = baseHeight.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.LEFT_CENTER) this.dismiss()
@@ -30,7 +38,7 @@ fun PopupWindow.setPopUpWindowFlickRight(
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                (anchorView.width - (anchorView.width) / 2) - 10,
+                anchorView.width - ((width - anchorView.width) / 2) - 10,
                 -(anchorView.height),
                 Gravity.CENTER
             )
@@ -39,7 +47,7 @@ fun PopupWindow.setPopUpWindowFlickRight(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                (anchorView.width - (anchorView.width) / 2) - 10,
+                anchorView.width - ((width - anchorView.width) / 2) - 10,
                 -(anchorView.height),
                 Gravity.CENTER
             )
@@ -48,7 +56,7 @@ fun PopupWindow.setPopUpWindowFlickRight(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                (anchorView.width - (anchorView.width) / 2) - 10,
+                anchorView.width - ((width - anchorView.width) / 2) - 10,
                 -(anchorView.height),
                 Gravity.CENTER
             )
@@ -61,10 +69,13 @@ fun PopupWindow.setPopUpWindowFlickRight(
 fun PopupWindow.setPopUpWindowFlickLeft(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width + (anchorView.width) / 2 + 24
-    this.height = anchorView.height
+    val baseWidth = anchorView.width + (anchorView.width) / 2 + 24
+    val baseHeight = anchorView.height
+    this.width = baseWidth.scaledPopupSize(sizeScalePercent)
+    this.height = baseHeight.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.RIGHT_CENTER) this.dismiss()
@@ -77,7 +88,7 @@ fun PopupWindow.setPopUpWindowFlickLeft(
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                -(anchorView.width + 14),
+                -width + (anchorView.width / 2) - 14,
                 -(anchorView.height),
                 Gravity.CENTER
             )
@@ -86,7 +97,7 @@ fun PopupWindow.setPopUpWindowFlickLeft(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                -(anchorView.width + 14),
+                -width + (anchorView.width / 2) - 14,
                 -(anchorView.height),
                 Gravity.CENTER
             )
@@ -95,7 +106,7 @@ fun PopupWindow.setPopUpWindowFlickLeft(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                -(anchorView.width + 14),
+                -width + (anchorView.width / 2) - 14,
                 -(anchorView.height),
                 Gravity.CENTER
             )
@@ -111,10 +122,13 @@ fun PopupWindow.setPopUpWindowFlickLeft(
 fun PopupWindow.setPopUpWindowFlickBottom(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height + (anchorView.height / 2) + 24
+    val baseWidth = anchorView.width
+    val baseHeight = anchorView.height + (anchorView.height / 2) + 24
+    this.width = baseWidth.scaledPopupSize(sizeScalePercent)
+    this.height = baseHeight.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.TOP_CENTER) this.dismiss()
@@ -135,7 +149,7 @@ fun PopupWindow.setPopUpWindowFlickBottom(
                 else -> {
                     showAsDropDown(
                         anchorView,
-                        0,
+                        -((width - anchorView.width) / 2),
                         -(anchorView.height / 2) - 8,
                         Gravity.CENTER
                     )
@@ -146,7 +160,7 @@ fun PopupWindow.setPopUpWindowFlickBottom(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                0,
+                -((width - anchorView.width) / 2),
                 -(anchorView.height / 2) - 8,
                 Gravity.CENTER
             )
@@ -163,7 +177,7 @@ fun PopupWindow.setPopUpWindowFlickBottom(
                 else -> {
                     showAsDropDown(
                         anchorView,
-                        0,
+                        -((width - anchorView.width) / 2),
                         -(anchorView.height / 2) - 8,
                         Gravity.CENTER
                     )
@@ -180,10 +194,13 @@ fun PopupWindow.setPopUpWindowFlickBottom(
 fun PopupWindow.setPopUpWindowFlickTop(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height + (anchorView.height / 2) + 24
+    val baseWidth = anchorView.width
+    val baseHeight = anchorView.height + (anchorView.height / 2) + 24
+    this.width = baseWidth.scaledPopupSize(sizeScalePercent)
+    this.height = baseHeight.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.BOTTOM_CENTER) this.dismiss()
@@ -196,8 +213,8 @@ fun PopupWindow.setPopUpWindowFlickTop(
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height * 2) - 16,
+                -((width - anchorView.width) / 2),
+                -height - anchorView.height - 16,
                 Gravity.CENTER
             )
         }
@@ -205,8 +222,8 @@ fun PopupWindow.setPopUpWindowFlickTop(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height * 2) - 16,
+                -((width - anchorView.width) / 2),
+                -height - anchorView.height - 16,
                 Gravity.CENTER
             )
         }
@@ -214,8 +231,8 @@ fun PopupWindow.setPopUpWindowFlickTop(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height * 2) - 16,
+                -((width - anchorView.width) / 2),
+                -height - anchorView.height - 16,
                 Gravity.CENTER
             )
         }
@@ -229,10 +246,11 @@ fun PopupWindow.setPopUpWindowFlickTop(
 fun PopupWindow.setPopUpWindowCenter(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height
+    this.width = anchorView.width.scaledPopupSize(sizeScalePercent)
+    this.height = anchorView.height.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.TOP_RIGHT) this.dismiss()
@@ -244,8 +262,8 @@ fun PopupWindow.setPopUpWindowCenter(
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height),
+                -((width - anchorView.width) / 2),
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -253,8 +271,8 @@ fun PopupWindow.setPopUpWindowCenter(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height),
+                -((width - anchorView.width) / 2),
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -262,8 +280,8 @@ fun PopupWindow.setPopUpWindowCenter(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height),
+                -((width - anchorView.width) / 2),
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -275,10 +293,11 @@ fun PopupWindow.setPopUpWindowCenter(
 fun PopupWindow.setPopUpWindowRight(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height
+    this.width = anchorView.width.scaledPopupSize(sizeScalePercent)
+    this.height = anchorView.height.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.LEFT_CENTER) this.dismiss()
@@ -291,7 +310,7 @@ fun PopupWindow.setPopUpWindowRight(
             showAsDropDown(
                 anchorView,
                 anchorView.width,
-                -(anchorView.height),
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -300,7 +319,7 @@ fun PopupWindow.setPopUpWindowRight(
             showAsDropDown(
                 anchorView,
                 anchorView.width,
-                -(anchorView.height),
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -309,7 +328,7 @@ fun PopupWindow.setPopUpWindowRight(
             showAsDropDown(
                 anchorView,
                 anchorView.width,
-                -(anchorView.height),
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -321,10 +340,11 @@ fun PopupWindow.setPopUpWindowRight(
 fun PopupWindow.setPopUpWindowLeft(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height
+    this.width = anchorView.width.scaledPopupSize(sizeScalePercent)
+    this.height = anchorView.height.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.RIGHT_CENTER) this.dismiss()
@@ -336,8 +356,8 @@ fun PopupWindow.setPopUpWindowLeft(
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                -(anchorView.width),
-                -(anchorView.height),
+                -width,
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -345,8 +365,8 @@ fun PopupWindow.setPopUpWindowLeft(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                -(anchorView.width),
-                -(anchorView.height),
+                -width,
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -354,8 +374,8 @@ fun PopupWindow.setPopUpWindowLeft(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                -(anchorView.width),
-                -(anchorView.height),
+                -width,
+                -((height + anchorView.height) / 2),
                 Gravity.CENTER
             )
         }
@@ -370,10 +390,11 @@ fun PopupWindow.setPopUpWindowLeft(
 fun PopupWindow.setPopUpWindowBottom(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height
+    this.width = anchorView.width.scaledPopupSize(sizeScalePercent)
+    this.height = anchorView.height.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.TOP_CENTER) this.dismiss()
@@ -393,7 +414,7 @@ fun PopupWindow.setPopUpWindowBottom(
                 else -> {
                     showAsDropDown(
                         anchorView,
-                        0,
+                        -((width - anchorView.width) / 2),
                         0,
                         Gravity.CENTER
                     )
@@ -404,7 +425,7 @@ fun PopupWindow.setPopUpWindowBottom(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                0,
+                -((width - anchorView.width) / 2),
                 0,
                 Gravity.CENTER
             )
@@ -421,7 +442,7 @@ fun PopupWindow.setPopUpWindowBottom(
                 else -> {
                     showAsDropDown(
                         anchorView,
-                        0,
+                        -((width - anchorView.width) / 2),
                         0,
                         Gravity.CENTER
                     )
@@ -438,10 +459,11 @@ fun PopupWindow.setPopUpWindowBottom(
 fun PopupWindow.setPopUpWindowTop(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
-    anchorView: View
+    anchorView: View,
+    sizeScalePercent: Int = 100
 ) {
-    this.width = anchorView.width
-    this.height = anchorView.height
+    this.width = anchorView.width.scaledPopupSize(sizeScalePercent)
+    this.height = anchorView.height.scaledPopupSize(sizeScalePercent)
     this.setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
     keyWindowLayout.let { bubble ->
         if (bubble.arrowDirection != ArrowDirection.BOTTOM_CENTER) this.dismiss()
@@ -453,8 +475,8 @@ fun PopupWindow.setPopUpWindowTop(
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height * 2),
+                -((width - anchorView.width) / 2),
+                -height - anchorView.height,
                 Gravity.CENTER
             )
         }
@@ -462,8 +484,8 @@ fun PopupWindow.setPopUpWindowTop(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height * 2),
+                -((width - anchorView.width) / 2),
+                -height - anchorView.height,
                 Gravity.CENTER
             )
         }
@@ -471,8 +493,8 @@ fun PopupWindow.setPopUpWindowTop(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                0,
-                -(anchorView.height * 2),
+                -((width - anchorView.width) / 2),
+                -height - anchorView.height,
                 Gravity.CENTER
             )
         }

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/extensions/PopupWindowExtension.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/extensions/PopupWindowExtension.kt
@@ -16,6 +16,16 @@ private fun Int.scaledPopupSize(sizeScalePercent: Int): Int {
     return (this * scale).toInt().coerceAtLeast(1)
 }
 
+private fun calculateCenteredXOffset(popupWidth: Int, anchorWidth: Int): Int {
+    return -((popupWidth - anchorWidth) / 2)
+}
+
+// 上フリックの y-offset は popup の拡大後 height に依存させない。
+// sizeScalePercent によって popup サイズだけが変わり、表示基準位置は anchorView 基準で維持する。
+private fun calculateFlickTopYOffset(anchorHeight: Int): Int {
+    return -(anchorHeight * 2) - 16
+}
+
 fun PopupWindow.setPopUpWindowFlickRight(
     context: Context,
     keyWindowLayout: KeyWindowLayout,
@@ -209,12 +219,16 @@ fun PopupWindow.setPopUpWindowFlickTop(
         bubble.arrowWidth = anchorView.width.toFloat() - 10
         bubble.cornersRadius = 20f
     }
+    // 上フリック popup の y-offset は popup の拡大後 height に依存させない。
+    // sizeScalePercent によって popup サイズだけが変わり、表示基準位置は anchorView 基準で維持する。
+    val xOffset = calculateCenteredXOffset(width, anchorView.width)
+    val yOffset = calculateFlickTopYOffset(anchorView.height)
     when (context.resources.configuration.orientation) {
         Configuration.ORIENTATION_PORTRAIT -> {
             showAsDropDown(
                 anchorView,
-                -((width - anchorView.width) / 2),
-                -height - anchorView.height - 16,
+                xOffset,
+                yOffset,
                 Gravity.CENTER
             )
         }
@@ -222,8 +236,8 @@ fun PopupWindow.setPopUpWindowFlickTop(
         Configuration.ORIENTATION_LANDSCAPE -> {
             showAsDropDown(
                 anchorView,
-                -((width - anchorView.width) / 2),
-                -height - anchorView.height - 16,
+                xOffset,
+                yOffset,
                 Gravity.CENTER
             )
         }
@@ -231,8 +245,8 @@ fun PopupWindow.setPopUpWindowFlickTop(
         Configuration.ORIENTATION_UNDEFINED -> {
             showAsDropDown(
                 anchorView,
-                -((width - anchorView.width) / 2),
-                -height - anchorView.height - 16,
+                xOffset,
+                yOffset,
                 Gravity.CENTER
             )
         }


### PR DESCRIPTION
## 概要

フリック入力時に表示される PopupView のサイズと文字サイズを、設定画面から変更できるようにしました。

## 変更内容

- TenKey の PopupView サイズ・文字サイズ設定を追加
- QWERTY のキー Preview Popup / Variation Popup のサイズ・文字サイズ設定を追加
- FlickKeyboard / Sumire / Custom 系の PopupView に、入力方式ごとのサイズ・文字サイズ設定を追加
  - 通常入力
  - サークル入力
  - 2段フリック
  - 3段フリック
- 設定値を AppPreference に保存し、IMEService から各 KeyboardView に反映する処理を追加
- PopupView 設定画面と Preview View を追加
- 設定画面のラベルを、ユーザーに分かりやすい名前へ修正

## 対応 Issue

- #659

## 確認項目

- TenKey の PopupView サイズ・文字サイズが設定に応じて変わること
- QWERTY の Preview Popup / Variation Popup が設定に応じて変わること
- FlickKeyboard / Sumire / Custom の各入力方式で PopupView のサイズ・文字サイズが反映されること
- Floating mode の TenKey でも PopupViewStyle が反映されること
- 既存のフリック入力・長押し入力・PopupView 表示が壊れていないこと