### PR TITLE
3段フリック入力にてイ段の濁音/拗音の判定角度を設定可能に

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1022,6 +1022,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var learnPredictionPreference: Int? = 2
     private var circularFlickWindowScale: Float? = 1.0f
     private var circularFlickDirectionCount: Int? = 4
+    private var hierarchicalFlickModeSwitchAngleMargin: Int? = 20
 
     private var customKeyBorderWidth: Int? = 1
 
@@ -1955,6 +1956,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         learnPredictionPreference = preferences.learnPredictionPreference
         circularFlickWindowScale = preferences.circularFlickWindowScale
         circularFlickDirectionCount = preferences.circularFlickDirectionCount
+        hierarchicalFlickModeSwitchAngleMargin = preferences.hierarchicalFlickModeSwitchAngleMargin
         customKeyBorderWidth = preferences.customKeyBorderWidth
         qwertySwitchNumberKeyWithoutNumberPreference =
             preferences.qwertySwitchNumberKeyWithoutNumberPreference
@@ -10176,6 +10178,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         flickView.setCircularFlickOptions(
             directionCount = circularFlickDirectionCount
                 ?: appPreference.circularFlickDirectionCount
+        )
+        flickView.setHierarchicalFlickModeSwitchAngleMargin(
+            (hierarchicalFlickModeSwitchAngleMargin
+                ?: appPreference.hierarchical_flick_mode_switch_angle_margin_preference).toDouble()
         )
 
         flickView.applyKeySizing(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImePreferencesSnapshot.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImePreferencesSnapshot.kt
@@ -214,6 +214,7 @@ data class ImePreferencesSnapshot(
     val learnPredictionPreference: Int,
     val circularFlickWindowScale: Float,
     val circularFlickDirectionCount: Int,
+    val hierarchicalFlickModeSwitchAngleMargin: Int,
     val customKeyBorderWidth: Int,
     val qwertySwitchNumberKeyWithoutNumberPreference: Boolean,
     val customRomajiZenkakuConversionEnablePreference: Boolean,
@@ -582,6 +583,8 @@ data class ImePreferencesSnapshot(
                 learnPredictionPreference = appPreference.learn_prediction_preference,
                 circularFlickWindowScale = appPreference.circular_flickWindow_scale,
                 circularFlickDirectionCount = appPreference.circularFlickDirectionCount,
+                hierarchicalFlickModeSwitchAngleMargin =
+                    appPreference.hierarchical_flick_mode_switch_angle_margin_preference,
                 customKeyBorderWidth = appPreference.custom_theme_border_width,
                 qwertySwitchNumberKeyWithoutNumberPreference =
                     appPreference.qwerty_switch_number_key_without_number_preference,

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -121,6 +121,8 @@ object AppPreference {
         Pair("flick_guide_text_size_sp_preference", 9)
     private val FLICK_GUIDE_MAX_CHARACTERS_PREFERENCE =
         Pair("flick_guide_max_characters_preference", 1)
+    private val HIERARCHICAL_FLICK_MODE_SWITCH_ANGLE_MARGIN =
+        Pair("hierarchical_flick_mode_switch_angle_margin_preference", 20)
 
     private val CUSTOM_KEYBOARD_TWO_WORDS_OUTPUTS =
         Pair("custom_keyboard_two_words_preference", true)
@@ -1368,6 +1370,18 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putInt(FLICK_SENSITIVITY.first, value ?: 100)
+        }
+
+    var hierarchical_flick_mode_switch_angle_margin_preference: Int
+        get() = preferences.getInt(
+            HIERARCHICAL_FLICK_MODE_SWITCH_ANGLE_MARGIN.first,
+            HIERARCHICAL_FLICK_MODE_SWITCH_ANGLE_MARGIN.second
+        ).coerceIn(0, 34)
+        set(value) = preferences.edit {
+            it.putInt(
+                HIERARCHICAL_FLICK_MODE_SWITCH_ANGLE_MARGIN.first,
+                value.coerceIn(0, 34)
+            )
         }
 
     var long_press_timeout_preference: Int?

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateHeightPreviewUtils.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateHeightPreviewUtils.kt
@@ -592,6 +592,9 @@ private fun configureFlickKeyboardPreview(
         appPreference.circular_flickWindow_scale
     )
     flickView.setCircularFlickOptions(directionCount = appPreference.circularFlickDirectionCount)
+    flickView.setHierarchicalFlickModeSwitchAngleMargin(
+        appPreference.hierarchical_flick_mode_switch_angle_margin_preference.toDouble()
+    )
     flickView.applyKeySizing(
         keyWidthScalePercent = appPreference.flick_key_width_scale_percent ?: 160,
         keyHeightScalePercent = appPreference.flick_key_height_scale_percent ?: 160,

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/FrequentSettingFilters.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/FrequentSettingFilters.kt
@@ -85,6 +85,7 @@ internal object FrequentSettingFilters {
             R.id.flickKeyboardPopupStyleListFragment,
             R.id.flickKeyboardSizeSettingsFragment,
             R.id.circularFlickSettingsFragment,
+            R.id.hierarchicalFlickAngleMarginFragment,
             R.id.circularSlotActionSettingFragment,
             R.id.sumireSpecialKeyEditorFragment,
                 -> SettingCategory.INPUT_METHOD

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingDestination.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SettingDestination.kt
@@ -774,6 +774,7 @@ object SettingDestinations {
             "custom_keyboard_size_preference" -> R.id.flickKeyboardSizeSettingsFragment
             "flick_keyboard_popup_view_style_preference" -> R.id.flickKeyboardPopupStyleListFragment
             "sumire_custom_angle_preference" -> R.id.circularFlickSettingsFragment
+            "hierarchical_flick_angle_margin_preference" -> R.id.hierarchicalFlickAngleMarginFragment
             "circular_slot_action_setting_preference" -> R.id.circularSlotActionSettingFragment
             "sumire_special_key_editor_preference" -> R.id.sumireSpecialKeyEditorFragment
             "physical_keyboard_shortcut_setting_preference" -> R.id.physicalKeyboardShortcutListFragment

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SumirePreferenceFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/SumirePreferenceFragment.kt
@@ -16,7 +16,9 @@ class SumirePreferenceFragment : PreferenceFragmentCompat() {
         val sumireKeyboardSizePreference =
             findPreference<Preference>("sumire_keyboard_size_preference")
 
-        // 先に sumireCustomAnglePreference を取得しておく（リスナー内で使うため）
+        // 入力スタイルに応じて表示を切り替える設定項目を先に取得しておく
+        val hierarchicalFlickAngleMarginPreference =
+            findPreference<Preference>("hierarchical_flick_angle_margin_preference")
         val sumireCustomAnglePreference =
             findPreference<Preference>("sumire_custom_angle_preference")
         val circularSlotActionSettingPreference =
@@ -31,7 +33,8 @@ class SumirePreferenceFragment : PreferenceFragmentCompat() {
                 summary = entries[findIndexOfValue(value)].toString()
             }
 
-            // 【追加】初期表示状態の設定 ("sumire" の場合のみ表示)
+            // 【追加】初期表示状態の設定
+            hierarchicalFlickAngleMarginPreference?.isVisible = (value == "third-flick")
             sumireCustomAnglePreference?.isVisible = (value == "sumire")
             circularSlotActionSettingPreference?.isVisible = (value == "sumire")
 
@@ -45,7 +48,8 @@ class SumirePreferenceFragment : PreferenceFragmentCompat() {
                     preference.summary = listPreference.entries[index].toString()
                 }
 
-                // 【追加】変更時の表示切り替え ("sumire" が選ばれたら表示、それ以外は非表示)
+                // 【追加】変更時の表示切り替え
+                hierarchicalFlickAngleMarginPreference?.isVisible = (stringValue == "third-flick")
                 sumireCustomAnglePreference?.isVisible = (stringValue == "sumire")
                 circularSlotActionSettingPreference?.isVisible = (stringValue == "sumire")
 
@@ -79,6 +83,13 @@ class SumirePreferenceFragment : PreferenceFragmentCompat() {
         findPreference<Preference>("flick_keyboard_popup_view_style_preference")?.apply {
             setOnPreferenceClickListener {
                 navigateSafely(R.id.flickKeyboardPopupStyleListFragment)
+                true
+            }
+        }
+
+        hierarchicalFlickAngleMarginPreference?.apply {
+            setOnPreferenceClickListener {
+                navigateSafely(R.id.hierarchicalFlickAngleMarginFragment)
                 true
             }
         }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/sumire_flick_angle/HierarchicalFlickAngleMarginFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/sumire_flick_angle/HierarchicalFlickAngleMarginFragment.kt
@@ -1,0 +1,158 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.sumire_flick_angle
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewParent
+import androidx.fragment.app.Fragment
+import com.kazumaproject.custom_keyboard.data.FlickDirection
+import com.kazumaproject.custom_keyboard.data.KeyAction
+import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
+import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
+import com.kazumaproject.custom_keyboard.view.FlickKeyboardView
+import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentHierarchicalFlickAngleMarginBinding
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+import kotlin.math.roundToInt
+
+@AndroidEntryPoint
+class HierarchicalFlickAngleMarginFragment : Fragment() {
+
+    @Inject
+    lateinit var appPreference: AppPreference
+
+    private var _binding: FragmentHierarchicalFlickAngleMarginBinding? = null
+    private val binding get() = _binding!!
+    private var isUpdatingUi = false
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentHierarchicalFlickAngleMarginBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.sliderMargin.value =
+            appPreference.hierarchical_flick_mode_switch_angle_margin_preference.toFloat()
+        updateMargin(binding.sliderMargin.value.roundToInt(), persist = false)
+        setupActualKeyPreview()
+
+        binding.sliderMargin.addOnChangeListener { _, value, fromUser ->
+            updateMargin(value.roundToInt(), persist = fromUser)
+        }
+
+        binding.btnReset.setOnClickListener {
+            binding.sliderMargin.value = DEFAULT_MARGIN.toFloat()
+            updateMargin(DEFAULT_MARGIN, persist = true)
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+
+    private fun updateMargin(value: Int, persist: Boolean) {
+        val margin = value.coerceIn(0, 34)
+        isUpdatingUi = true
+        binding.tvMarginValue.text = getString(
+            com.kazumaproject.markdownhelperkeyboard.R.string.hierarchical_flick_angle_margin_value,
+            margin
+        )
+        if (binding.sliderMargin.value.roundToInt() != margin) {
+            binding.sliderMargin.value = margin.toFloat()
+        }
+        isUpdatingUi = false
+        binding.actualKeyPreview.setHierarchicalFlickModeSwitchAngleMargin(margin.toDouble())
+        if (persist) {
+            appPreference.hierarchical_flick_mode_switch_angle_margin_preference = margin
+        }
+    }
+
+    private fun setupActualKeyPreview() {
+        binding.actualKeyPreview.apply {
+            setPopupWindowAnchorProvider(null)
+            setVisibleKeyLabels(PREVIEW_VISIBLE_KEY_LABELS)
+            setFlickSensitivityValue(appPreference.flick_sensitivity_preference ?: 100)
+            setLongPressTimeout((appPreference.long_press_timeout_preference ?: 300).toLong())
+            setHierarchicalFlickModeSwitchAngleMargin(
+                appPreference.hierarchical_flick_mode_switch_angle_margin_preference.toDouble()
+            )
+            applyKeySizing(
+                keyWidthScalePercent = appPreference.flick_key_width_scale_percent ?: 160,
+                keyHeightScalePercent = appPreference.flick_key_height_scale_percent ?: 160,
+                iconScalePercent = appPreference.flick_key_icon_scale_percent ?: 80,
+                textSizeSp = appPreference.flick_key_text_size_sp ?: 16.0f,
+                specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp ?: 16.0f
+            )
+            setOnKeyboardActionListener(object : FlickKeyboardView.OnKeyboardActionListener {
+                override fun onPress(action: KeyAction) = Unit
+                override fun onAction(action: KeyAction, isFlick: Boolean) {
+                    binding.tvActualKeyResult.text = getString(
+                        com.kazumaproject.markdownhelperkeyboard.R.string.hierarchical_flick_angle_margin_result,
+                        action.previewText()
+                    )
+                }
+
+                override fun onActionLongPress(action: KeyAction) = Unit
+                override fun onActionUpAfterLongPress(action: KeyAction) = Unit
+                override fun onFlickDirectionChanged(direction: FlickDirection) = Unit
+                override fun onFlickActionLongPress(action: KeyAction) = Unit
+                override fun onFlickActionUpAfterLongPress(action: KeyAction, isFlick: Boolean) = Unit
+                override fun onLongPressActionCanceled(action: KeyAction) = Unit
+            })
+            setOnTouchListener { view, event ->
+                when (event.actionMasked) {
+                    MotionEvent.ACTION_DOWN -> {
+                        view.requestAncestorsDisallowIntercept(true)
+                    }
+
+                    MotionEvent.ACTION_MOVE ->
+                        view.requestAncestorsDisallowIntercept(true)
+
+                    MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                        view.requestAncestorsDisallowIntercept(false)
+                    }
+                }
+                false
+            }
+            setKeyboard(createHierarchicalPreviewLayout())
+        }
+    }
+
+    private fun createHierarchicalPreviewLayout() =
+        KeyboardDefaultLayouts.createFinalLayout(
+            mode = KeyboardInputMode.HIRAGANA,
+            dynamicKeyStates = emptyMap(),
+            inputLayoutType = "flick",
+            inputStyle = "third-flick"
+        )
+
+    private fun View.requestAncestorsDisallowIntercept(disallow: Boolean) {
+        var current: ViewParent? = parent
+        while (current != null) {
+            current.requestDisallowInterceptTouchEvent(disallow)
+            current = current.parent
+        }
+    }
+
+    private fun KeyAction.previewText(): String =
+        when (this) {
+            is KeyAction.Text -> text
+            is KeyAction.InputText -> text
+            else -> this::class.simpleName.orEmpty()
+        }
+
+    private companion object {
+        const val DEFAULT_MARGIN = 20
+        val PREVIEW_VISIBLE_KEY_LABELS = setOf("か")
+    }
+}

--- a/app/src/main/res/layout/fragment_hierarchical_flick_angle_margin.xml
+++ b/app/src/main/res/layout/fragment_hierarchical_flick_angle_margin.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvMarginHeading"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/hierarchical_flick_angle_margin_heading"
+            android:textAppearance="?attr/textAppearanceHeadline6"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvMarginDescription"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/hierarchical_flick_angle_margin_description"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvMarginHeading" />
+
+        <TextView
+            android:id="@+id/tvMarginLabel"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/hierarchical_flick_angle_margin_label"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvMarginDescription" />
+
+        <TextView
+            android:id="@+id/tvMarginValue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:layout_constraintBaseline_toBaselineOf="@id/tvMarginLabel"
+            app:layout_constraintEnd_toEndOf="parent"
+            tools:text="20°" />
+
+        <com.google.android.material.slider.Slider
+            android:id="@+id/sliderMargin"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:stepSize="1"
+            android:valueFrom="0"
+            android:valueTo="34"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvMarginLabel" />
+
+        <Button
+            android:id="@+id/btnReset"
+            style="@style/Widget.MaterialComponents.Button.TextButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/hierarchical_flick_angle_margin_reset"
+            app:icon="@android:drawable/ic_menu_revert"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/sliderMargin" />
+
+        <TextView
+            android:id="@+id/tvActualKeyResult"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:gravity="center"
+            android:textSize="28sp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/btnReset"
+            tools:text="きょ" />
+
+        <FrameLayout
+            android:id="@+id/actualKeyPreviewContainer"
+            android:layout_width="0dp"
+            android:layout_height="260dp"
+            android:layout_marginTop="8dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/tvActualKeyResult">
+
+            <com.kazumaproject.custom_keyboard.view.FlickKeyboardView
+                android:id="@+id/actualKeyPreview"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </FrameLayout>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -80,6 +80,9 @@
             android:id="@+id/action_navigation_setting_to_circularFlickSettingsFragment"
             app:destination="@id/circularFlickSettingsFragment" />
         <action
+            android:id="@+id/action_navigation_setting_to_hierarchicalFlickAngleMarginFragment"
+            app:destination="@id/hierarchicalFlickAngleMarginFragment" />
+        <action
             android:id="@+id/action_navigation_setting_to_circularSlotActionSettingFragment"
             app:destination="@id/circularSlotActionSettingFragment" />
         <action
@@ -421,6 +424,11 @@
         android:id="@+id/circularFlickSettingsFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.sumire_custom_angle.CircularFlickSettingsFragment"
         android:label="@string/circularflicksettingsfragment" />
+    <fragment
+        android:id="@+id/hierarchicalFlickAngleMarginFragment"
+        android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.sumire_flick_angle.HierarchicalFlickAngleMarginFragment"
+        android:label="@string/hierarchical_flick_angle_margin_preference_title"
+        tools:layout="@layout/fragment_hierarchical_flick_angle_margin" />
     <fragment
         android:id="@+id/circularSlotActionSettingFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.circular_slot.CircularSlotActionSettingFragment"

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -810,6 +810,14 @@
     <string name="circularflicksettingsfragment">ドーナツ入力</string>
     <string name="sumire_custom_angle_preference_title">ドーナツ入力の設定</string>
     <string name="sumire_custom_angle_preference_summary">フリックの角度を調整します。\n変更の適応にはキーボードの再起動が必要です。</string>
+    <string name="hierarchical_flick_angle_margin_preference_title">３段フリック入力の判定角度</string>
+    <string name="hierarchical_flick_angle_margin_preference_summary">隣り合う入力候補の境界角度を調整します</string>
+    <string name="hierarchical_flick_angle_margin_heading">イ段 濁音/拗音</string>
+    <string name="hierarchical_flick_angle_margin_description">「きょ / ぎょ」などが意図した入力になるように調整できます。\n角度を大きくすると「きょ」を入力するときに誤って「ぎょ」と判定されにくくなります。</string>
+    <string name="hierarchical_flick_angle_margin_label">濁音化に必要な角度差</string>
+    <string name="hierarchical_flick_angle_margin_value">%1$d°</string>
+    <string name="hierarchical_flick_angle_margin_reset">リセット</string>
+    <string name="hierarchical_flick_angle_margin_result">%1$s</string>
     <string name="custom_border_width">枠線の太さ</string>
     <string name="qwerty_switch_number_key_without_number_preference_title">数字キーボード切り替え時の入力モード</string>
     <string name="qwerty_switch_number_key_without_number_preference_sumary">かなキーボード／スミレキーボードに切り替えるとき、数字キーボードではなく日本語入力モードに切り替えます。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -896,7 +896,7 @@
     <string name="sumire_custom_angle_preference_summary">Adjust the flick recognition angle</string>
     <string name="hierarchical_flick_angle_margin_preference_title">Recognition angle for three-step flick input</string>
     <string name="hierarchical_flick_angle_margin_preference_summary">Adjusts the boundary angle between neighboring input candidates</string>
-    <string name="hierarchical_flick_angle_margin_heading">I-row dakuten / contracted sounds</string>
+    <string name="hierarchical_flick_angle_margin_heading">I-column dakuten / contracted sounds</string>
     <string name="hierarchical_flick_angle_margin_reset">Reset</string>
     <string name="hierarchical_flick_angle_margin_label">Angle difference required for dakuten</string>
     <string name="hierarchical_flick_angle_margin_description">Adjust this so inputs such as kyo / gyo are recognized as intended.\nIncreasing the angle makes gyo less likely to be recognized by mistake when entering kyo.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -894,6 +894,14 @@
     <string name="circularflicksettingsfragment">Donuts Input</string>
     <string name="sumire_custom_angle_preference_title">Donuts Input</string>
     <string name="sumire_custom_angle_preference_summary">Adjust the flick recognition angle</string>
+    <string name="hierarchical_flick_angle_margin_preference_title">Recognition angle for three-step flick input</string>
+    <string name="hierarchical_flick_angle_margin_preference_summary">Adjusts the boundary angle between neighboring input candidates</string>
+    <string name="hierarchical_flick_angle_margin_heading">I-row dakuten / contracted sounds</string>
+    <string name="hierarchical_flick_angle_margin_reset">Reset</string>
+    <string name="hierarchical_flick_angle_margin_label">Angle difference required for dakuten</string>
+    <string name="hierarchical_flick_angle_margin_description">Adjust this so inputs such as kyo / gyo are recognized as intended.\nIncreasing the angle makes gyo less likely to be recognized by mistake when entering kyo.</string>
+    <string name="hierarchical_flick_angle_margin_value">%1$d°</string>
+    <string name="hierarchical_flick_angle_margin_result">%1$s</string>
     <string name="custom_border_width">Border width</string>
     <string name="qwerty_switch_number_key_without_number_preference_title">Input mode when switching from the number keyboard</string>
     <string name="qwerty_switch_number_key_without_number_preference_sumary">When switching to the Kana keyboard or Sumire keyboard, switch to Japanese input mode instead of the number keyboard.。</string>

--- a/app/src/main/res/xml/pref_sumire.xml
+++ b/app/src/main/res/xml/pref_sumire.xml
@@ -96,6 +96,11 @@
             app:summary="@string/sumire_custom_angle_preference_summary" />
 
         <Preference
+            android:key="hierarchical_flick_angle_margin_preference"
+            android:title="@string/hierarchical_flick_angle_margin_preference_title"
+            app:summary="@string/hierarchical_flick_angle_margin_preference_summary" />
+
+        <Preference
             android:key="circular_slot_action_setting_preference"
             android:title="Circular Flick SLOT4〜6 設定"
             app:summary="日本語・英語・数字モードの通常キーに、追加フリックアクションを設定します" />

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
@@ -462,7 +462,7 @@ class TfbiHierarchicalFlickController(
     ): Boolean {
         val targetNode = currentMap[targetDirection] as? TfbiFlickNode.Input ?: return false
         if (targetNode.triggersMode == null || targetNode.triggersMode == currentMode) return true
-        if (targetNode.modeSwitchBoundary != ModeSwitchBoundary.I_ROW_DIACRITIC) return true
+        if (targetNode.modeSwitchBoundary != ModeSwitchBoundary.I_COLUMN_DIACRITIC) return true
 
         val targetAngle = centerAngle(targetDirection) ?: return false
         val angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble()))

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
@@ -11,6 +11,7 @@ import android.widget.PopupWindow
 import androidx.core.graphics.drawable.toDrawable
 import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.custom_keyboard.data.KeyMode
+import com.kazumaproject.custom_keyboard.data.ModeSwitchBoundary
 import com.kazumaproject.custom_keyboard.data.TfbiFlickNode
 import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 import com.kazumaproject.custom_keyboard.view.TfbiFlickPopupView
@@ -91,6 +92,7 @@ class TfbiHierarchicalFlickController(
     private var popupBackgroundColor: Int? = null
     private var popupHighlightedColor: Int? = null
     private var popupTextColor: Int? = null
+    private var modeSwitchAngleMargin = MODE_SWITCH_ANGLE_MARGIN
 
     /**
      * ▼▼▼ 追加: 色を設定するメソッド ▼▼▼
@@ -109,6 +111,10 @@ class TfbiHierarchicalFlickController(
             textColor = style.textColor
         )
         popupView?.applyPopupViewStyle(popupStyle)
+    }
+
+    fun setModeSwitchAngleMargin(margin: Double) {
+        modeSwitchAngleMargin = margin.coerceIn(0.0, 34.0)
     }
 
     fun setPopupWindowAnchorProvider(provider: (() -> View?)?) {
@@ -456,6 +462,7 @@ class TfbiHierarchicalFlickController(
     ): Boolean {
         val targetNode = currentMap[targetDirection] as? TfbiFlickNode.Input ?: return false
         if (targetNode.triggersMode == null || targetNode.triggersMode == currentMode) return true
+        if (targetNode.modeSwitchBoundary != ModeSwitchBoundary.I_ROW_DIACRITIC) return true
 
         val targetAngle = centerAngle(targetDirection) ?: return false
         val angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble()))
@@ -469,7 +476,7 @@ class TfbiHierarchicalFlickController(
             .minOrNull()
 
         return nearestAlternativeDiff == null ||
-                targetDiff + MODE_SWITCH_ANGLE_MARGIN < nearestAlternativeDiff
+                targetDiff + modeSwitchAngleMargin < nearestAlternativeDiff
     }
 
     private fun angleDifference(angle: Double, targetAngle: Double): Double {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
@@ -48,6 +48,7 @@ class TfbiHierarchicalFlickController(
 
     companion object {
         private const val MAX_ANGLE_DIFFERENCE = 70.0
+        private const val MODE_SWITCH_ANGLE_MARGIN = 20.0
         private const val TAG = "TfbiHierarchical"
     }
 
@@ -259,14 +260,23 @@ class TfbiHierarchicalFlickController(
         // (TAP 以外の方向に動いたので、ジッターガードは解除)
         isJitterGuardActive = false
 
-        val highlightTargetDirection = direction
-        if (highlightTargetDirection == currentHighlight) return // 変化なし
-
         // ハイライト対象のノードを取得
-        val node = currentM[highlightTargetDirection]
+        val node = currentM[direction]
+        if (direction == currentHighlight) {
+            if (node is TfbiFlickNode.Input && isModeSwitchGestureConfident(
+                    dx = dx,
+                    dy = dy,
+                    targetDirection = direction,
+                    currentMap = currentM
+                )
+            ) {
+                updateInternalState(node.triggersMode, event)
+            }
+            return // 変化なし
+        }
 
         // ハイライトを更新
-        currentHighlight = highlightTargetDirection
+        currentHighlight = direction
 
         when (node) {
             is TfbiFlickNode.Input -> {
@@ -274,7 +284,9 @@ class TfbiHierarchicalFlickController(
                 popupView?.highlightDirection(currentHighlight)
 
                 // 状態更新
-                updateInternalState(node.triggersMode, event)
+                if (isModeSwitchGestureConfident(dx, dy, currentHighlight, currentM)) {
+                    updateInternalState(node.triggersMode, event)
+                }
             }
 
             is TfbiFlickNode.SubMenu -> {
@@ -284,7 +296,7 @@ class TfbiHierarchicalFlickController(
                 currentMap = node.nextMap
 
                 mapStack.push(currentMap!!)
-                highlightStack.push(highlightTargetDirection) // どの方向から来たかを記録
+                highlightStack.push(direction) // どの方向から来たかを記録
 
                 // ハイライトは開いた方向 (currentHighlight) を維持
                 // ただし、ジッターガードを有効にする
@@ -434,6 +446,52 @@ class TfbiHierarchicalFlickController(
         // 9. ★ UI（ポップアップ）を即座に更新
         setupStageUI(this.currentMap!!)
         popupView?.highlightDirection(this.currentHighlight)
+    }
+
+    private fun isModeSwitchGestureConfident(
+        dx: Float,
+        dy: Float,
+        targetDirection: TfbiFlickDirection,
+        currentMap: Map<TfbiFlickDirection, TfbiFlickNode>
+    ): Boolean {
+        val targetNode = currentMap[targetDirection] as? TfbiFlickNode.Input ?: return false
+        if (targetNode.triggersMode == null || targetNode.triggersMode == currentMode) return true
+
+        val targetAngle = centerAngle(targetDirection) ?: return false
+        val angle = Math.toDegrees(atan2(dy.toDouble(), dx.toDouble()))
+        val targetDiff = angleDifference(angle, targetAngle)
+
+        val nearestAlternativeDiff = currentMap.keys
+            .filter { it != targetDirection && it != TfbiFlickDirection.TAP }
+            .mapNotNull { direction ->
+                centerAngle(direction)?.let { angleDifference(angle, it) }
+            }
+            .minOrNull()
+
+        return nearestAlternativeDiff == null ||
+                targetDiff + MODE_SWITCH_ANGLE_MARGIN < nearestAlternativeDiff
+    }
+
+    private fun angleDifference(angle: Double, targetAngle: Double): Double {
+        var diff = abs(angle - targetAngle)
+        if (diff > 180) {
+            diff = 360 - diff
+        }
+        return diff
+    }
+
+    private fun centerAngle(direction: TfbiFlickDirection): Double? {
+        return when (direction) {
+            TfbiFlickDirection.RIGHT -> 0.0
+            TfbiFlickDirection.DOWN_RIGHT -> 35.0
+            TfbiFlickDirection.DOWN -> 90.0
+            TfbiFlickDirection.DOWN_LEFT -> 125.0
+            TfbiFlickDirection.LEFT -> 180.0
+            TfbiFlickDirection.UP_LEFT -> -125.0
+            TfbiFlickDirection.UP -> -90.0
+            TfbiFlickDirection.UP_RIGHT -> -35.0
+            TfbiFlickDirection.TAP -> null
+        }
     }
 
     // --- ポップアップとUIのヘルパー ---

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/TfbiFlickNode.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/TfbiFlickNode.kt
@@ -15,7 +15,7 @@ enum class KeyMode {
 
 enum class ModeSwitchBoundary {
     NONE,
-    I_ROW_DIACRITIC
+    I_COLUMN_DIACRITIC
 }
 
 sealed class TfbiFlickNode {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/TfbiFlickNode.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/TfbiFlickNode.kt
@@ -13,16 +13,23 @@ enum class KeyMode {
     HANDAKUTEN
 }
 
+enum class ModeSwitchBoundary {
+    NONE,
+    I_ROW_DIACRITIC
+}
+
 sealed class TfbiFlickNode {
     /**
      * 終端ノード（文字入力を表す）
      * @param char 入力される文字
      * @param triggersMode この文字が入力された後、
      * コントローラーが遷移すべき次の状態（nullなら状態維持）
+     * @param modeSwitchBoundary triggersMode による状態遷移前に使用する追加の境界判定
      */
     data class Input(
         val char: String,
-        val triggersMode: KeyMode? = null // ★ 変更点
+        val triggersMode: KeyMode? = null,
+        val modeSwitchBoundary: ModeSwitchBoundary = ModeSwitchBoundary.NONE
     ) : TfbiFlickNode()
 
     /**

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -9975,7 +9975,7 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
                     char = "ぎ",
                     triggersMode = KeyMode.DAKUTEN,
-                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
+                    modeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "きゅ", nextMap = subMenuForKyu, cancelOnTap = true
@@ -10251,7 +10251,7 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
                     char = "じ",
                     triggersMode = KeyMode.DAKUTEN,
-                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
+                    modeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "しゅ", nextMap = subMenuForSyu, cancelOnTap = true
@@ -10356,7 +10356,7 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
                     char = "ぢ",
                     triggersMode = KeyMode.DAKUTEN,
-                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
+                    modeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "ちゅ", nextMap = subMenuForTyu, cancelOnTap = true
@@ -10502,12 +10502,12 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
                     char = "び",
                     triggersMode = KeyMode.DAKUTEN,
-                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
+                    modeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
                 ),
                 TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input(
                     char = "ぴ",
                     triggersMode = KeyMode.HANDAKUTEN,
-                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
+                    modeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "ひゅ", nextMap = subMenuForHyu, cancelOnTap = true

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -11,6 +11,7 @@ import com.kazumaproject.custom_keyboard.data.KeyType
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
 import com.kazumaproject.custom_keyboard.data.KeyboardLayout
 import com.kazumaproject.custom_keyboard.data.KeyboardLayoutItem
+import com.kazumaproject.custom_keyboard.data.ModeSwitchBoundary
 import com.kazumaproject.custom_keyboard.data.SpacerItem
 import com.kazumaproject.custom_keyboard.data.TfbiFlickNode
 import com.kazumaproject.custom_keyboard.data.copyWithItems
@@ -9972,7 +9973,9 @@ object KeyboardDefaultLayouts {
                     "き", triggersMode = KeyMode.NORMAL
                 ),
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
-                    char = "ぎ", triggersMode = KeyMode.DAKUTEN
+                    char = "ぎ",
+                    triggersMode = KeyMode.DAKUTEN,
+                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "きゅ", nextMap = subMenuForKyu, cancelOnTap = true
@@ -10246,7 +10249,9 @@ object KeyboardDefaultLayouts {
                     "し", triggersMode = KeyMode.NORMAL
                 ),
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
-                    char = "じ", triggersMode = KeyMode.DAKUTEN
+                    char = "じ",
+                    triggersMode = KeyMode.DAKUTEN,
+                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "しゅ", nextMap = subMenuForSyu, cancelOnTap = true
@@ -10349,7 +10354,9 @@ object KeyboardDefaultLayouts {
                     "ち", triggersMode = KeyMode.NORMAL
                 ),
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
-                    char = "ぢ", triggersMode = KeyMode.DAKUTEN
+                    char = "ぢ",
+                    triggersMode = KeyMode.DAKUTEN,
+                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "ちゅ", nextMap = subMenuForTyu, cancelOnTap = true
@@ -10493,10 +10500,14 @@ object KeyboardDefaultLayouts {
                     "ひ", triggersMode = KeyMode.NORMAL
                 ),
                 TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
-                    char = "び", triggersMode = KeyMode.DAKUTEN
+                    char = "び",
+                    triggersMode = KeyMode.DAKUTEN,
+                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
                 ),
                 TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input(
-                    char = "ぴ", triggersMode = KeyMode.HANDAKUTEN
+                    char = "ぴ",
+                    triggersMode = KeyMode.HANDAKUTEN,
+                    modeSwitchBoundary = ModeSwitchBoundary.I_ROW_DIACRITIC
                 ),
                 TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
                     label = "ひゅ", nextMap = subMenuForHyu, cancelOnTap = true

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -152,6 +152,8 @@ class FlickKeyboardView @JvmOverloads constructor(
     private var customAngleAndRange: Map<CircularFlickDirection, Pair<Float, Float>> = emptyMap()
     private var circularViewScale: Float = 1.0f
     private var circularFlickDirectionCount: Int = 4
+    private var hierarchicalFlickModeSwitchAngleMargin: Double = 20.0
+    private var visibleKeyLabels: Set<String>? = null
     private var borderWidth: Int = 1
     private var flickGuideEnabled: Boolean = false
     private var flickGuideTextSizeSp: Float = 9f
@@ -291,6 +293,20 @@ class FlickKeyboardView @JvmOverloads constructor(
         circularFlickDirectionCount = directionCount.coerceIn(4, 7)
     }
 
+    fun setHierarchicalFlickModeSwitchAngleMargin(margin: Double) {
+        hierarchicalFlickModeSwitchAngleMargin = margin.coerceIn(0.0, 34.0)
+        hierarchicalTfbiControllers.forEach {
+            it.setModeSwitchAngleMargin(hierarchicalFlickModeSwitchAngleMargin)
+        }
+    }
+
+    fun setVisibleKeyLabels(labels: Set<String>?) {
+        visibleKeyLabels = labels
+        dynamicKeyMap.values.forEach { info ->
+            applyVisibleKeyFilter(info.view, info.keyData)
+        }
+    }
+
     fun applyKeyboardTheme(
         themeMode: String,
         currentNightMode: Int,
@@ -398,12 +414,24 @@ class FlickKeyboardView @JvmOverloads constructor(
         val keyView = createKeyView(keyData)
         keyView.layoutParams = createLayoutParams(item.placement, keyData)
         val controller = attachKeyBehavior(keyView, keyData)
+        applyVisibleKeyFilter(keyView, keyData)
 
         keyData.keyId?.let { id ->
             dynamicKeyMap[id] = KeyInfo(keyView, keyData, controller, index)
         }
 
         addView(keyView)
+    }
+
+    private fun applyVisibleKeyFilter(keyView: View, keyData: KeyData) {
+        val labels = visibleKeyLabels ?: run {
+            keyView.visibility = View.VISIBLE
+            keyView.isEnabled = true
+            return
+        }
+        val isVisible = keyData.label in labels
+        keyView.visibility = if (isVisible) View.VISIBLE else View.INVISIBLE
+        keyView.isEnabled = isVisible
     }
 
     private fun addSpacerItem(item: SpacerItem) {
@@ -2003,6 +2031,7 @@ class FlickKeyboardView @JvmOverloads constructor(
                         flickSensitivity = flickSensitivity.toFloat()
                     ).apply {
                         setPopupWindowAnchorProvider(popupWindowAnchorProvider)
+                        setModeSwitchAngleMargin(hierarchicalFlickModeSwitchAngleMargin)
                         applyPopupViewStyle(popupViewStyleSet.tfbi)
                         this.listener = object : TfbiHierarchicalFlickController.TfbiListener {
                             override fun onPress(character: String) {


### PR DESCRIPTION
https://github.com/KazumaProject/JapaneseKeyboard/issues/812 の対応をしてみました
`き` から `きょ` へ最短距離で動かすと `ぎ` を掠めて `ぎょ` と判定されるため，`ぎ` と `きょ` の判定角度を調整できるようにしました

デフォルトで20°を追加するようにしており，設定にて試しながら調整できるようにしています

[Screen_recording_20260621_100502.webm](https://github.com/user-attachments/assets/84e45423-9a8d-4eb1-9ab8-704a2792bc86)

お手すきでレビューいただければと思いますmm