### PR TITLE
schemaとgeneratorにより「か」キーを直接TfbiFlickNodeで書かないように変更

### DIFF
--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/FlickKeyDefinition.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/FlickKeyDefinition.kt
@@ -1,0 +1,116 @@
+package com.kazumaproject.custom_keyboard.data
+
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
+
+/**
+ * Definition-layer model for generating runtime [TfbiFlickNode] maps.
+ */
+data class FlickKeyDefinition(
+    val id: String,
+    val label: String,
+    val normal: FlickStageDefinition,
+    val dakuten: FlickStageDefinition? = null,
+    val handakuten: FlickStageDefinition? = null
+)
+
+enum class FlickKeyState {
+    NORMAL,
+    DAKUTEN,
+    HANDAKUTEN
+}
+
+enum class FlickDefinitionFeature {
+    A_ROW_SECOND_STAGE
+}
+
+data class FlickStageDefinition(
+    val entries: List<FlickEntryDefinition>
+)
+
+data class FlickEntryDefinition(
+    val direction: TfbiFlickDirection,
+    val node: FlickNodeDefinition,
+    val requiredFeature: FlickDefinitionFeature? = null
+)
+
+sealed class FlickNodeDefinition {
+    data class Input(
+        val output: String,
+        val nextState: FlickKeyState? = null,
+        val modeSwitchBoundary: ModeSwitchBoundary = ModeSwitchBoundary.NONE
+    ) : FlickNodeDefinition()
+
+    data class Branch(
+        val label: String? = null,
+        val stage: FlickStageDefinition,
+        val cancelOnTap: Boolean = true
+    ) : FlickNodeDefinition()
+}
+
+fun FlickKeyDefinition.enabledFeatures(
+    features: Set<FlickDefinitionFeature>
+): FlickKeyDefinition = copy(
+    normal = normal.enabledFeatures(features),
+    dakuten = dakuten?.enabledFeatures(features),
+    handakuten = handakuten?.enabledFeatures(features)
+)
+
+fun FlickStageDefinition.enabledFeatures(
+    features: Set<FlickDefinitionFeature>
+): FlickStageDefinition {
+    return copy(
+        entries = entries
+            .filter { entry -> entry.requiredFeature == null || entry.requiredFeature in features }
+            .map { entry ->
+                entry.copy(
+                    node = when (val node = entry.node) {
+                        is FlickNodeDefinition.Branch ->
+                            node.copy(stage = node.stage.enabledFeatures(features))
+
+                        is FlickNodeDefinition.Input -> node
+                    }
+                )
+            }
+    )
+}
+
+object FlickKeyDefinitionTfbiMapper {
+    fun toStatefulKey(definition: FlickKeyDefinition): TfbiFlickNode.StatefulKey {
+        return TfbiFlickNode.StatefulKey(
+            normalMap = definition.normal.toTfbiMap(),
+            dakutenMap = definition.dakuten?.toTfbiMap(),
+            handakutenMap = definition.handakuten?.toTfbiMap(),
+            label = definition.label
+        )
+    }
+
+    private fun FlickStageDefinition.toTfbiMap(): Map<TfbiFlickDirection, TfbiFlickNode> {
+        return entries.associate { entry ->
+            entry.direction to entry.node.toTfbiNode()
+        }
+    }
+
+    private fun FlickNodeDefinition.toTfbiNode(): TfbiFlickNode {
+        return when (this) {
+            is FlickNodeDefinition.Input -> TfbiFlickNode.Input(
+                char = output,
+                triggersMode = nextState?.toKeyMode(),
+                modeSwitchBoundary = modeSwitchBoundary
+            )
+
+            is FlickNodeDefinition.Branch -> TfbiFlickNode.SubMenu(
+                nextMap = stage.toTfbiMap(),
+                label = label,
+                cancelOnTap = cancelOnTap
+            )
+        }
+    }
+
+    private fun FlickKeyState.toKeyMode(): KeyMode {
+        return when (this) {
+            FlickKeyState.NORMAL -> KeyMode.NORMAL
+            FlickKeyState.DAKUTEN -> KeyMode.DAKUTEN
+            FlickKeyState.HANDAKUTEN -> KeyMode.HANDAKUTEN
+        }
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KanaRowFlickDefinitionGenerator.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/data/KanaRowFlickDefinitionGenerator.kt
@@ -1,0 +1,190 @@
+package com.kazumaproject.custom_keyboard.data
+
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.DOWN
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.DOWN_LEFT
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.DOWN_RIGHT
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.LEFT
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.RIGHT
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.TAP
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.UP
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.UP_LEFT
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection.UP_RIGHT
+
+data class KanaSeries(
+    val a: String,
+    val i: String,
+    val u: String,
+    val e: String,
+    val o: String
+)
+
+data class KanaRowSpec(
+    val id: String,
+    val label: String,
+    val number: String? = null,
+    val normal: KanaSeries,
+    val dakuten: KanaSeries? = null,
+    val handakuten: KanaSeries? = null,
+    val iColumnModeSwitchBoundary: ModeSwitchBoundary = ModeSwitchBoundary.NONE
+)
+
+@DslMarker
+private annotation class KanaRowFlickDefinitionDsl
+
+object KanaRowFlickDefinitionGenerator {
+    fun create(spec: KanaRowSpec): FlickKeyDefinition {
+        require(spec.handakuten == null) {
+            "Handakuten row generation is not supported yet."
+        }
+        return FlickKeyDefinition(
+            id = spec.id,
+            label = spec.label,
+            normal = createNormalStage(spec),
+            dakuten = spec.dakuten?.let { createDakutenStage(spec, it) },
+            handakuten = null
+        )
+    }
+
+    private fun createNormalStage(spec: KanaRowSpec): FlickStageDefinition = stage {
+        add(TAP, input(spec.normal.a))
+        spec.dakuten?.let { dakuten ->
+            add(UP_RIGHT, dakutenAColumn(spec.normal, dakuten))
+        }
+        add(LEFT, branch(label = spec.normal.i, cancelOnTap = false) {
+            add(LEFT, input(spec.normal.i, nextState = FlickKeyState.NORMAL))
+            spec.dakuten?.let { dakuten ->
+                add(
+                    DOWN_LEFT,
+                    input(
+                        text = dakuten.i,
+                        nextState = FlickKeyState.DAKUTEN,
+                        modeSwitchBoundary = spec.iColumnModeSwitchBoundary
+                    )
+                )
+            }
+            add(UP, yoonBranch("${spec.normal.i}ゅ"))
+            add(RIGHT, input("${spec.normal.i}ゃ"))
+            add(DOWN, yoonBranch("${spec.normal.i}ょ"))
+        })
+        add(UP, branch(label = spec.normal.u) {
+            add(UP, input(spec.normal.u))
+            spec.dakuten?.let { dakuten ->
+                add(UP_LEFT, input(dakuten.u, nextState = FlickKeyState.DAKUTEN))
+            }
+            add(UP_RIGHT, input("${spec.normal.u}う"))
+        })
+        add(RIGHT, branch(label = spec.normal.e) {
+            add(RIGHT, input(spec.normal.e))
+            spec.dakuten?.let { dakuten ->
+                add(DOWN_RIGHT, input(dakuten.e, nextState = FlickKeyState.DAKUTEN))
+            }
+        })
+        add(DOWN, branch(label = spec.normal.o) {
+            add(DOWN, input(spec.normal.o))
+            spec.dakuten?.let { dakuten ->
+                add(DOWN_RIGHT, input(dakuten.o, nextState = FlickKeyState.DAKUTEN))
+            }
+            add(DOWN_LEFT, input("${spec.normal.o}う"))
+            spec.number?.let { number ->
+                add(LEFT, input(number))
+            }
+        })
+    }
+
+    private fun createDakutenStage(
+        spec: KanaRowSpec,
+        dakuten: KanaSeries
+    ): FlickStageDefinition = stage {
+        add(TAP, input(spec.normal.a))
+        add(UP_RIGHT, dakutenAColumn(spec.normal, dakuten))
+        add(LEFT, branch(cancelOnTap = false) {
+            add(DOWN_LEFT, input(dakuten.i, nextState = FlickKeyState.DAKUTEN))
+            add(UP_LEFT, input(spec.normal.i, nextState = FlickKeyState.NORMAL))
+            add(UP, yoonBranch("${dakuten.i}ゅ"))
+            add(RIGHT, input("${dakuten.i}ゃ"))
+            add(DOWN, yoonBranch("${dakuten.i}ょ"))
+        })
+        add(UP, branch {
+            add(UP_LEFT, input(dakuten.u))
+            add(UP, input(spec.normal.u, nextState = FlickKeyState.NORMAL))
+            add(LEFT, input("${dakuten.u}う"))
+        })
+        add(RIGHT, branch {
+            add(DOWN_RIGHT, input(dakuten.e))
+            add(RIGHT, input(spec.normal.e, nextState = FlickKeyState.NORMAL))
+        })
+        add(DOWN, branch {
+            add(DOWN_RIGHT, input(dakuten.o))
+            add(DOWN, input(spec.normal.o, nextState = FlickKeyState.NORMAL))
+            add(RIGHT, input("${dakuten.o}う"))
+        })
+    }
+
+    private fun dakutenAColumn(
+        normal: KanaSeries,
+        dakuten: KanaSeries
+    ): FlickNodeDefinition.Branch {
+        return branch(label = dakuten.a) {
+            add(TAP, input(normal.a))
+            add(UP_RIGHT, input(dakuten.a))
+        }
+    }
+
+    private fun yoonBranch(text: String): FlickNodeDefinition.Branch {
+        val longDirection = if (text.endsWith("ょ")) {
+            DOWN_LEFT
+        } else {
+            UP_LEFT
+        }
+        val primaryDirection = if (text.endsWith("ょ")) {
+            DOWN
+        } else {
+            UP
+        }
+        return branch(label = text) {
+            add(primaryDirection, input(text))
+            add(longDirection, input("${text}う"))
+        }
+    }
+
+    private fun stage(
+        block: FlickStageBuilder.() -> Unit
+    ): FlickStageDefinition = FlickStageDefinition(
+        entries = buildList {
+            FlickStageBuilder(this).block()
+        }
+    )
+
+    private fun input(
+        text: String,
+        nextState: FlickKeyState? = null,
+        modeSwitchBoundary: ModeSwitchBoundary = ModeSwitchBoundary.NONE
+    ): FlickNodeDefinition.Input = FlickNodeDefinition.Input(
+        output = text,
+        nextState = nextState,
+        modeSwitchBoundary = modeSwitchBoundary
+    )
+
+    private fun branch(
+        label: String? = null,
+        cancelOnTap: Boolean = true,
+        block: FlickStageBuilder.() -> Unit
+    ): FlickNodeDefinition.Branch = FlickNodeDefinition.Branch(
+        label = label,
+        stage = stage(block),
+        cancelOnTap = cancelOnTap
+    )
+
+    @KanaRowFlickDefinitionDsl
+    private class FlickStageBuilder(
+        private val entries: MutableList<FlickEntryDefinition>
+    ) {
+        fun add(
+            direction: TfbiFlickDirection,
+            node: FlickNodeDefinition
+        ) {
+            entries += FlickEntryDefinition(direction, node)
+        }
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -1,8 +1,12 @@
 package com.kazumaproject.custom_keyboard.layout
 
 import com.kazumaproject.custom_keyboard.data.FlickAction
+import com.kazumaproject.custom_keyboard.data.FlickKeyDefinitionTfbiMapper
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.GridPlacement
+import com.kazumaproject.custom_keyboard.data.KanaRowFlickDefinitionGenerator
+import com.kazumaproject.custom_keyboard.data.KanaRowSpec
+import com.kazumaproject.custom_keyboard.data.KanaSeries
 import com.kazumaproject.custom_keyboard.data.KeyAction
 import com.kazumaproject.custom_keyboard.data.KeyData
 import com.kazumaproject.custom_keyboard.data.KeyItem
@@ -9931,6 +9935,18 @@ object KeyboardDefaultLayouts {
 
     }
 
+    private fun createHierarchicalKaKeyDefinition() =
+        KanaRowFlickDefinitionGenerator.create(
+            KanaRowSpec(
+                id = "kana_ka",
+                label = "か",
+                number = "2",
+                normal = KanaSeries("か", "き", "く", "け", "こ"),
+                dakuten = KanaSeries("が", "ぎ", "ぐ", "げ", "ご"),
+                iColumnModeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
+            )
+        )
+
     private fun createHierarchicalFlickMaps(): Map<String, TfbiFlickNode.StatefulKey> {
         // --- "あ"行 SubMenus ---
         val subMenu_Small_A = TfbiFlickNode.SubMenu(
@@ -9956,83 +9972,6 @@ object KeyboardDefaultLayouts {
             TfbiFlickDirection.DOWN to TfbiFlickNode.Input("お"),
             TfbiFlickDirection.DOWN_RIGHT to TfbiFlickNode.Input("ぉ"),
             TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input("1")
-        )
-
-        // --- "か"行 SubMenus (ご提示のコード) ---
-        val subMenuForKyo = mapOf(
-            TfbiFlickDirection.DOWN to TfbiFlickNode.Input("きょ"),
-            TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input("きょう")
-        )
-        val subMenuForKyu = mapOf(
-            TfbiFlickDirection.UP to TfbiFlickNode.Input("きゅ"),
-            TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input("きゅう")
-        )
-        val subMenu_KI = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.LEFT to TfbiFlickNode.Input(
-                    "き", triggersMode = KeyMode.NORMAL
-                ),
-                TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
-                    char = "ぎ",
-                    triggersMode = KeyMode.DAKUTEN,
-                    modeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
-                ),
-                TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
-                    label = "きゅ", nextMap = subMenuForKyu, cancelOnTap = true
-                ),
-                TfbiFlickDirection.RIGHT to TfbiFlickNode.Input("きゃ"),
-                TfbiFlickDirection.DOWN to TfbiFlickNode.SubMenu(
-                    label = "きょ", nextMap = subMenuForKyo, cancelOnTap = true
-                )
-            ),
-            label = "き",
-        )
-        val subMenu_KU = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.UP to TfbiFlickNode.Input("く"),
-                TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input(
-                    char = "ぐ", triggersMode = KeyMode.DAKUTEN
-                ),
-                TfbiFlickDirection.UP_RIGHT to TfbiFlickNode.Input(
-                    char = "くう",
-                )
-            ),
-            cancelOnTap = true,
-            label = "く",
-        )
-
-        val subMenu_KE = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.RIGHT to TfbiFlickNode.Input("け"),
-                TfbiFlickDirection.DOWN_RIGHT to TfbiFlickNode.Input(
-                    char = "げ", triggersMode = KeyMode.DAKUTEN
-                )
-            ),
-            cancelOnTap = true,
-            label = "け",
-        )
-        val subMenu_KO = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.DOWN to TfbiFlickNode.Input("こ"),
-                TfbiFlickDirection.DOWN_RIGHT to TfbiFlickNode.Input(
-                    char = "ご", triggersMode = KeyMode.DAKUTEN
-                ),
-                TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input("こう"),
-                TfbiFlickDirection.LEFT to TfbiFlickNode.Input("2"),
-            ),
-            cancelOnTap = true,
-            label = "こ",
-        )
-
-        // --- "が"行 SubMenus (ご提示のコード) ---
-        val subMenuForGyo = mapOf(
-            TfbiFlickDirection.DOWN to TfbiFlickNode.Input("ぎょ"),
-            TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input("ぎょう")
-        )
-
-        val subMenuForGyu = mapOf(
-            TfbiFlickDirection.UP to TfbiFlickNode.Input("ぎゅ"),
-            TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input("ぎゅう")
         )
 
         val subMenuForSyu = mapOf(
@@ -10147,30 +10086,6 @@ object KeyboardDefaultLayouts {
             TfbiFlickDirection.UP to TfbiFlickNode.Input("てぃー")
         )
 
-        val subMenu_GI = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.DOWN_LEFT to TfbiFlickNode.Input(
-                    "ぎ", triggersMode = KeyMode.DAKUTEN
-                ),
-                TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input(
-                    char = "き", triggersMode = KeyMode.NORMAL
-                ),
-                TfbiFlickDirection.UP to TfbiFlickNode.SubMenu(
-                    label = "ぎゅ", nextMap = subMenuForGyu, cancelOnTap = true
-                ),
-                TfbiFlickDirection.RIGHT to TfbiFlickNode.Input("ぎゃ"),
-                TfbiFlickDirection.DOWN to TfbiFlickNode.SubMenu(
-                    label = "ぎょ", nextMap = subMenuForGyo, cancelOnTap = true
-                )
-            )
-        )
-        val subMenu_GA = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.TAP to TfbiFlickNode.Input("か"),
-                TfbiFlickDirection.UP_RIGHT to TfbiFlickNode.Input("が"),
-            ), cancelOnTap = true, label = "が"
-        )
-
         val subMenu_ZA = TfbiFlickNode.SubMenu(
             mapOf(
                 TfbiFlickDirection.TAP to TfbiFlickNode.Input("さ"),
@@ -10211,35 +10126,6 @@ object KeyboardDefaultLayouts {
                 TfbiFlickDirection.TAP to TfbiFlickNode.Input("は"),
                 TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input("ぱ"),
             ), cancelOnTap = true, label = "ぱ"
-        )
-
-        val subMenu_GU = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.UP_LEFT to TfbiFlickNode.Input("ぐ"),
-                TfbiFlickDirection.UP to TfbiFlickNode.Input(
-                    char = "く", triggersMode = KeyMode.NORMAL
-                ),
-                TfbiFlickDirection.LEFT to TfbiFlickNode.Input(
-                    char = "ぐう",
-                )
-            ), cancelOnTap = true
-        )
-        val subMenu_GE = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.DOWN_RIGHT to TfbiFlickNode.Input("げ"),
-                TfbiFlickDirection.RIGHT to TfbiFlickNode.Input(
-                    char = "け", triggersMode = KeyMode.NORMAL
-                )
-            ), cancelOnTap = true
-        )
-        val subMenu_GO = TfbiFlickNode.SubMenu(
-            mapOf(
-                TfbiFlickDirection.DOWN_RIGHT to TfbiFlickNode.Input("ご"),
-                TfbiFlickDirection.DOWN to TfbiFlickNode.Input(
-                    char = "こ", triggersMode = KeyMode.NORMAL
-                ),
-                TfbiFlickDirection.RIGHT to TfbiFlickNode.Input("ごう"),
-            ), cancelOnTap = true
         )
 
         // --- "さ"行 SubMenus ---
@@ -10885,24 +10771,6 @@ object KeyboardDefaultLayouts {
             )
         )
 
-        // --- "か"行 Map (ご提示のコード) ---
-        val k_Map = mapOf(
-            TfbiFlickDirection.TAP to TfbiFlickNode.Input("か"),
-            TfbiFlickDirection.UP_RIGHT to subMenu_GA,
-            TfbiFlickDirection.LEFT to subMenu_KI,
-            TfbiFlickDirection.UP to subMenu_KU,
-            TfbiFlickDirection.RIGHT to subMenu_KE,
-            TfbiFlickDirection.DOWN to subMenu_KO
-        )
-        val g_Map = mapOf(
-            TfbiFlickDirection.TAP to TfbiFlickNode.Input("か"),
-            TfbiFlickDirection.UP_RIGHT to subMenu_GA,
-            TfbiFlickDirection.LEFT to subMenu_GI,
-            TfbiFlickDirection.UP to subMenu_GU,
-            TfbiFlickDirection.RIGHT to subMenu_GE,
-            TfbiFlickDirection.DOWN to subMenu_GO
-        )
-
         // --- "さ"行 Map ---
         val s_Map = mapOf(
             TfbiFlickDirection.TAP to TfbiFlickNode.Input("さ"),
@@ -11030,9 +10898,7 @@ object KeyboardDefaultLayouts {
                 label = "あ", normalMap = a_Map, dakutenMap = null, handakutenMap = null
             ),
             // か行
-            "か" to TfbiFlickNode.StatefulKey(
-                label = "か", normalMap = k_Map, dakutenMap = g_Map, handakutenMap = null
-            ),
+            "か" to FlickKeyDefinitionTfbiMapper.toStatefulKey(createHierarchicalKaKeyDefinition()),
             // さ行
             "さ" to TfbiFlickNode.StatefulKey(
                 label = "さ", normalMap = s_Map, dakutenMap = z_Map, handakutenMap = null

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/data/FlickKeyDefinitionTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/data/FlickKeyDefinitionTest.kt
@@ -1,0 +1,118 @@
+package com.kazumaproject.custom_keyboard.data
+
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FlickKeyDefinitionTest {
+    @Test
+    fun mapsHierarchicalDefinitionToTfbiStatefulKey() {
+        val definition = FlickKeyDefinition(
+            id = "kana_ka",
+            label = "か",
+            normal = FlickStageDefinition(
+                entries = listOf(
+                    FlickEntryDefinition(
+                        direction = TfbiFlickDirection.TAP,
+                        node = FlickNodeDefinition.Input("か")
+                    ),
+                    FlickEntryDefinition(
+                        direction = TfbiFlickDirection.LEFT,
+                        node = FlickNodeDefinition.Branch(
+                            label = "き",
+                            stage = FlickStageDefinition(
+                                entries = listOf(
+                                    FlickEntryDefinition(
+                                        direction = TfbiFlickDirection.LEFT,
+                                        node = FlickNodeDefinition.Input(
+                                            output = "き",
+                                            nextState = FlickKeyState.NORMAL
+                                        )
+                                    ),
+                                    FlickEntryDefinition(
+                                        direction = TfbiFlickDirection.DOWN_LEFT,
+                                        node = FlickNodeDefinition.Input(
+                                            output = "ぎ",
+                                            nextState = FlickKeyState.DAKUTEN,
+                                            modeSwitchBoundary =
+                                                ModeSwitchBoundary.I_COLUMN_DIACRITIC
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val statefulKey = FlickKeyDefinitionTfbiMapper.toStatefulKey(definition)
+        val leftNode = statefulKey.normalMap.getValue(TfbiFlickDirection.LEFT)
+        val leftMap = (leftNode as TfbiFlickNode.SubMenu).nextMap
+        val gi = leftMap.getValue(TfbiFlickDirection.DOWN_LEFT) as TfbiFlickNode.Input
+
+        assertEquals("か", statefulKey.label)
+        assertEquals("き", leftNode.label)
+        assertEquals("ぎ", gi.char)
+        assertEquals(KeyMode.DAKUTEN, gi.triggersMode)
+        assertEquals(ModeSwitchBoundary.I_COLUMN_DIACRITIC, gi.modeSwitchBoundary)
+    }
+
+    @Test
+    fun filtersEntriesByFeatureRecursively() {
+        val definition = FlickKeyDefinition(
+            id = "kana_a",
+            label = "あ",
+            normal = FlickStageDefinition(
+                entries = listOf(
+                    FlickEntryDefinition(
+                        direction = TfbiFlickDirection.TAP,
+                        node = FlickNodeDefinition.Input("あ")
+                    ),
+                    FlickEntryDefinition(
+                        direction = TfbiFlickDirection.LEFT,
+                        node = FlickNodeDefinition.Branch(
+                            label = "い",
+                            stage = FlickStageDefinition(
+                                entries = listOf(
+                                    FlickEntryDefinition(
+                                        direction = TfbiFlickDirection.LEFT,
+                                        node = FlickNodeDefinition.Input(
+                                            "い"
+                                        )
+                                    ),
+                                    FlickEntryDefinition(
+                                        direction = TfbiFlickDirection.DOWN_LEFT,
+                                        node = FlickNodeDefinition.Input(
+                                            "ぃ"
+                                        ),
+                                        requiredFeature =
+                                            FlickDefinitionFeature.A_ROW_SECOND_STAGE
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val disabled = definition.enabledFeatures(emptySet())
+        val enabled = definition.enabledFeatures(setOf(FlickDefinitionFeature.A_ROW_SECOND_STAGE))
+        val disabledLeftStage = (disabled.normal.entries
+            .first { it.direction == TfbiFlickDirection.LEFT }
+            .node as FlickNodeDefinition.Branch).stage
+        val enabledLeftStage = (enabled.normal.entries
+            .first { it.direction == TfbiFlickDirection.LEFT }
+            .node as FlickNodeDefinition.Branch).stage
+
+        assertFalse(disabledLeftStage.hasDirection(TfbiFlickDirection.DOWN_LEFT))
+        assertTrue(enabledLeftStage.hasDirection(TfbiFlickDirection.DOWN_LEFT))
+    }
+
+    private fun FlickStageDefinition.hasDirection(direction: TfbiFlickDirection): Boolean {
+        return entries.any { it.direction == direction }
+    }
+}

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/data/KanaRowFlickDefinitionGeneratorTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/data/KanaRowFlickDefinitionGeneratorTest.kt
@@ -1,0 +1,70 @@
+package com.kazumaproject.custom_keyboard.data
+
+import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class KanaRowFlickDefinitionGeneratorTest {
+    @Test
+    fun generatesKaRowDefinitionWithNormalDakutenAndNumberCandidates() {
+        val definition = KanaRowFlickDefinitionGenerator.create(
+            KanaRowSpec(
+                id = "kana_ka",
+                label = "か",
+                number = "2",
+                normal = KanaSeries("か", "き", "く", "け", "こ"),
+                dakuten = KanaSeries("が", "ぎ", "ぐ", "げ", "ご"),
+                iColumnModeSwitchBoundary = ModeSwitchBoundary.I_COLUMN_DIACRITIC
+            )
+        )
+
+        val statefulKey = FlickKeyDefinitionTfbiMapper.toStatefulKey(definition)
+        val normalKiNode = statefulKey.normalMap.subMenu(TfbiFlickDirection.LEFT)
+        val normalKi = normalKiNode.nextMap
+        val gi = normalKi.input(TfbiFlickDirection.DOWN_LEFT)
+        val normalKyo = normalKi.branch(TfbiFlickDirection.DOWN)
+        val normalKo = statefulKey.normalMap.branch(TfbiFlickDirection.DOWN)
+        val dakutenMap = requireNotNull(statefulKey.dakutenMap)
+        val dakutenGi = dakutenMap.branch(TfbiFlickDirection.LEFT)
+        val dakutenGyo = dakutenGi.branch(TfbiFlickDirection.DOWN)
+        val dakutenGu = dakutenMap.branch(TfbiFlickDirection.UP)
+        val dakutenGo = dakutenMap.branch(TfbiFlickDirection.DOWN)
+        val kiFromDakuten = dakutenGi.input(TfbiFlickDirection.UP_LEFT)
+        val kuFromDakuten = dakutenGu.input(TfbiFlickDirection.UP)
+
+        assertEquals("か", statefulKey.label)
+        assertNull(statefulKey.handakutenMap)
+        assertEquals("きょう", normalKyo.input(TfbiFlickDirection.DOWN_LEFT).char)
+        assertEquals("2", normalKo.input(TfbiFlickDirection.LEFT).char)
+        assertFalse(normalKiNode.cancelOnTap)
+        assertEquals("ぎ", gi.char)
+        assertEquals(KeyMode.DAKUTEN, gi.triggersMode)
+        assertEquals(ModeSwitchBoundary.I_COLUMN_DIACRITIC, gi.modeSwitchBoundary)
+        assertEquals("き", kiFromDakuten.char)
+        assertEquals(KeyMode.NORMAL, kiFromDakuten.triggersMode)
+        assertEquals("く", kuFromDakuten.char)
+        assertEquals(KeyMode.NORMAL, kuFromDakuten.triggersMode)
+        assertEquals("ぎょう", dakutenGyo.input(TfbiFlickDirection.DOWN_LEFT).char)
+        assertEquals("ごう", dakutenGo.input(TfbiFlickDirection.RIGHT).char)
+    }
+
+    private fun Map<TfbiFlickDirection, TfbiFlickNode>.branch(
+        direction: TfbiFlickDirection
+    ): Map<TfbiFlickDirection, TfbiFlickNode> {
+        return subMenu(direction).nextMap
+    }
+
+    private fun Map<TfbiFlickDirection, TfbiFlickNode>.subMenu(
+        direction: TfbiFlickDirection
+    ): TfbiFlickNode.SubMenu {
+        return getValue(direction) as TfbiFlickNode.SubMenu
+    }
+
+    private fun Map<TfbiFlickDirection, TfbiFlickNode>.input(
+        direction: TfbiFlickDirection
+    ): TfbiFlickNode.Input {
+        return getValue(direction) as TfbiFlickNode.Input
+    }
+}


### PR DESCRIPTION
- https://github.com/KazumaProject/JapaneseKeyboard/issues/852

の1段階目としてschemaの定義とgeneratorの作成，「か」キーの差し替えを実施しました
最終的に生成されるTfbiFlickNodeに変化はないことをUT，動作確認で確認しています

当初はschema導入とgenerator導入のPRを分割する予定でしたが，生のschemaを直接書こうとすると既存のTfbiFlickNodeよりも煩雑な記載になった(またgenerator導入ですぐに削除されることにもなる)ので，まとめることとしました

次のPRとしては残りのキーをgenerator経由で生成する修正を予定しています
diffの大きさによっては複数のPRに分割するかもです

お手すきでレビューいただけますと幸いです