### PR TITLE
スミレキーボードにて絵文字/濁点キーの切り替えを入力末尾から判定

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -10547,12 +10547,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         )
     }
 
-    /**
-     * 濁点モードを切り替えてキーボードを更新するメソッドの例
-     */
-    private fun setSumireKeyboardDakutenKey() {
-        // 0と1を交互に切り替える
-        currentDakutenKeyIndex = 1
+    private fun updateSumireDakutenKeyForCurrentInput() {
+        val isSumireJapaneseInput =
+            qwertyMode.value == TenKeyQWERTYMode.Sumire &&
+                currentInputModeForSession == InputMode.ModeJapanese
+        val canTransformLastCharacter =
+            inputString.value.lastOrNull()?.getDakutenSmallChar() != null
+        currentDakutenKeyIndex = if (isSumireJapaneseInput && canTransformLastCharacter) 1 else 0
         updateDynamicKeyOnActiveSurface("dakuten_toggle_key", currentDakutenKeyIndex)
     }
 
@@ -11647,6 +11648,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             TenKeyQWERTYMode.Sumire -> {
                                 Timber.d("TenKeyQWERTYMode.Sumire: $text $isFlick")
                                 handleOnKeyForSumire(text, mainView, isFlick)
+                                updateSumireDakutenKeyForCurrentInput()
                             }
 
                             TenKeyQWERTYMode.Number -> {
@@ -13993,7 +13995,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         updateQwertyOnActiveSurface { setReturnKeyText("done") }
                     }
                     if (mainView.customLayoutDefault.isVisible) {
-                        setSumireKeyboardDakutenKey()
+                        updateSumireDakutenKeyForCurrentInput()
                         setSumireKeyboardEnterKey(5)
                         when (currentInputModeForSession) {
                             InputMode.ModeJapanese -> {


### PR DESCRIPTION
スミレキーボードにて英字配列をQWERTYにした状態で，
QWERTY英字入力後にスミレキーボードへ戻り，かなを入力して濁点キーを押すと濁点にならない事象がありました

既存では候補状態が Idel → Updatingになる際に濁点キーへ切り替えていましたが，
英字配列をQWERTYにして英字を入力すると，候補状態はQWERTY表示中ですでに Updatingとなるため，戻ってかなを入力してもUpdating → Updatingで切り替わっていないことが原因のようでした

スミレキーボードで文字を入力した直後に
- スミレキーボード入力中
- 日本語モード
- 末尾が getDakutenSmallChar() で変換できる文字

の場合に濁点キーへ切り替えるようにしています

お手すきでレビューいただけると幸いです