### PR TITLE
Stabilize fast-input emulator test setup

### DIFF
--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -108,42 +108,157 @@ wait_for_android_services() {
   return 1
 }
 
+android_runtime_config() {
+  adb -s "$fast_input_emulator_serial" shell am get-config 2>/dev/null |
+    tr -d '\r' |
+    head -n 1
+}
+
+detach_emulated_at_keyboard() {
+  local adb_root_output
+  local atkbd_devices
+  local device_name
+  local runtime_config
+  local selinux_mode
+  local attempt
+
+  runtime_config="$(android_runtime_config)"
+  echo "Android runtime configuration before keyboard setup: $runtime_config" |
+    tee -a "$fast_input_readiness_log"
+  if [[ "$runtime_config" == *"-nokeys-"* ]]; then
+    return 0
+  fi
+
+  # The x86_64 ranchu machine can expose its translated PS/2 keyboard even when
+  # the AVD has hw.keyboard=no. IMEService correctly treats that device as a
+  # physical alphabetic keyboard, so remove the emulator-only device rather
+  # than adding a production exception for CI.
+  adb -s "$fast_input_emulator_serial" shell dumpsys input \
+    > "$fast_input_log_dir/input-service-before-keyboard-detach.txt" || true
+
+  adb_root_output="$(
+    adb -s "$fast_input_emulator_serial" root 2>&1 ||
+      true
+  )"
+  echo "adb root: $adb_root_output" | tee -a "$fast_input_readiness_log"
+  if ! adb -s "$fast_input_emulator_serial" wait-for-device; then
+    echo "The emulator did not reconnect after restarting adbd as root." |
+      tee -a "$fast_input_readiness_log"
+    return 1
+  fi
+  if ! wait_for_android_services 2>&1 | tee -a "$fast_input_readiness_log"; then
+    return 1
+  fi
+  if [[ "$(
+    adb -s "$fast_input_emulator_serial" shell id -u 2>/dev/null |
+      tr -d '\r'
+  )" != "0" ]]; then
+    echo "The google_apis emulator did not permit root ADB." |
+      tee -a "$fast_input_readiness_log"
+    return 1
+  fi
+
+  atkbd_devices="$(
+    adb -s "$fast_input_emulator_serial" shell \
+      'for link in /sys/bus/serio/drivers/atkbd/serio*; do
+        if [ -e "$link" ]; then basename "$link"; fi
+      done' 2>/dev/null |
+      tr -d '\r'
+  )"
+  if [[ -z "$atkbd_devices" ]]; then
+    echo "No bound atkbd device was found for runtime config [$runtime_config]." |
+      tee -a "$fast_input_readiness_log"
+    return 1
+  fi
+
+  selinux_mode="$(
+    adb -s "$fast_input_emulator_serial" shell getenforce 2>/dev/null |
+      tr -d '\r'
+  )"
+  while IFS= read -r device_name; do
+    if [[ ! "$device_name" =~ ^serio[0-9]+$ ]]; then
+      echo "Refusing unexpected atkbd device name [$device_name]." |
+        tee -a "$fast_input_readiness_log"
+      return 1
+    fi
+    echo "Detaching emulator AT keyboard $device_name." |
+      tee -a "$fast_input_readiness_log"
+    if ! adb -s "$fast_input_emulator_serial" shell \
+      "echo $device_name > /sys/bus/serio/drivers/atkbd/unbind"; then
+      if [[ "$selinux_mode" != "Enforcing" ]]; then
+        return 1
+      fi
+      echo "Retrying keyboard detach with SELinux temporarily permissive." |
+        tee -a "$fast_input_readiness_log"
+      adb -s "$fast_input_emulator_serial" shell setenforce 0
+      if ! adb -s "$fast_input_emulator_serial" shell \
+        "echo $device_name > /sys/bus/serio/drivers/atkbd/unbind"; then
+        adb -s "$fast_input_emulator_serial" shell setenforce 1 || true
+        return 1
+      fi
+      adb -s "$fast_input_emulator_serial" shell setenforce 1
+    fi
+  done <<< "$atkbd_devices"
+
+  for ((attempt = 1; attempt <= 30; attempt += 1)); do
+    runtime_config="$(android_runtime_config)"
+    if [[ "$runtime_config" == *"-nokeys-"* ]]; then
+      echo "Android runtime configuration after keyboard setup: $runtime_config" |
+        tee -a "$fast_input_readiness_log"
+      adb -s "$fast_input_emulator_serial" shell dumpsys input \
+        > "$fast_input_log_dir/input-service-after-keyboard-detach.txt" || true
+      return 0
+    fi
+    sleep 1
+  done
+
+  echo "AT keyboard detach did not produce a nokeys runtime configuration: " \
+    "[$runtime_config]." | tee -a "$fast_input_readiness_log"
+  adb -s "$fast_input_emulator_serial" shell dumpsys input \
+    > "$fast_input_log_dir/input-service-after-keyboard-detach.txt" || true
+  return 1
+}
+
 export ANDROID_SERIAL="$fast_input_emulator_serial"
 if ! wait_for_android_services 2>&1 | tee "$fast_input_readiness_log"; then
   exit 3
 fi
 
-adb shell settings put secure show_ime_with_hard_keyboard 1
+if ! detach_emulated_at_keyboard; then
+  exit 4
+fi
+
+adb -s "$fast_input_emulator_serial" shell \
+  settings put secure show_ime_with_hard_keyboard 1
 fast_input_show_ime_with_hard_keyboard="$(
-  adb shell settings get secure show_ime_with_hard_keyboard 2>/dev/null |
+  adb -s "$fast_input_emulator_serial" shell \
+    settings get secure show_ime_with_hard_keyboard 2>/dev/null |
     tr -d '\r'
 )"
 if [[ "$fast_input_show_ime_with_hard_keyboard" != "1" ]]; then
   echo "Unable to enable the software IME while hardware keys are present." |
     tee -a "$fast_input_readiness_log"
-  exit 4
+  exit 5
 fi
 
-fast_input_android_config="$(
-  adb shell am get-config 2>/dev/null |
-    tr -d '\r' |
-    head -n 1
-)"
+fast_input_android_config="$(android_runtime_config)"
 echo "Android runtime configuration: $fast_input_android_config" |
   tee -a "$fast_input_readiness_log"
 if [[ "$fast_input_android_config" != *"-nokeys-"* ]]; then
   echo "The emulator exposes a hardware keyboard; expected the nokeys configuration." |
     tee -a "$fast_input_readiness_log"
-  adb shell dumpsys input \
+  adb -s "$fast_input_emulator_serial" shell dumpsys input \
     > "$fast_input_log_dir/input-service-readiness-failure.txt" || true
-  exit 5
+  exit 6
 fi
 
-adb shell input keyevent KEYCODE_WAKEUP
-adb shell wm dismiss-keyguard
-adb shell dumpsys input > "$fast_input_log_dir/input-service-before-test.txt"
-adb shell dumpsys input_method > "$fast_input_log_dir/input-method-before-test.txt"
-adb logcat -c
+adb -s "$fast_input_emulator_serial" shell input keyevent KEYCODE_WAKEUP
+adb -s "$fast_input_emulator_serial" shell wm dismiss-keyguard
+adb -s "$fast_input_emulator_serial" shell dumpsys input \
+  > "$fast_input_log_dir/input-service-before-test.txt"
+adb -s "$fast_input_emulator_serial" shell dumpsys input_method \
+  > "$fast_input_log_dir/input-method-before-test.txt"
+adb -s "$fast_input_emulator_serial" logcat -c
 
 fast_input_test_method=\
 "com.kazumaproject.markdownhelperkeyboard.FastInputMatrixInstrumentedTest#rapidInputFullMatrixOnPhysicalDevice"
@@ -163,10 +278,13 @@ set +e
 fast_input_gradle_status=${PIPESTATUS[0]}
 set -e
 
-adb logcat -d -v threadtime > "$fast_input_log_dir/device-logcat.txt" || true
+adb -s "$fast_input_emulator_serial" logcat -d -v threadtime \
+  > "$fast_input_log_dir/device-logcat.txt" || true
 
-if adb shell test -d "$fast_input_device_output"; then
-  adb pull "$fast_input_device_output" "$fast_input_device_dir/" ||
+if adb -s "$fast_input_emulator_serial" shell \
+  test -d "$fast_input_device_output"; then
+  adb -s "$fast_input_emulator_serial" \
+    pull "$fast_input_device_output" "$fast_input_device_dir/" ||
     echo "Unable to pull fast-input screenshots from the emulator."
 fi
 

--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -10,6 +10,8 @@ fast_input_artifact_dir="${GITHUB_WORKSPACE:-.}/fast-input-artifacts"
 fast_input_log_dir="$fast_input_artifact_dir/logs"
 fast_input_device_dir="$fast_input_artifact_dir/device"
 fast_input_device_output="/sdcard/Android/data/com.kazumaproject.markdownhelperkeyboard/files/fast-input"
+fast_input_readiness_log="$fast_input_log_dir/android-readiness.log"
+fast_input_emulator_serial="${ANDROID_SERIAL:-emulator-${EMULATOR_PORT:-5554}}"
 
 is_positive_integer() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
@@ -36,10 +38,111 @@ fi
 
 mkdir -p "$fast_input_log_dir" "$fast_input_device_dir"
 
-adb wait-for-device
+wait_for_android_services() {
+  local attempt
+  local boot_completed
+  local device_state
+  local input_method_service
+  local package_service
+  local stable_samples=0
+
+  echo "Waiting for Android services on $fast_input_emulator_serial."
+  adb start-server >/dev/null 2>&1 || true
+
+  for ((attempt = 1; attempt <= 90; attempt += 1)); do
+    device_state="$(
+      adb -s "$fast_input_emulator_serial" get-state 2>/dev/null ||
+        true
+    )"
+    if [[ "$device_state" != "device" ]]; then
+      stable_samples=0
+      echo "Readiness attempt $attempt/90: adb state=${device_state:-unavailable}."
+      if [[ "$device_state" == "offline" && $((attempt % 5)) -eq 0 ]]; then
+        adb reconnect offline >/dev/null 2>&1 || true
+      fi
+      sleep 2
+      continue
+    fi
+
+    boot_completed="$(
+      adb -s "$fast_input_emulator_serial" \
+        shell getprop sys.boot_completed 2>/dev/null |
+        tr -d '\r' ||
+        true
+    )"
+    package_service="$(
+      adb -s "$fast_input_emulator_serial" \
+        shell service check package 2>/dev/null |
+        tr -d '\r' ||
+        true
+    )"
+    input_method_service="$(
+      adb -s "$fast_input_emulator_serial" \
+        shell service check input_method 2>/dev/null |
+        tr -d '\r' ||
+        true
+    )"
+
+    if [[ "$boot_completed" == "1" &&
+      "$package_service" == *"found"* &&
+      "$input_method_service" == *"found"* ]]; then
+      stable_samples=$((stable_samples + 1))
+      echo "Readiness attempt $attempt/90: stable sample $stable_samples/3."
+      if ((stable_samples >= 3)); then
+        echo "Android package and input-method services are stable."
+        return 0
+      fi
+    else
+      stable_samples=0
+      echo "Readiness attempt $attempt/90: boot=$boot_completed " \
+        "package=[$package_service] input_method=[$input_method_service]."
+    fi
+    sleep 2
+  done
+
+  echo "Android services did not become stable."
+  adb devices -l || true
+  adb -s "$fast_input_emulator_serial" shell getprop sys.boot_completed || true
+  adb -s "$fast_input_emulator_serial" shell service check package || true
+  adb -s "$fast_input_emulator_serial" shell service check input_method || true
+  return 1
+}
+
+export ANDROID_SERIAL="$fast_input_emulator_serial"
+if ! wait_for_android_services 2>&1 | tee "$fast_input_readiness_log"; then
+  exit 3
+fi
+
+adb shell settings put secure show_ime_with_hard_keyboard 1
+fast_input_show_ime_with_hard_keyboard="$(
+  adb shell settings get secure show_ime_with_hard_keyboard 2>/dev/null |
+    tr -d '\r'
+)"
+if [[ "$fast_input_show_ime_with_hard_keyboard" != "1" ]]; then
+  echo "Unable to enable the software IME while hardware keys are present." |
+    tee -a "$fast_input_readiness_log"
+  exit 4
+fi
+
+fast_input_android_config="$(
+  adb shell am get-config 2>/dev/null |
+    tr -d '\r' |
+    head -n 1
+)"
+echo "Android runtime configuration: $fast_input_android_config" |
+  tee -a "$fast_input_readiness_log"
+if [[ "$fast_input_android_config" != *"-nokeys-"* ]]; then
+  echo "The emulator exposes a hardware keyboard; expected the nokeys configuration." |
+    tee -a "$fast_input_readiness_log"
+  adb shell dumpsys input \
+    > "$fast_input_log_dir/input-service-readiness-failure.txt" || true
+  exit 5
+fi
+
 adb shell input keyevent KEYCODE_WAKEUP
 adb shell wm dismiss-keyguard
-adb shell settings put secure show_ime_with_hard_keyboard 1
+adb shell dumpsys input > "$fast_input_log_dir/input-service-before-test.txt"
+adb shell dumpsys input_method > "$fast_input_log_dir/input-method-before-test.txt"
 adb logcat -c
 
 fast_input_test_method=\

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -105,7 +105,8 @@ jobs:
           disable-animations: false
           disable-spellchecker: true
           # android-emulator-runner only adds hw.keyboard=yes when this input is true.
-          # Explicitly override the Pixel profile so the test exercises the software IME.
+          # Explicitly override the Pixel profile as the first line of defense. The
+          # test script also detaches x86_64 ranchu's translated PS/2 keyboard.
           # Keep this folded into one command because the action parses each line separately.
           pre-emulator-launch-script: >-
             avd_config="${ANDROID_AVD_HOME}/test.avd/config.ini" &&

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -104,6 +104,14 @@ jobs:
           enable-hw-keyboard: false
           disable-animations: false
           disable-spellchecker: true
+          # android-emulator-runner only adds hw.keyboard=yes when this input is true.
+          # Explicitly override the Pixel profile so the test exercises the software IME.
+          # Keep this folded into one command because the action parses each line separately.
+          pre-emulator-launch-script: >-
+            avd_config="${ANDROID_AVD_HOME}/test.avd/config.ini" &&
+            sed -i '/^[[:space:]]*hw\.keyboard[[:space:]]*=/d' "$avd_config" &&
+            printf '%s\n' 'hw.keyboard=no' >> "$avd_config" &&
+            grep '^hw.keyboard=no$' "$avd_config"
           emulator-options: >-
             -no-window -gpu swiftshader_indirect -no-snapshot
             -noaudio -no-boot-anim -camera-back none

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -35,7 +35,7 @@ jobs:
   fast-input-regression:
     name: Pixel 6 Pro API 35
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 120
     env:
       ZENZ_MODEL_CACHE_DIR: ${{ github.workspace }}/.zenz-model-cache
       ZENZ_DEBUG_NATIVE_ABIS: x86_64

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -15,12 +15,14 @@ import android.os.Bundle
 import android.os.ParcelFileDescriptor
 import android.os.PowerManager
 import android.os.SystemClock
+import android.provider.Settings
 import android.util.Log
 import android.view.InputDevice
 import android.view.MotionEvent
-import android.view.WindowInsets
 import android.view.accessibility.AccessibilityNodeInfo
 import android.view.inputmethod.InputMethodManager
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -89,7 +91,7 @@ class FastInputMatrixInstrumentedTest {
                     "Failed to prepare the TenKey number-guide scenario"
                 }
 
-                reloadIme(session)
+                ensureTargetImeSelected(session)
                 restartInput(scenario)
                 SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
                 assertDeviceReady(session.context, session.targetIme, scenario)
@@ -150,7 +152,7 @@ class FastInputMatrixInstrumentedTest {
                 ) {
                     "Failed to disable the TenKey number guide for the control measurement"
                 }
-                reloadIme(session)
+                ensureTargetImeSelected(session)
                 restartInput(scenario)
                 SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
                 val legacyBounds = awaitVisibleNodeBounds("key_small_letter")
@@ -203,7 +205,7 @@ class FastInputMatrixInstrumentedTest {
                             .putBoolean("qwerty_glide_input_preference", glideEnabled)
                             .commit()
                     )
-                    reloadIme(session)
+                    ensureTargetImeSelected(session)
                     restartInput(scenario)
                     SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
                     assertDeviceReady(session.context, session.targetIme, scenario)
@@ -268,7 +270,7 @@ class FastInputMatrixInstrumentedTest {
                             .putBoolean("qwerty_glide_input_preference", glideEnabled)
                             .commit()
                     )
-                    reloadIme(session)
+                    ensureTargetImeSelected(session)
                     restartInput(scenario)
                     SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
                     assertDeviceReady(session.context, session.targetIme, scenario)
@@ -389,7 +391,7 @@ class FastInputMatrixInstrumentedTest {
                                         )
                                         val configKey = "case-$caseIndex-${testCase.fileToken()}"
                                         applyCasePreferences(session.preferences, testCase)
-                                        reloadIme(session)
+                                        ensureTargetImeSelected(session)
                                         restartInput(scenario)
                                         SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
                                         if (casePauseMs > 0L) SystemClock.sleep(casePauseMs)
@@ -462,6 +464,7 @@ class FastInputMatrixInstrumentedTest {
                                             if (screenshots.add(configKey)) {
                                                 saveScreenshot(session, configKey)
                                             }
+                                            throw SetupException(result, error)
                                         }
 
                                         completedConfigurations += 1
@@ -577,7 +580,7 @@ class FastInputMatrixInstrumentedTest {
                                 )
                                 val configKey = "rate-${testCase.fileToken()}"
                                 applyCasePreferences(session.preferences, testCase)
-                                reloadIme(session)
+                                ensureTargetImeSelected(session)
                                 restartInput(scenario)
                                 SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
 
@@ -944,18 +947,58 @@ class FastInputMatrixInstrumentedTest {
     }
 
     private fun restartInput(scenario: ActivityScenario<FastInputHostActivity>) {
+        awaitHostWindowFocus(scenario)
         scenario.onActivity { activity ->
-            activity.editText.setText("")
-            activity.editText.requestFocus()
-            activity.editText.setSelection(0)
-            val inputMethodManager = activity.getSystemService(InputMethodManager::class.java)
-            inputMethodManager.restartInput(activity.editText)
-            activity.editText.windowInsetsController?.show(WindowInsets.Type.ime())
-            inputMethodManager.showSoftInput(
-                activity.editText,
-                InputMethodManager.SHOW_FORCED
-            )
+            activity.restartEditorInput(clearText = true)
         }
+
+        val deadline = SystemClock.uptimeMillis() + EDITOR_CONNECTION_TIMEOUT_MS
+        var stableSamples = 0
+        var lastState = "host activity unavailable"
+        while (SystemClock.uptimeMillis() < deadline) {
+            var ready = false
+            scenario.onActivity { activity ->
+                val editor = activity.editText
+                val inputMethodManager =
+                    activity.getSystemService(InputMethodManager::class.java)
+                val attached = editor.isAttachedToWindow
+                val windowFocused = editor.hasWindowFocus()
+                val viewFocused = editor.hasFocus()
+                val shown = editor.isShown
+                val active = inputMethodManager.isActive(editor)
+                val acceptingText = inputMethodManager.isAcceptingText
+                val imeVisible = ViewCompat.getRootWindowInsets(editor)
+                    ?.isVisible(WindowInsetsCompat.Type.ime()) == true
+
+                ready = attached &&
+                    windowFocused &&
+                    viewFocused &&
+                    shown &&
+                    active &&
+                    acceptingText &&
+                    imeVisible
+                lastState =
+                    "attached=$attached windowFocused=$windowFocused " +
+                        "viewFocused=$viewFocused shown=$shown active=$active " +
+                        "acceptingText=$acceptingText imeVisible=$imeVisible"
+                if (!ready) {
+                    activity.requestImeForEditor()
+                }
+            }
+
+            if (ready) {
+                stableSamples += 1
+                if (stableSamples >= EDITOR_CONNECTION_STABLE_SAMPLES) return
+            } else {
+                stableSamples = 0
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+
+        throw SetupException(
+            "Host editor was not served by InputMethodManager " +
+                "within ${EDITOR_CONNECTION_TIMEOUT_MS}ms ($lastState)"
+        )
     }
 
     private fun prepareEmptyEditor(scenario: ActivityScenario<FastInputHostActivity>) {
@@ -1587,8 +1630,61 @@ class FastInputMatrixInstrumentedTest {
             Intent(context, FastInputHostActivity::class.java)
                 .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         )
-        SystemClock.sleep(HOST_LAUNCH_SETTLE_MS)
+        awaitHostWindowFocus(scenario)
         return scenario
+    }
+
+    private fun awaitHostWindowFocus(
+        scenario: ActivityScenario<FastInputHostActivity>
+    ) {
+        val startedAt = SystemClock.uptimeMillis()
+        val deadline = startedAt + HOST_WINDOW_FOCUS_TIMEOUT_MS
+        var recreated = false
+        var lastState = "host activity unavailable"
+
+        while (SystemClock.uptimeMillis() < deadline) {
+            var ready = false
+            scenario.onActivity { activity ->
+                val editor = activity.editText
+                val attached = editor.isAttachedToWindow
+                val decorFocused = activity.window.decorView.hasWindowFocus()
+                val editorWindowFocused = editor.hasWindowFocus()
+                val editorFocused = editor.hasFocus()
+                val shown = editor.isShown
+                ready = attached &&
+                    decorFocused &&
+                    editorWindowFocused &&
+                    editorFocused &&
+                    shown
+                lastState =
+                    "attached=$attached decorFocused=$decorFocused " +
+                        "editorWindowFocused=$editorWindowFocused " +
+                        "editorFocused=$editorFocused shown=$shown"
+                if (decorFocused) {
+                    activity.requestImeForEditor()
+                }
+            }
+            if (ready) return
+
+            if (
+                !recreated &&
+                SystemClock.uptimeMillis() - startedAt >= HOST_WINDOW_RECREATE_AFTER_MS
+            ) {
+                Log.w(TAG, "Recreating host after window-focus timeout ($lastState)")
+                scenario.recreate()
+                recreated = true
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+
+        val focusedWindow = shell(
+            "dumpsys window windows | grep -E 'mCurrentFocus|mFocusedApp'"
+        ).replace('\n', ' ')
+        throw SetupException(
+            "Host activity did not gain window focus " +
+                "within ${HOST_WINDOW_FOCUS_TIMEOUT_MS}ms " +
+                "($lastState, windowManager=[$focusedWindow])"
+        )
     }
 
     private fun assertDeviceReady(
@@ -1604,7 +1700,7 @@ class FastInputMatrixInstrumentedTest {
         if (keyguardManager.isKeyguardLocked) {
             throw SetupException("Device is locked by keyguard")
         }
-        val currentIme = shell("settings get secure default_input_method")
+        val currentIme = currentIme(context)
         if (!sameComponent(currentIme, expectedIme)) {
             throw SetupException("Default IME is [$currentIme], expected [$expectedIme]")
         }
@@ -1636,24 +1732,15 @@ class FastInputMatrixInstrumentedTest {
         configureAccessibilityInspection()
         val preferences = PreferenceManager.getDefaultSharedPreferences(context)
         val originalPreferences = preferences.all.toMap()
-        val originalIme = shell("settings get secure default_input_method")
+        val originalIme = currentIme(context)
             .takeUnless { it.isBlank() || it == "null" }
         val expectedTargetIme =
             "${context.packageName}/" +
                 "com.kazumaproject.markdownhelperkeyboard.ime_service.IMEService"
-        // `-a` also returns installed-but-disabled IMEs. Android 16 reports those entries but
-        // rejects `ime set`, so only select a reload fallback from the currently enabled list.
-        val installedImeIds = shell("ime list -s")
-            .lineSequence()
-            .map(String::trim)
-            .filter(String::isNotEmpty)
-            .toList()
-        val targetIme = installedImeIds
-            .firstOrNull { sameComponent(it, expectedTargetIme) }
-            ?: expectedTargetIme
-        val fallbackIme = installedImeIds
-            .filterNot { sameComponent(it, targetIme) }
-            .minByOrNull(::imeReloadFallbackPriority)
+        val enabledImeIds = listImeIds(includeDisabled = false)
+        val targetImeInitiallyEnabled =
+            enabledImeIds.any { sameComponent(it, expectedTargetIme) }
+        val targetIme = awaitAvailableIme(expectedTargetIme)
         val outputDirectory = File(
             context.getExternalFilesDir("fast-input"),
             "${name}-${System.currentTimeMillis()}"
@@ -1665,27 +1752,33 @@ class FastInputMatrixInstrumentedTest {
             context = context,
             preferences = preferences,
             targetIme = targetIme,
-            fallbackIme = fallbackIme,
             originalIme = originalIme,
+            targetImeInitiallyEnabled = targetImeInitiallyEnabled,
             outputDirectory = outputDirectory
         )
 
         sendProgress(
             "FAST_INPUT_SESSION name=$name device=${android.os.Build.MODEL} " +
                 "sdk=${android.os.Build.VERSION.SDK_INT} output=$outputDirectory " +
-                "originalIme=$originalIme fallbackIme=$fallbackIme\n"
+                "originalIme=$originalIme initiallyEnabled=$targetImeInitiallyEnabled\n"
         )
 
         try {
-            setIme(targetIme)
+            setIme(context, targetIme)
             assertDeviceReady(context, targetIme)
             block(session)
         } finally {
             restorePreferences(preferences, originalPreferences)
-            // Reload the restored settings before handing the device back.
-            runCatching { setIme(targetIme) }
             if (originalIme != null) {
-                runCatching { setIme(originalIme) }
+                runCatching { setIme(context, originalIme) }
+                    .onFailure { reportImeRestoreFailure("restore default", originalIme, it) }
+            }
+            if (
+                !targetImeInitiallyEnabled &&
+                (originalIme == null || !sameComponent(originalIme, targetIme))
+            ) {
+                runCatching { disableIme(targetIme) }
+                    .onFailure { reportImeRestoreFailure("restore enabled state", targetIme, it) }
             }
             uiAutomation.setRotation(UiAutomation.ROTATION_UNFREEZE)
             sendProgress(
@@ -1709,22 +1802,58 @@ class FastInputMatrixInstrumentedTest {
         }
     }
 
-    private fun reloadIme(session: PhysicalDeviceSession) {
-        session.fallbackIme?.let {
-            setIme(it)
-            SystemClock.sleep(IME_TOGGLE_SETTLE_MS)
-        }
-        setIme(session.targetIme)
-        SystemClock.sleep(IME_RELOAD_SETTLE_MS)
-        if (!sameComponent(shell("settings get secure default_input_method"), session.targetIme)) {
-            // A cold emulator can fall back while the target IME process is still starting.
-            // Re-select only for setup; the measured key timing below remains unchanged.
-            setIme(session.targetIme)
-            SystemClock.sleep(IME_RELOAD_SETTLE_MS)
+    private fun ensureTargetImeSelected(session: PhysicalDeviceSession) {
+        if (!sameComponent(currentIme(session.context), session.targetIme)) {
+            setIme(session.context, session.targetIme)
         }
     }
 
-    private fun setIme(component: String) {
+    private fun awaitAvailableIme(component: String): String {
+        val deadline = SystemClock.uptimeMillis() + IME_REGISTRATION_TIMEOUT_MS
+        var availableImeIds = emptyList<String>()
+        while (SystemClock.uptimeMillis() < deadline) {
+            availableImeIds = listImeIds(includeDisabled = true)
+            availableImeIds.firstOrNull { sameComponent(it, component) }?.let { return it }
+            SystemClock.sleep(IME_STATE_POLL_MS)
+        }
+        throw SetupException(
+            "IME was not registered by InputMethodManager: target=$component " +
+                "available=$availableImeIds enabled=${listImeIds(includeDisabled = false)}"
+        )
+    }
+
+    private fun ensureImeEnabled(component: String) {
+        val deadline = SystemClock.uptimeMillis() + IME_ENABLE_TIMEOUT_MS
+        var enabledImeIds = listImeIds(includeDisabled = false)
+        while (SystemClock.uptimeMillis() < deadline) {
+            if (enabledImeIds.any { sameComponent(it, component) }) return
+            shell("ime enable $component")
+            SystemClock.sleep(IME_STATE_POLL_MS)
+            enabledImeIds = listImeIds(includeDisabled = false)
+        }
+        throw SetupException(
+            "Unable to enable IME $component; " +
+                "available=${listImeIds(includeDisabled = true)} enabled=$enabledImeIds"
+        )
+    }
+
+    private fun disableIme(component: String) {
+        val deadline = SystemClock.uptimeMillis() + IME_ENABLE_TIMEOUT_MS
+        var enabledImeIds = listImeIds(includeDisabled = false)
+        while (SystemClock.uptimeMillis() < deadline) {
+            if (enabledImeIds.none { sameComponent(it, component) }) return
+            shell("ime disable $component")
+            SystemClock.sleep(IME_STATE_POLL_MS)
+            enabledImeIds = listImeIds(includeDisabled = false)
+        }
+        throw SetupException(
+            "Unable to restore disabled state for IME $component; enabled=$enabledImeIds"
+        )
+    }
+
+    private fun setIme(context: Context, component: String) {
+        awaitAvailableIme(component)
+        ensureImeEnabled(component)
         val deadline = SystemClock.uptimeMillis() + IME_SWITCH_TIMEOUT_MS
         while (SystemClock.uptimeMillis() < deadline) {
             shell("ime set $component")
@@ -1733,18 +1862,37 @@ class FastInputMatrixInstrumentedTest {
                 SystemClock.uptimeMillis() + IME_SWITCH_RETRY_MS
             )
             while (SystemClock.uptimeMillis() < attemptDeadline) {
-                if (
-                    sameComponent(
-                        shell("settings get secure default_input_method"),
-                        component
-                    )
-                ) {
+                if (sameComponent(currentIme(context), component)) {
                     return
                 }
                 SystemClock.sleep(POLL_MS)
             }
         }
-        throw SetupException("Unable to select IME $component")
+        throw SetupException(
+            "Unable to select IME $component; current=${currentIme(context)} " +
+                "available=${listImeIds(includeDisabled = true)} " +
+                "enabled=${listImeIds(includeDisabled = false)}"
+        )
+    }
+
+    private fun currentIme(context: Context): String =
+        Settings.Secure.getString(
+            context.contentResolver,
+            Settings.Secure.DEFAULT_INPUT_METHOD
+        ).orEmpty().trim()
+
+    private fun listImeIds(includeDisabled: Boolean): List<String> =
+        shell(if (includeDisabled) "ime list -a -s" else "ime list -s")
+            .lineSequence()
+            .map(String::trim)
+            .filter(String::isNotEmpty)
+            .toList()
+
+    private fun reportImeRestoreFailure(action: String, component: String, error: Throwable) {
+        val message =
+            "FAST_INPUT_RESTORE_ERROR action=$action ime=$component error=${error.message}\n"
+        Log.e(TAG, message.trim(), error)
+        sendProgress(message)
     }
 
     private fun sameComponent(first: String, second: String): Boolean {
@@ -1754,17 +1902,6 @@ class FastInputMatrixInstrumentedTest {
             firstComponent == secondComponent
         } else {
             first == second
-        }
-    }
-
-    private fun imeReloadFallbackPriority(component: String): Int {
-        return when (ComponentName.unflattenFromString(component)?.packageName) {
-            // The system keyboard remains selectable through repeated switches on stock devices.
-            "com.google.android.inputmethod.latin" -> 0
-            // An alternate installed build is also a keyboard-mode IME and is a safe fallback.
-            "com.kazumaproject.markdownhelperkeyboard.lite.fdroid" -> 1
-            // Auxiliary voice IMEs and third-party IMEs may reject repeated `ime set` calls.
-            else -> 2
         }
     }
 
@@ -1906,8 +2043,8 @@ class FastInputMatrixInstrumentedTest {
         val context: Context,
         val preferences: SharedPreferences,
         val targetIme: String,
-        val fallbackIme: String?,
         val originalIme: String?,
+        val targetImeInitiallyEnabled: Boolean,
         val outputDirectory: File
     )
 
@@ -2078,7 +2215,10 @@ class FastInputMatrixInstrumentedTest {
             "expected=$expected,yaNa=$yaNa,other=$other,missing=$missing"
     }
 
-    private class SetupException(message: String) : RuntimeException(message)
+    private class SetupException(
+        message: String,
+        cause: Throwable? = null
+    ) : RuntimeException(message, cause)
 
     companion object {
         private const val TAG = "FastInputMatrix"
@@ -2103,10 +2243,14 @@ class FastInputMatrixInstrumentedTest {
         private const val RESULT_TIMEOUT_MS = 1_000L
         private const val ORIENTATION_TIMEOUT_MS = 4_000L
         private const val ORIENTATION_SETTLE_MS = 500L
-        private const val HOST_LAUNCH_SETTLE_MS = 1_000L
+        private const val HOST_WINDOW_FOCUS_TIMEOUT_MS = 15_000L
+        private const val HOST_WINDOW_RECREATE_AFTER_MS = 4_000L
         private const val IME_LAYOUT_SETTLE_MS = 350L
-        private const val IME_TOGGLE_SETTLE_MS = 100L
-        private const val IME_RELOAD_SETTLE_MS = 600L
+        private const val EDITOR_CONNECTION_TIMEOUT_MS = 10_000L
+        private const val EDITOR_CONNECTION_STABLE_SAMPLES = 3
+        private const val IME_STATE_POLL_MS = 250L
+        private const val IME_REGISTRATION_TIMEOUT_MS = 30_000L
+        private const val IME_ENABLE_TIMEOUT_MS = 15_000L
         private const val IME_SWITCH_TIMEOUT_MS = 15_000L
         private const val IME_SWITCH_RETRY_MS = 1_000L
         private const val TOTAL_CASES = 3 * 3 * 2 * 2 * 2 * 2

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
@@ -2,12 +2,13 @@ package com.kazumaproject.markdownhelperkeyboard
 
 import android.app.Activity
 import android.os.Bundle
-import android.view.WindowInsets
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 
 class FastInputHostActivity : Activity() {
     lateinit var editText: EditText
@@ -50,10 +51,41 @@ class FastInputHostActivity : Activity() {
                 WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE
         )
         editText.requestFocus()
-        editText.postDelayed({
-            editText.windowInsetsController?.show(WindowInsets.Type.ime())
-            getSystemService(InputMethodManager::class.java)
-                .showSoftInput(editText, InputMethodManager.SHOW_FORCED)
-        }, 250L)
+    }
+
+    override fun onWindowFocusChanged(hasFocus: Boolean) {
+        super.onWindowFocusChanged(hasFocus)
+        if (hasFocus) {
+            editText.requestFocus()
+            getSystemService(InputMethodManager::class.java).restartInput(editText)
+            requestImeForEditor()
+        }
+    }
+
+    /**
+     * Reconnects the editor without changing the selected IME.
+     *
+     * Switching the default IME while this window owns focus tears down the served editor. The
+     * matrix test only needs InputMethodService.onStartInput() to reload its preferences, so a
+     * restart on the existing connection is both sufficient and deterministic.
+     */
+    fun restartEditorInput(clearText: Boolean) {
+        if (clearText) {
+            editText.setText("")
+        }
+        editText.requestFocus()
+        editText.setSelection(editText.text.length)
+        getSystemService(InputMethodManager::class.java).restartInput(editText)
+        requestImeForEditor()
+    }
+
+    fun requestImeForEditor() {
+        if (!editText.hasWindowFocus()) return
+        editText.post {
+            if (isFinishing || isDestroyed) return@post
+            editText.requestFocus()
+            WindowCompat.getInsetsController(window, editText)
+                .show(WindowInsetsCompat.Type.ime())
+        }
     }
 }


### PR DESCRIPTION
## Summary

- wait for stable ADB, boot completion, package service, and input-method service before connected tests
- enable, select, retry, and verify the target IME entirely from test code
- detach the x86_64 emulator translated PS/2 keyboard so the existing production hardware-keyboard detection sees the intended software-keyboard environment
- wait for host editor focus, InputMethodManager readiness, and visible IME before input injection
- increase the workflow timeout to leave safe headroom for the complete matrix

No app/src/main production code is changed.

## Root cause

The runner could enter the test during an ADB offline/service-startup window. In addition, the x86_64 emulator exposed an AT Translated Set 2 keyboard even with hw.keyboard=no, so the existing IMEService correctly entered physical-keyboard mode. The test also attempted IME selection without first proving that the IME was registered and enabled.

## Verification

- local: ./gradlew :app:compileFullStandardDebugAndroidTestKotlin --no-daemon --max-workers=2
- full matrix CI: https://github.com/KazumaProject/JapaneseKeyboard/actions/runs/30260312385
  - configurations 144/144
  - measurements 144/144
  - phases 288
  - misinputOrInjection 0
  - setupErrors 0
  - JUnit failures 0, errors 0
- final-head smoke CI: https://github.com/KazumaProject/JapaneseKeyboard/actions/runs/30264594655