### PR TITLE
feature: Add fullscreen mode configuration

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -4902,6 +4902,22 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         return true
     }
 
+
+    override fun onEvaluateFullscreenMode(): Boolean {
+        val isFullscreenModeAllowed: Boolean =
+            resources.getBoolean(R.bool.config_allow_fullscreen_mode)
+
+        if (super.onEvaluateFullscreenMode() && isFullscreenModeAllowed) {
+            // TODO: Remove this hack. Actually we should not really assume NO_EXTRACT_UI
+            // implies NO_FULLSCREEN. However, the framework mistakenly does.  i.e. NO_EXTRACT_UI
+            // without NO_FULLSCREEN doesn't work as expected. Because of this we need this
+            // hack for now.  Let's get rid of this once the framework gets fixed.
+            val ei = getCurrentInputEditorInfo()
+            return !(ei != null && ((ei.imeOptions and EditorInfo.IME_FLAG_NO_EXTRACT_UI) != 0))
+        }
+        return false
+    }
+
     /**
      * FloatingDockViewを非表示にします。
      */

--- a/app/src/main/res/values-small/config.xml
+++ b/app/src/main/res/values-small/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_allow_fullscreen_mode">true</bool>
+</resources>

--- a/app/src/main/res/values/config.xml
+++ b/app/src/main/res/values/config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <bool name="config_allow_fullscreen_mode">false</bool>
+</resources>


### PR DESCRIPTION
The current implementation falls to the default InputMethodService.java implementation to show keyboard on full screen at all times on landscape mode. This is not desired for screens with larger screen. In fact is ti desired for screens for small screens only.

This commit introduces a new configuration option to allow or disallow fullscreen mode for the keyboard. A new method onEvaluateFullscreenMode is added to IMEService to handle this setting. The default configuration is set to 'false' for standard displays and 'true' for small displays.

This is similar to the implementation for LatinIME.java on android.googlesource.com/platform/packages/inputmethods/LatinIME.