### PR TITLE
Androidのインラインオートフィル候補に対応

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1068,6 +1068,7 @@ dependencies {
     implementation 'androidx.navigation:navigation-fragment-ktx:2.9.0'
     implementation 'androidx.navigation:navigation-ui-ktx:2.9.0'
     implementation 'androidx.preference:preference-ktx:1.2.1'
+    implementation 'androidx.autofill:autofill:1.3.0'
     implementation project(':flexbox')
     implementation project(':tenkey')
     implementation project(':core')

--- a/app/src/androidTest/AndroidManifest.xml
+++ b/app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="com.kazumaproject.markdownhelperkeyboard.qa.InlineAutofillLoginActivity"
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:theme="@android:style/Theme.Material.Light.NoActionBar"
+            android:windowSoftInputMode="adjustResize|stateAlwaysVisible" />
+    </application>
+</manifest>

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/qa/InlineAutofillLoginActivity.java
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/qa/InlineAutofillLoginActivity.java
@@ -1,0 +1,85 @@
+package com.kazumaproject.markdownhelperkeyboard.qa;
+
+import android.app.Activity;
+import android.graphics.Color;
+import android.os.Bundle;
+import android.text.InputType;
+import android.view.Gravity;
+import android.view.View;
+import android.view.WindowManager;
+import android.view.inputmethod.InputMethodManager;
+import android.widget.EditText;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+/** Separate test-APK activity used as the client of the debug AutofillService. */
+public final class InlineAutofillLoginActivity extends Activity {
+    private EditText usernameField;
+    private EditText passwordField;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getWindow().setSoftInputMode(
+                WindowManager.LayoutParams.SOFT_INPUT_ADJUST_RESIZE
+                        | WindowManager.LayoutParams.SOFT_INPUT_STATE_ALWAYS_VISIBLE);
+
+        usernameField = new EditText(this);
+        usernameField.setHint("ユーザー名");
+        usernameField.setInputType(
+                InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_EMAIL_ADDRESS);
+        usernameField.setAutofillHints(View.AUTOFILL_HINT_USERNAME, View.AUTOFILL_HINT_EMAIL_ADDRESS);
+        usernameField.setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_YES);
+        usernameField.setLayoutParams(fieldLayoutParams());
+
+        passwordField = new EditText(this);
+        passwordField.setHint("パスワード");
+        passwordField.setInputType(
+                InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
+        passwordField.setAutofillHints(View.AUTOFILL_HINT_PASSWORD);
+        passwordField.setImportantForAutofill(View.IMPORTANT_FOR_AUTOFILL_YES);
+        passwordField.setLayoutParams(fieldLayoutParams());
+
+        LinearLayout content = new LinearLayout(this);
+        content.setOrientation(LinearLayout.VERTICAL);
+        content.setGravity(Gravity.CENTER_HORIZONTAL);
+        content.setPadding(dp(24), dp(32), dp(24), dp(16));
+        content.setBackgroundColor(Color.WHITE);
+
+        TextView title = new TextView(this);
+        title.setText("Inline Autofill QA");
+        title.setTextSize(24f);
+        title.setTextColor(Color.BLACK);
+        content.addView(title);
+
+        TextView notice = new TextView(this);
+        notice.setText("架空のテストアカウントのみを使用しています");
+        notice.setTextSize(14f);
+        notice.setTextColor(Color.DKGRAY);
+        notice.setPadding(0, dp(8), 0, dp(16));
+        content.addView(notice);
+        content.addView(usernameField);
+        content.addView(passwordField);
+        setContentView(content);
+
+        passwordField.postDelayed(() -> {
+            passwordField.requestFocus();
+            InputMethodManager inputMethodManager = getSystemService(InputMethodManager.class);
+            inputMethodManager.showSoftInput(passwordField, InputMethodManager.SHOW_IMPLICIT);
+            // Let the initially focused username field bind the IME first. Moving to password
+            // afterwards gives the framework a live IME host token for inline rendering.
+        }, 3000L);
+    }
+
+    private LinearLayout.LayoutParams fieldLayoutParams() {
+        LinearLayout.LayoutParams params = new LinearLayout.LayoutParams(
+                LinearLayout.LayoutParams.MATCH_PARENT,
+                dp(56));
+        params.bottomMargin = dp(12);
+        return params;
+    }
+
+    private int dp(int value) {
+        return (int) (value * getResources().getDisplayMetrics().density);
+    }
+}

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,6 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
     <application>
+        <activity
+            android:name=".autofill.DebugInlineAutofillAttributionActivity"
+            android:exported="false"
+            android:theme="@android:style/Theme.Material.Light.Dialog.Alert" />
+
+        <service
+            android:name=".autofill.DebugInlineAutofillService"
+            android:exported="true"
+            android:label="Sumire Inline Autofill QA"
+            android:permission="android.permission.BIND_AUTOFILL_SERVICE"
+            tools:targetApi="r">
+            <intent-filter>
+                <action android:name="android.service.autofill.AutofillService" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.autofill"
+                android:resource="@xml/debug_inline_autofill_service" />
+        </service>
+
         <activity
             android:name=".FastInputHostActivity"
             android:exported="true"

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/autofill/DebugInlineAutofillAttributionActivity.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/autofill/DebugInlineAutofillAttributionActivity.kt
@@ -1,0 +1,18 @@
+package com.kazumaproject.markdownhelperkeyboard.autofill
+
+import android.app.Activity
+import android.os.Bundle
+import android.widget.TextView
+
+/** Attribution target required by the Slice used in the debug inline presentation. */
+class DebugInlineAutofillAttributionActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(
+            TextView(this).apply {
+                text = "Sumire Inline Autofill QA provider"
+                setPadding(48, 48, 48, 48)
+            }
+        )
+    }
+}

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/autofill/DebugInlineAutofillService.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/autofill/DebugInlineAutofillService.kt
@@ -1,0 +1,225 @@
+package com.kazumaproject.markdownhelperkeyboard.autofill
+
+import android.annotation.SuppressLint
+import android.app.PendingIntent
+import android.app.assist.AssistStructure
+import android.content.Intent
+import android.os.Build
+import android.os.CancellationSignal
+import android.service.autofill.AutofillService
+import android.service.autofill.Dataset
+import android.service.autofill.Field
+import android.service.autofill.FillCallback
+import android.service.autofill.FillRequest
+import android.service.autofill.FillResponse
+import android.service.autofill.InlinePresentation
+import android.service.autofill.Presentations
+import android.service.autofill.SaveCallback
+import android.service.autofill.SaveRequest
+import android.util.Log
+import android.view.View
+import android.view.autofill.AutofillId
+import android.view.autofill.AutofillValue
+import android.view.inputmethod.InlineSuggestionsRequest
+import android.widget.RemoteViews
+import androidx.annotation.RequiresApi
+import androidx.autofill.inline.v1.InlineSuggestionUi
+import com.kazumaproject.markdownhelperkeyboard.R
+
+/**
+ * Debug-only deterministic AutofillService used to exercise the real framework/IME pipeline.
+ */
+@RequiresApi(Build.VERSION_CODES.R)
+class DebugInlineAutofillService : AutofillService() {
+
+    override fun onFillRequest(
+        request: FillRequest,
+        cancellationSignal: CancellationSignal,
+        callback: FillCallback,
+    ) {
+        val structure = request.fillContexts.lastOrNull()?.structure
+        val fields = structure?.let(::findAutofillFields).orEmpty()
+        if (fields.isEmpty() || cancellationSignal.isCanceled) {
+            Log.d(TAG, "No supported fields in debug Autofill request")
+            callback.onSuccess(null)
+            return
+        }
+
+        val inlineRequest = request.inlineSuggestionsRequest
+        val response = FillResponse.Builder().apply {
+            QA_DATASETS.forEachIndexed { index, qaDataset ->
+                addDataset(buildDataset(fields, qaDataset, inlineRequest, index))
+            }
+        }.build()
+        Log.d(
+            TAG,
+            "Returning ${QA_DATASETS.size} datasets for ${fields.size} fields; " +
+                "inline=${inlineRequest != null}",
+        )
+        callback.onSuccess(response)
+    }
+
+    override fun onSaveRequest(request: SaveRequest, callback: SaveCallback) {
+        callback.onSuccess()
+    }
+
+    private fun findAutofillFields(structure: AssistStructure): List<AutofillField> = buildList {
+        for (windowIndex in 0 until structure.windowNodeCount) {
+            collectFields(structure.getWindowNodeAt(windowIndex).rootViewNode, this)
+        }
+    }
+
+    private fun collectFields(
+        node: AssistStructure.ViewNode,
+        destination: MutableList<AutofillField>,
+    ) {
+        val id = node.autofillId
+        val kind = resolveFieldKind(node)
+        if (id != null && kind != null) {
+            destination += AutofillField(id, kind)
+        }
+        for (childIndex in 0 until node.childCount) {
+            collectFields(node.getChildAt(childIndex), destination)
+        }
+    }
+
+    private fun resolveFieldKind(node: AssistStructure.ViewNode): FieldKind? {
+        val hints = node.autofillHints.orEmpty().map(String::lowercase)
+        return when {
+            hints.any { it.contains("password") } -> FieldKind.Password
+            hints.any { it.contains("username") || it.contains("email") } -> FieldKind.Username
+            node.inputType and android.text.InputType.TYPE_TEXT_VARIATION_PASSWORD != 0 ->
+                FieldKind.Password
+            else -> null
+        }
+    }
+
+    // SlicedContent.slice is the bridge required by InlinePresentation. AndroidX
+    // exposes it publicly but currently annotates the accessor as RestrictedApi.
+    @SuppressLint("RestrictedApi")
+    private fun buildDataset(
+        fields: List<AutofillField>,
+        qaDataset: QaDataset,
+        inlineRequest: InlineSuggestionsRequest?,
+        datasetIndex: Int,
+    ): Dataset {
+        val menuPresentation = menuPresentation(qaDataset.label)
+        val inlinePresentation = inlineRequest?.let { request ->
+            val specs = request.inlinePresentationSpecs
+            if (specs.isEmpty()) null else {
+                val spec = specs[datasetIndex.coerceAtMost(specs.lastIndex)]
+                InlinePresentation(
+                    InlineSuggestionUi.newContentBuilder(attributionPendingIntent(datasetIndex))
+                        .setTitle(qaDataset.label)
+                        .build()
+                        .slice,
+                    spec,
+                    false,
+                )
+            }
+        }
+
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            buildModernDataset(fields, qaDataset, menuPresentation, inlinePresentation)
+        } else {
+            buildLegacyDataset(fields, qaDataset, menuPresentation, inlinePresentation)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private fun buildModernDataset(
+        fields: List<AutofillField>,
+        qaDataset: QaDataset,
+        menuPresentation: RemoteViews,
+        inlinePresentation: InlinePresentation?,
+    ): Dataset {
+        val builder = Dataset.Builder()
+        fields.forEach { field ->
+            val presentations = Presentations.Builder()
+                .setMenuPresentation(menuPresentation)
+                .apply {
+                    inlinePresentation?.let(::setInlinePresentation)
+                }
+                .build()
+            val value = AutofillValue.forText(qaDataset.valueFor(field.kind))
+            builder.setField(
+                field.id,
+                Field.Builder()
+                    .setValue(value)
+                    .setPresentations(presentations)
+                    .build(),
+            )
+        }
+        return builder.build()
+    }
+
+    @Suppress("DEPRECATION")
+    private fun buildLegacyDataset(
+        fields: List<AutofillField>,
+        qaDataset: QaDataset,
+        menuPresentation: RemoteViews,
+        inlinePresentation: InlinePresentation?,
+    ): Dataset {
+        val builder = Dataset.Builder(menuPresentation)
+        fields.forEach { field ->
+            val value = AutofillValue.forText(qaDataset.valueFor(field.kind))
+            if (inlinePresentation == null) {
+                builder.setValue(field.id, value, menuPresentation)
+            } else {
+                builder.setValue(field.id, value, menuPresentation, inlinePresentation)
+            }
+        }
+        return builder.build()
+    }
+
+    private fun menuPresentation(label: String): RemoteViews {
+        return RemoteViews(packageName, R.layout.debug_inline_autofill_menu_item).apply {
+            setTextViewText(R.id.debug_inline_autofill_label, label)
+        }
+    }
+
+    private fun attributionPendingIntent(datasetIndex: Int): PendingIntent {
+        val intent = Intent(this, DebugInlineAutofillAttributionActivity::class.java)
+        return PendingIntent.getActivity(
+            this,
+            datasetIndex,
+            intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE,
+        )
+    }
+
+    private data class AutofillField(
+        val id: AutofillId,
+        val kind: FieldKind,
+    )
+
+    private enum class FieldKind { Username, Password }
+
+    private data class QaDataset(
+        val label: String,
+        val username: String,
+        val password: String,
+    ) {
+        fun valueFor(kind: FieldKind): String = when (kind) {
+            FieldKind.Username -> username
+            FieldKind.Password -> password
+        }
+    }
+
+    private companion object {
+        const val TAG = "SumireInlineAutofillQA"
+
+        val QA_DATASETS = listOf(
+            QaDataset(
+                label = "🔐 個人アカウント",
+                username = "personal@example.test",
+                password = "sumire-personal-password",
+            ),
+            QaDataset(
+                label = "🔐 仕事用",
+                username = "work@example.test",
+                password = "sumire-work-password",
+            ),
+        )
+    }
+}

--- a/app/src/debug/res/layout/debug_inline_autofill_menu_item.xml
+++ b/app/src/debug/res/layout/debug_inline_autofill_menu_item.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/debug_inline_autofill_label"
+    android:layout_width="wrap_content"
+    android:layout_height="48dp"
+    android:gravity="center_vertical"
+    android:maxLines="1"
+    android:paddingStart="16dp"
+    android:paddingEnd="16dp"
+    android:textColor="@android:color/black"
+    android:textSize="15sp" />

--- a/app/src/debug/res/xml/debug_inline_autofill_service.xml
+++ b/app/src/debug/res/xml/debug_inline_autofill_service.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<autofill-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:supportsInlineSuggestions="true" />

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -57,6 +57,8 @@ import android.view.inputmethod.InputConnection
 import android.view.inputmethod.InputContentInfo
 import android.view.inputmethod.InputMethodInfo
 import android.view.inputmethod.InputMethodManager
+import android.view.inputmethod.InlineSuggestionsRequest
+import android.view.inputmethod.InlineSuggestionsResponse
 import android.widget.ArrayAdapter
 import android.widget.FrameLayout
 import android.widget.ImageView
@@ -65,9 +67,11 @@ import android.widget.ListView
 import android.widget.PopupWindow
 import android.widget.TextView
 import android.widget.Toast
+import android.widget.inline.InlineContentView
 import android.window.OnBackInvokedCallback
 import android.window.OnBackInvokedDispatcher
 import androidx.annotation.ColorInt
+import androidx.annotation.RequiresApi
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.content.ContextCompat
@@ -218,6 +222,9 @@ import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.GridSpacing
 import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.ShortcutAdapter
 import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionAdapter
 import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.resolveCandidateEmptyPopupThemeColors
+import com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineAutofillController
+import com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView
+import com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionsRequestFactory
 import com.kazumaproject.markdownhelperkeyboard.ime_service.candidate.CandidateStripContent
 import com.kazumaproject.markdownhelperkeyboard.ime_service.candidate.CandidateStripContentResolver
 import com.kazumaproject.markdownhelperkeyboard.ime_service.candidate.CandidateStripInputState
@@ -380,6 +387,7 @@ import java.text.BreakIterator
 import java.text.SimpleDateFormat
 import java.util.ArrayDeque
 import java.util.Calendar
+import java.util.IdentityHashMap
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
@@ -723,6 +731,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private var suggestionAdapter: SuggestionAdapter? = null
     private var suggestionAdapterFull: SuggestionAdapter? = null
+    private var inlineAutofillController: InlineAutofillController? = null
+    private var inlineSuggestionsDisplayed = false
+    private val inlineHostPreviousVisibility = IdentityHashMap<View, Pair<Boolean, Boolean>>()
     private var currentCandidateStripCandidates: List<Candidate> = emptyList()
     private var currentCandidateStripFullCandidates: List<Candidate> = emptyList()
     private var currentCandidateStripContent: CandidateStripContent = CandidateStripContent.Empty
@@ -747,6 +758,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var integratedShortcutEntryExpanded: Boolean = false
     private var lastSuggestionLayoutKey: SuggestionLayoutKey? = null
     private var mainSuggestionGridSpacingDecoration: RecyclerView.ItemDecoration? = null
+
+    private data class InlineSuggestionHost(
+        val clipView: InlineSuggestionClipView,
+        val container: LinearLayout,
+        val suggestionRecyclerView: RecyclerView,
+        val suggestionVisibility: View,
+    )
 
     private data class ClipboardPreviewSnapshot(
         val text: String,
@@ -981,6 +999,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             content = content
         )
         applyCandidateStripPresentation(presentation)
+        enforceInlineSuggestionVisibility()
     }
 
     private fun isFullCandidateViewVisible(): Boolean {
@@ -2202,6 +2221,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     override fun onCreate() {
         super.onCreate()
         Timber.d("onCreate")
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController = InlineAutofillController(
+                context = this,
+                onViewsChanged = ::renderInlineSuggestionViews,
+            )
+        }
         lifecycleRegistry = LifecycleRegistry(this)
         lifecycleRegistry.currentState = Lifecycle.State.CREATED
         runtimeInputSharedPreferences =
@@ -2434,11 +2459,27 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 startScope(mainView)
             }
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.onHostChanged()
+        }
         return keyboardContainer
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    override fun onCreateInlineSuggestionsRequest(uiExtras: Bundle): InlineSuggestionsRequest {
+        return InlineSuggestionsRequestFactory.create(this)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    override fun onInlineSuggestionsResponse(response: InlineSuggestionsResponse): Boolean {
+        return inlineAutofillController?.handleResponse(response) ?: false
     }
 
     override fun onStartInput(attribute: EditorInfo?, restarting: Boolean) {
         super.onStartInput(attribute, restarting)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.startInputSession()
+        }
         resetEditorSelectionSnapshot()
         flickPreviewEditorSessionId += 1L
         flickInputPreviewCoordinator.resetForEditorSession()
@@ -4066,6 +4107,117 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             floatingView?.suggestionRecyclerView?.adapter = null
             floatingView?.candidatesRowView?.adapter = null
         }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.onHostChanged()
+        }
+    }
+
+    private fun inlineSuggestionHosts(): List<InlineSuggestionHost> = buildList {
+        mainLayoutBinding?.let { binding ->
+            add(
+                InlineSuggestionHost(
+                    clipView = binding.inlineSuggestionsClip,
+                    container = binding.inlineSuggestionsContainer,
+                    suggestionRecyclerView = binding.suggestionRecyclerView,
+                    suggestionVisibility = binding.suggestionVisibility,
+                )
+            )
+        }
+        floatingKeyboardBinding?.let { binding ->
+            add(
+                InlineSuggestionHost(
+                    clipView = binding.inlineSuggestionsClip,
+                    container = binding.inlineSuggestionsContainer,
+                    suggestionRecyclerView = binding.suggestionRecyclerView,
+                    suggestionVisibility = binding.suggestionVisibility,
+                )
+            )
+        }
+    }
+
+    private fun activeInlineSuggestionHost(): InlineSuggestionHost? {
+        return if (isKeyboardFloatingMode == true) {
+            floatingKeyboardBinding?.let { binding ->
+                InlineSuggestionHost(
+                    clipView = binding.inlineSuggestionsClip,
+                    container = binding.inlineSuggestionsContainer,
+                    suggestionRecyclerView = binding.suggestionRecyclerView,
+                    suggestionVisibility = binding.suggestionVisibility,
+                )
+            }
+        } else {
+            mainLayoutBinding?.let { binding ->
+                InlineSuggestionHost(
+                    clipView = binding.inlineSuggestionsClip,
+                    container = binding.inlineSuggestionsContainer,
+                    suggestionRecyclerView = binding.suggestionRecyclerView,
+                    suggestionVisibility = binding.suggestionVisibility,
+                )
+            }
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun renderInlineSuggestionViews(views: List<InlineContentView>) {
+        assertMainThread("renderInlineSuggestionViews")
+        clearInlineSuggestionHosts(restoreNativeVisibility = true)
+        if (views.isEmpty()) return
+
+        val host = activeInlineSuggestionHost() ?: return
+        Timber.d("Rendering ${views.size} inline suggestion views")
+        host.clipView.setBackgroundColor(
+            ContextCompat.getColor(this, com.kazumaproject.core.R.color.keyboard_bg)
+        )
+        inlineHostPreviousVisibility[host.clipView] =
+            host.suggestionRecyclerView.isVisible to host.suggestionVisibility.isVisible
+        views.forEach { view ->
+            (view.parent as? ViewGroup)?.removeView(view)
+            view.setZOrderedOnTop(true)
+            val frameworkWidth = view.layoutParams?.width
+                ?.takeIf { it > 0 }
+                ?: ViewGroup.LayoutParams.WRAP_CONTENT
+            val frameworkHeight = view.layoutParams?.height
+                ?.takeIf { it > 0 }
+                ?: ViewGroup.LayoutParams.MATCH_PARENT
+            host.container.addView(
+                view,
+                LinearLayout.LayoutParams(
+                    frameworkWidth,
+                    frameworkHeight,
+                ).apply {
+                    val margin = (4 * resources.displayMetrics.density).toInt()
+                    marginStart = margin
+                    marginEnd = margin
+                }
+            )
+        }
+        inlineSuggestionsDisplayed = true
+        enforceInlineSuggestionVisibility()
+        Timber.d(
+            "Inline suggestion host visible=${host.clipView.isVisible} " +
+                "children=${host.container.childCount}"
+        )
+    }
+
+    private fun clearInlineSuggestionHosts(restoreNativeVisibility: Boolean) {
+        inlineSuggestionHosts().forEach { host ->
+            host.container.removeAllViews()
+            host.clipView.isVisible = false
+            val previous = inlineHostPreviousVisibility.remove(host.clipView)
+            if (restoreNativeVisibility && previous != null) {
+                host.suggestionRecyclerView.isVisible = previous.first
+                host.suggestionVisibility.isVisible = previous.second
+            }
+        }
+        inlineSuggestionsDisplayed = false
+    }
+
+    private fun enforceInlineSuggestionVisibility() {
+        if (!inlineSuggestionsDisplayed) return
+        val activeHost = activeInlineSuggestionHost() ?: return
+        activeHost.clipView.isVisible = true
+        activeHost.suggestionRecyclerView.isVisible = false
+        activeHost.suggestionVisibility.isVisible = false
     }
 
     private fun updateFloatingKeyboardBackgroundBounds(
@@ -4792,7 +4944,17 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         consumePendingGemmaPickedImage()
     }
 
+    override fun onFinishInput() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.clear()
+        }
+        super.onFinishInput()
+    }
+
     override fun onFinishInputView(finishingInput: Boolean) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.clear()
+        }
         flickInputPreviewCoordinator.cancel(restore = false)
         gemmaMediaPanelController?.onInputViewHidden()
         gemmaHandwritingController?.onInputViewHidden()
@@ -4826,6 +4988,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun onWindowHidden() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.clear()
+        }
         flickInputPreviewCoordinator.cancel(restore = true)
         gemmaMediaPanelController?.onInputViewHidden()
         gemmaHandwritingController?.onInputViewHidden()
@@ -4834,6 +4999,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun onDestroy() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            inlineAutofillController?.destroy()
+            inlineAutofillController = null
+        }
         flickInputPreviewCoordinator.cancel(restore = false)
         resetEditorSelectionSnapshot()
         Timber.d("onUpdate onDestroy")

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineAutofillController.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineAutofillController.kt
@@ -1,0 +1,147 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.autofill
+
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import android.util.Size
+import android.view.ViewGroup
+import android.view.inputmethod.InlineSuggestion
+import android.view.inputmethod.InlineSuggestionsResponse
+import android.widget.inline.InlineContentView
+import androidx.annotation.RequiresApi
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+/**
+ * Inflates framework-owned inline suggestions without inspecting or converting their contents.
+ */
+@RequiresApi(Build.VERSION_CODES.R)
+internal class InlineAutofillController(
+    context: Context,
+    private val onViewsChanged: (List<InlineContentView>) -> Unit,
+) {
+    // InlineContentView is attached to the IME window, so inflate it with the service context.
+    private val hostContext = context
+    private val mainExecutor = context.mainExecutor
+    private val inflateExecutor: ExecutorService = Executors.newFixedThreadPool(2) { runnable ->
+        Thread(runnable, "InlineAutofillInflater").apply { isDaemon = true }
+    }
+    private val generationTracker = InlineAutofillGenerationTracker()
+    private val stateLock = Any()
+    private var inflatedViews: List<InlineContentView> = emptyList()
+    private var activeToken: InlineAutofillGenerationTracker.Token? = null
+    private var destroyed = false
+
+    fun startInputSession() {
+        val token = synchronized(stateLock) {
+            inflatedViews = emptyList()
+            generationTracker.startInputSession().also { activeToken = it }
+        }
+        publishIfCurrent(token, emptyList())
+    }
+
+    fun handleResponse(response: InlineSuggestionsResponse): Boolean {
+        val suggestions = response.inlineSuggestions
+            .take(InlineSuggestionsRequestFactory.MAX_SUGGESTION_COUNT)
+        Log.d(TAG, "Received ${suggestions.size} inline suggestions")
+        val token = synchronized(stateLock) {
+            if (destroyed) return false
+            inflatedViews = emptyList()
+            generationTracker.beginResponse().also { activeToken = it }
+        }
+        if (suggestions.isEmpty()) {
+            publishIfCurrent(token, emptyList())
+        } else {
+            inflate(token, suggestions)
+        }
+        return true
+    }
+
+    /** Reparents the already inflated views when the active normal or floating host changes. */
+    fun onHostChanged() {
+        val (token, views) = synchronized(stateLock) {
+            if (destroyed || inflatedViews.isEmpty()) return
+            (activeToken ?: return) to inflatedViews
+        }
+        publishIfCurrent(token, views)
+    }
+
+    fun clear() {
+        val token = synchronized(stateLock) {
+            inflatedViews = emptyList()
+            generationTracker.invalidateResponse().also { activeToken = it }
+        }
+        publishIfCurrent(token, emptyList())
+    }
+
+    fun destroy() {
+        val token = synchronized(stateLock) {
+            destroyed = true
+            inflatedViews = emptyList()
+            generationTracker.invalidateResponse().also { activeToken = it }
+        }
+        publishIfCurrent(token, emptyList())
+        inflateExecutor.shutdownNow()
+    }
+
+    private fun inflate(
+        token: InlineAutofillGenerationTracker.Token,
+        suggestions: List<InlineSuggestion>,
+    ) {
+        val results = arrayOfNulls<InlineContentView>(suggestions.size)
+        val resultLock = Any()
+        var completed = 0
+
+        fun complete(index: Int, view: InlineContentView?) {
+            val readyViews = synchronized(resultLock) {
+                results[index] = view
+                completed += 1
+                if (completed == results.size) results.filterNotNull() else null
+            }
+            if (readyViews != null) {
+                publishIfCurrent(token, readyViews)
+            }
+        }
+
+        suggestions.forEachIndexed { index, suggestion ->
+            runCatching {
+                suggestion.inflate(
+                    hostContext,
+                    Size(
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                        ViewGroup.LayoutParams.WRAP_CONTENT,
+                    ),
+                    inflateExecutor,
+                ) { view ->
+                    Log.d(TAG, "Inflated inline suggestion ${index + 1}/${suggestions.size}: ${view != null}")
+                    complete(index, view)
+                }
+            }.onFailure {
+                Log.w(TAG, "Inline suggestion inflation failed", it)
+                complete(index, null)
+            }
+        }
+    }
+
+    private fun publishIfCurrent(
+        token: InlineAutofillGenerationTracker.Token,
+        views: List<InlineContentView>,
+    ) {
+        mainExecutor.execute {
+            if (!generationTracker.isCurrent(token)) {
+                Log.d(TAG, "Discarded stale inline suggestion response")
+                return@execute
+            }
+            synchronized(stateLock) {
+                if (destroyed && views.isNotEmpty()) return@execute
+                inflatedViews = views
+            }
+            Log.d(TAG, "Publishing ${views.size} inline suggestion views")
+            onViewsChanged(views)
+        }
+    }
+
+    private companion object {
+        const val TAG = "SumireInlineAutofill"
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineAutofillGenerationTracker.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineAutofillGenerationTracker.kt
@@ -1,0 +1,40 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.autofill
+
+/** Rejects asynchronous inline-suggestion results belonging to an old editor or response. */
+internal class InlineAutofillGenerationTracker {
+
+    data class Token internal constructor(
+        val sessionGeneration: Long,
+        val responseGeneration: Long,
+    )
+
+    private var sessionGeneration = 0L
+    private var responseGeneration = 0L
+
+    @Synchronized
+    fun startInputSession(): Token {
+        sessionGeneration += 1L
+        responseGeneration += 1L
+        return currentToken()
+    }
+
+    @Synchronized
+    fun beginResponse(): Token {
+        responseGeneration += 1L
+        return currentToken()
+    }
+
+    @Synchronized
+    fun invalidateResponse(): Token {
+        responseGeneration += 1L
+        return currentToken()
+    }
+
+    @Synchronized
+    fun isCurrent(token: Token): Boolean = token == currentToken()
+
+    private fun currentToken() = Token(
+        sessionGeneration = sessionGeneration,
+        responseGeneration = responseGeneration,
+    )
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineSuggestionClipView.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineSuggestionClipView.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2026 KazumaProject
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.kazumaproject.markdownhelperkeyboard.ime_service.autofill
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.PixelFormat
+import android.graphics.Rect
+import android.util.AttributeSet
+import android.view.Choreographer
+import android.view.Surface
+import android.view.SurfaceHolder
+import android.view.SurfaceView
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewTreeObserver
+import android.widget.FrameLayout
+
+/**
+ * Clips embedded inline-suggestion surfaces to the visible candidate-strip area.
+ *
+ * The implementation deliberately avoids a static reference to InlineContentView so this layout
+ * class can still be inflated on Android versions earlier than API 30.
+ */
+class InlineSuggestionClipView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0,
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    private val parentBounds = Rect()
+    private val contentBounds = Rect()
+    private val backgroundView = SurfaceView(context).apply {
+        setZOrderOnTop(true)
+        holder.setFormat(PixelFormat.TRANSPARENT)
+        layoutParams = ViewGroup.LayoutParams(
+            ViewGroup.LayoutParams.MATCH_PARENT,
+            ViewGroup.LayoutParams.MATCH_PARENT,
+        )
+        holder.addCallback(object : SurfaceHolder.Callback {
+            override fun surfaceCreated(holder: SurfaceHolder) {
+                drawBackgroundColorIfReady()
+            }
+
+            override fun surfaceChanged(
+                holder: SurfaceHolder,
+                format: Int,
+                width: Int,
+                height: Int,
+            ) = Unit
+
+            override fun surfaceDestroyed(holder: SurfaceHolder) = Unit
+        })
+    }
+    private var surfaceBackgroundColor = Color.TRANSPARENT
+    private val onDrawListener = ViewTreeObserver.OnDrawListener {
+        clipInlineContentDescendants(this)
+    }
+
+    init {
+        // A SurfaceView background keeps the remote suggestion surfaces composited with the IME
+        // strip. This follows AOSP's AutofillKeyboard InlineContentClipView implementation.
+        addView(backgroundView)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        viewTreeObserver.addOnDrawListener(onDrawListener)
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        if (viewTreeObserver.isAlive) {
+            viewTreeObserver.removeOnDrawListener(onDrawListener)
+        }
+    }
+
+    override fun setBackgroundColor(color: Int) {
+        surfaceBackgroundColor = color
+        Choreographer.getInstance().postFrameCallback {
+            drawBackgroundColorIfReady()
+        }
+    }
+
+    private fun drawBackgroundColorIfReady() {
+        val surface: Surface = backgroundView.holder.surface
+        if (!surface.isValid) return
+        val canvas: Canvas = surface.lockCanvas(null)
+        try {
+            canvas.drawColor(surfaceBackgroundColor)
+        } finally {
+            surface.unlockCanvasAndPost(canvas)
+        }
+    }
+
+    private fun clipInlineContentDescendants(root: View?) {
+        if (root == null || width <= 0 || height <= 0) return
+        if (root.javaClass.name == INLINE_CONTENT_VIEW_CLASS_NAME) {
+            parentBounds.set(0, 0, width, height)
+            contentBounds.set(parentBounds)
+            offsetRectIntoDescendantCoords(root, contentBounds)
+            root.clipBounds = contentBounds
+            return
+        }
+        if (root is ViewGroup) {
+            for (index in 0 until root.childCount) {
+                clipInlineContentDescendants(root.getChildAt(index))
+            }
+        }
+    }
+
+    private companion object {
+        const val INLINE_CONTENT_VIEW_CLASS_NAME = "android.widget.inline.InlineContentView"
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineSuggestionsRequestFactory.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineSuggestionsRequestFactory.kt
@@ -1,0 +1,105 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.autofill
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.graphics.drawable.Icon
+import android.os.Build
+import android.util.Size
+import android.util.TypedValue
+import android.view.inputmethod.InlineSuggestionsRequest
+import android.widget.inline.InlinePresentationSpec
+import androidx.annotation.RequiresApi
+import androidx.autofill.inline.UiVersions
+import androidx.autofill.inline.common.ImageViewStyle
+import androidx.autofill.inline.common.TextViewStyle
+import androidx.autofill.inline.common.ViewStyle
+import androidx.autofill.inline.v1.InlineSuggestionUi
+import androidx.core.content.ContextCompat
+import com.kazumaproject.markdownhelperkeyboard.R
+
+@RequiresApi(Build.VERSION_CODES.R)
+internal object InlineSuggestionsRequestFactory {
+
+    const val MAX_SUGGESTION_COUNT = 4
+    private const val MIN_CHIP_WIDTH_DP = 64
+    private const val MAX_CHIP_WIDTH_DP = 240
+    private const val CHIP_HEIGHT_DP = 48
+
+    // These style mutators are the AndroidX Inline Autofill API used by the AOSP
+    // sample, but the artifact currently marks them RestrictedApi for lint.
+    @SuppressLint("RestrictedApi")
+    fun create(context: Context): InlineSuggestionsRequest {
+        val chipBackground = Icon.createWithResource(
+            context,
+            R.drawable.inline_suggestion_chip_background,
+        )
+        val textColor = ContextCompat.getColor(
+            context,
+            com.kazumaproject.core.R.color.keyboard_icon_color,
+        )
+        val style = InlineSuggestionUi.newStyleBuilder()
+            .setSingleIconChipStyle(
+                ViewStyle.Builder()
+                    .setBackground(chipBackground)
+                    .setPadding(dp(context, 8), 0, dp(context, 8), 0)
+                    .build()
+            )
+            .setChipStyle(
+                ViewStyle.Builder()
+                    .setBackground(chipBackground)
+                    .setPadding(dp(context, 12), 0, dp(context, 12), 0)
+                    .build()
+            )
+            .setStartIconStyle(
+                ImageViewStyle.Builder()
+                    .setLayoutMargin(0, 0, dp(context, 4), 0)
+                    .build()
+            )
+            .setTitleStyle(
+                TextViewStyle.Builder()
+                    .setTextColor(textColor)
+                    .setTextSize(15f)
+                    .build()
+            )
+            .setSubtitleStyle(
+                TextViewStyle.Builder()
+                    .setTextColor(textColor)
+                    .setTextSize(13f)
+                    .build()
+            )
+            .setEndIconStyle(
+                ImageViewStyle.Builder()
+                    .setLayoutMargin(dp(context, 4), 0, 0, 0)
+                    .build()
+            )
+            .build()
+
+        val styles = UiVersions.newStylesBuilder()
+            .addStyle(style)
+            .build()
+        val minWidth = dp(context, MIN_CHIP_WIDTH_DP)
+        val maxWidth = dp(context, MAX_CHIP_WIDTH_DP)
+            .coerceAtMost(context.resources.displayMetrics.widthPixels)
+            .coerceAtLeast(minWidth)
+        val height = dp(context, CHIP_HEIGHT_DP)
+        val specs = ArrayList<InlinePresentationSpec>(MAX_SUGGESTION_COUNT).apply {
+            repeat(MAX_SUGGESTION_COUNT) {
+                add(
+                    InlinePresentationSpec.Builder(
+                        Size(minWidth, height),
+                        Size(maxWidth, height),
+                    ).setStyle(styles).build()
+                )
+            }
+        }
+        return InlineSuggestionsRequest.Builder(specs)
+            .setMaxSuggestionCount(MAX_SUGGESTION_COUNT)
+            .build()
+    }
+
+    private fun dp(context: Context, value: Int): Int = TypedValue.applyDimension(
+        TypedValue.COMPLEX_UNIT_DIP,
+        value.toFloat(),
+        context.resources.displayMetrics,
+    ).toInt()
+}

--- a/app/src/main/res/drawable/inline_suggestion_chip_background.xml
+++ b/app/src/main/res/drawable/inline_suggestion_chip_background.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/keyboard_bg" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/keyboard_icon_color" />
+    <corners android:radius="18dp" />
+</shape>

--- a/app/src/main/res/layout-land/main_layout.xml
+++ b/app/src/main/res/layout-land/main_layout.xml
@@ -116,6 +116,35 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView
+            android:id="@+id/inline_suggestions_clip"
+            android:layout_width="0dp"
+            android:layout_height="58dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/suggestion_visibility"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="true"
+                android:fillViewport="false"
+                android:overScrollMode="never"
+                android:scrollbars="none">
+
+                <LinearLayout
+                    android:id="@+id/inline_suggestions_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="4dp"
+                    android:paddingEnd="4dp" />
+            </HorizontalScrollView>
+        </com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView>
+
         <!-- Visibility Toggle Button -->
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/suggestion_visibility"

--- a/app/src/main/res/layout-sw600dp/main_layout.xml
+++ b/app/src/main/res/layout-sw600dp/main_layout.xml
@@ -117,6 +117,35 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView
+            android:id="@+id/inline_suggestions_clip"
+            android:layout_width="0dp"
+            android:layout_height="58dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/suggestion_visibility"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="true"
+                android:fillViewport="false"
+                android:overScrollMode="never"
+                android:scrollbars="none">
+
+                <LinearLayout
+                    android:id="@+id/inline_suggestions_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="4dp"
+                    android:paddingEnd="4dp" />
+            </HorizontalScrollView>
+        </com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView>
+
         <!-- Visibility Toggle Button -->
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/suggestion_visibility"

--- a/app/src/main/res/layout/floating_keyboard_layout.xml
+++ b/app/src/main/res/layout/floating_keyboard_layout.xml
@@ -117,6 +117,35 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
 
+            <com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView
+                android:id="@+id/inline_suggestions_clip"
+                android:layout_width="0dp"
+                android:layout_height="58dp"
+                android:visibility="gone"
+                app:layout_constraintBottom_toBottomOf="parent"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent">
+
+                <HorizontalScrollView
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    android:clipToPadding="true"
+                    android:fillViewport="false"
+                    android:overScrollMode="never"
+                    android:scrollbars="none">
+
+                    <LinearLayout
+                        android:id="@+id/inline_suggestions_container"
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:gravity="center_vertical"
+                        android:orientation="horizontal"
+                        android:paddingStart="4dp"
+                        android:paddingEnd="4dp" />
+                </HorizontalScrollView>
+            </com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView>
+
             <!-- Visibility Toggle Button -->
             <com.google.android.material.imageview.ShapeableImageView
                 android:id="@+id/suggestion_visibility"

--- a/app/src/main/res/layout/main_layout.xml
+++ b/app/src/main/res/layout/main_layout.xml
@@ -118,6 +118,35 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView
+            android:id="@+id/inline_suggestions_clip"
+            android:layout_width="0dp"
+            android:layout_height="58dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/suggestion_visibility"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent">
+
+            <HorizontalScrollView
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="true"
+                android:fillViewport="false"
+                android:overScrollMode="never"
+                android:scrollbars="none">
+
+                <LinearLayout
+                    android:id="@+id/inline_suggestions_container"
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal"
+                    android:paddingStart="4dp"
+                    android:paddingEnd="4dp" />
+            </HorizontalScrollView>
+        </com.kazumaproject.markdownhelperkeyboard.ime_service.autofill.InlineSuggestionClipView>
+
         <!-- Visibility Toggle Button -->
         <com.google.android.material.imageview.ShapeableImageView
             android:id="@+id/suggestion_visibility"

--- a/app/src/main/res/xml/method.xml
+++ b/app/src/main/res/xml/method.xml
@@ -1,5 +1,6 @@
 <input-method xmlns:android="http://schemas.android.com/apk/res/android"
     android:isDefault="true"
+    android:supportsInlineSuggestions="true"
     android:settingsActivity="com.kazumaproject.markdownhelperkeyboard.setting_activity.MainActivity">
     <subtype
         android:imeSubtypeLocale="jp_JP"

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineAutofillGenerationTrackerTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineAutofillGenerationTrackerTest.kt
@@ -1,0 +1,41 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.autofill
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class InlineAutofillGenerationTrackerTest {
+
+    @Test
+    fun startingAnotherInputSessionRejectsThePreviousFieldsResponse() {
+        val tracker = InlineAutofillGenerationTracker()
+        tracker.startInputSession()
+        val fieldAResponse = tracker.beginResponse()
+
+        tracker.startInputSession()
+
+        assertFalse(tracker.isCurrent(fieldAResponse))
+    }
+
+    @Test
+    fun beginningAnotherResponseRejectsAnOlderResponseInTheSameField() {
+        val tracker = InlineAutofillGenerationTracker()
+        tracker.startInputSession()
+        val olderResponse = tracker.beginResponse()
+        val currentResponse = tracker.beginResponse()
+
+        assertFalse(tracker.isCurrent(olderResponse))
+        assertTrue(tracker.isCurrent(currentResponse))
+    }
+
+    @Test
+    fun clearingSuggestionsRejectsInflationThatFinishesLater() {
+        val tracker = InlineAutofillGenerationTracker()
+        tracker.startInputSession()
+        val inflatingResponse = tracker.beginResponse()
+        val clearedState = tracker.invalidateResponse()
+
+        assertFalse(tracker.isCurrent(inflatingResponse))
+        assertTrue(tracker.isCurrent(clearedState))
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineSuggestionsRequestFactoryTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/autofill/InlineSuggestionsRequestFactoryTest.kt
@@ -1,0 +1,42 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service.autofill
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+class InlineSuggestionsRequestFactoryTest {
+
+    @Test
+    @Config(sdk = [35])
+    fun requestUsesFourFixedHeightAndroidxStyleSpecs() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        val request = InlineSuggestionsRequestFactory.create(context)
+        val specs = request.inlinePresentationSpecs
+
+        assertEquals(InlineSuggestionsRequestFactory.MAX_SUGGESTION_COUNT, request.maxSuggestionCount)
+        assertEquals(InlineSuggestionsRequestFactory.MAX_SUGGESTION_COUNT, specs.size)
+        specs.forEach { spec ->
+            assertTrue(spec.minSize.width > 0)
+            assertTrue(spec.maxSize.width >= spec.minSize.width)
+            assertEquals(spec.minSize.height, spec.maxSize.height)
+            assertTrue(spec.minSize.height > 0)
+            assertTrue(spec.style.size() > 0)
+        }
+    }
+
+    @Test
+    @Config(sdk = [29])
+    fun inlineHostClassCanBeCreatedBeforeAndroidEleven() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+
+        assertNotNull(InlineSuggestionClipView(context))
+    }
+}


### PR DESCRIPTION
## 概要

Android AutofillServiceが提供するインライン候補を、キーボードの候補領域に表示できるようにします。

## 変更内容

- IMEがインラインサジェストに対応していることを宣言
- インライン候補のリクエスト作成とレスポンス処理を追加
- AndroidX Autofill APIを使用した候補表示スタイルを追加
- 通常キーボードとフローティングキーボードの両方に対応
- Frameworkが生成したInlineContentViewを候補領域へ表示
- 表示中は通常の候補リストを一時的に隠し、終了後に元の表示状態を復元
- インライン候補のクリッピングと横スクロールに対応
- 入力欄の切り替え、キーボード表示状態、非同期レスポンスを考慮したライフサイクル管理を追加
- 古い入力セッションやレスポンスの候補が表示されないよう世代管理を追加
- Android 11（API 30）未満では既存動作を維持
- Debugビルド用のAutofillServiceとインライン候補確認用テスト画面を追加
- 世代管理とリクエスト生成のユニットテストを追加