### PR TITLE
fix settings action bar state across navigation

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyEditorFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyEditorFragment.kt
@@ -2047,10 +2047,6 @@ class KeyEditorFragment : Fragment(R.layout.fragment_key_editor) {
             pendingUserIconPaths.forEach { deleteUserIconFile(it) }
             pendingUserIconPaths.clear()
         }
-        (activity as? AppCompatActivity)?.supportActionBar?.apply {
-            title = null
-            setDisplayHomeAsUpEnabled(false)
-        }
         viewModel.doneNavigatingToKeyEditor()
 
         _binding = null

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardEditorFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardEditorFragment.kt
@@ -415,10 +415,6 @@ class KeyboardEditorFragment : Fragment(R.layout.fragment_keyboard_editor),
     override fun onDestroyView() {
         super.onDestroyView()
         viewModel.clearSelectedItemForDeletion()
-        (activity as? AppCompatActivity)?.supportActionBar?.apply {
-            title = null
-            setDisplayHomeAsUpEnabled(false)
-        }
         binding.flickKeyboardView.removeOnKeyEditListener()
         _binding = null
     }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardListFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardListFragment.kt
@@ -67,13 +67,6 @@ class KeyboardListFragment : Fragment(R.layout.fragment_keyboard_list) {
             }
         }
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        (activity as AppCompatActivity).supportActionBar?.apply {
-            setDisplayHomeAsUpEnabled(false)
-        }
-    }
-
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         _binding = FragmentKeyboardListBinding.bind(view)
@@ -172,6 +165,14 @@ class KeyboardListFragment : Fragment(R.layout.fragment_keyboard_list) {
                 }
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        (activity as? AppCompatActivity)?.supportActionBar?.apply {
+            title = getString(R.string.custom_layout_fragment_title)
+        }
+        requireActivity().invalidateOptionsMenu()
     }
 
     // [ADD] Function to set up the menu

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/MainActivity.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/MainActivity.kt
@@ -34,6 +34,13 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private lateinit var mainNavController: NavController
     private var currentDestinationId: Int? = null
+    private val destinationsWithOwnToolbar = setOf(
+        R.id.candidateViewHeightSettingFragment,
+        R.id.candidateHeightLandscapeSettingFragment,
+        R.id.shortcutToolbarSizeSettingFragment,
+    )
+    private val destinationsWithoutSharedActionBar =
+        destinationsWithOwnToolbar + R.id.enableKeyboardFragment
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -77,6 +84,7 @@ class MainActivity : AppCompatActivity() {
             ) {
                 navView.menu.findItem(R.id.navigation_setting)?.isChecked = true
             }
+            updateSharedActionBarVisibility(destination.id)
             invalidateOptionsMenu()
         }
 
@@ -94,6 +102,14 @@ class MainActivity : AppCompatActivity() {
     override fun onSupportNavigateUp(): Boolean {
         val navController = currentNavController()
         return navController.navigateUp() || super.onSupportNavigateUp()
+    }
+
+    private fun updateSharedActionBarVisibility(destinationId: Int) {
+        if (destinationId in destinationsWithoutSharedActionBar) {
+            supportActionBar?.hide()
+        } else {
+            supportActionBar?.show()
+        }
     }
 
     /**

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_landscape_setting/CandidateHeightLandscapeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_landscape_setting/CandidateHeightLandscapeSettingFragment.kt
@@ -15,7 +15,6 @@ import android.widget.LinearLayout
 import android.widget.SeekBar
 import androidx.annotation.AttrRes
 import androidx.appcompat.R as AppCompatR
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
@@ -141,7 +140,6 @@ class CandidateHeightLandscapeSettingFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         restoreBottomNavigationVisibility()
-        (activity as? AppCompatActivity)?.supportActionBar?.show()
         binding.candidateHeightSettingRecyclerview.adapter = null
         suggestionAdapter.release()
         _binding = null
@@ -223,7 +221,6 @@ class CandidateHeightLandscapeSettingFragment : Fragment() {
     }
 
     private fun setupMenu() {
-        (activity as? AppCompatActivity)?.supportActionBar?.hide()
         binding.toolbar.setNavigationIcon(AppCompatR.drawable.abc_ic_ab_back_material)
         binding.toolbar.setNavigationOnClickListener {
             parentFragmentManager.popBackStack()

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateViewHeightSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateViewHeightSettingFragment.kt
@@ -15,7 +15,6 @@ import android.widget.LinearLayout
 import android.widget.SeekBar
 import androidx.annotation.AttrRes
 import androidx.appcompat.R as AppCompatR
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.constraintlayout.widget.ConstraintSet
@@ -133,7 +132,6 @@ class CandidateViewHeightSettingFragment : Fragment() {
     override fun onDestroyView() {
         super.onDestroyView()
         restoreBottomNavigationVisibility()
-        (activity as? AppCompatActivity)?.supportActionBar?.show()
         binding.candidateHeightSettingRecyclerview.adapter = null
         suggestionAdapter.release()
         _binding = null
@@ -215,7 +213,6 @@ class CandidateViewHeightSettingFragment : Fragment() {
     }
 
     private fun setupMenu() {
-        (activity as? AppCompatActivity)?.supportActionBar?.hide()
         binding.toolbar.setNavigationIcon(AppCompatR.drawable.abc_ic_ab_back_material)
         binding.toolbar.setNavigationOnClickListener {
             parentFragmentManager.popBackStack()

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/enable_keyboard_setting/EnableKeyboardFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/enable_keyboard_setting/EnableKeyboardFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
-import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat.getSystemService
 import androidx.fragment.app.Fragment
 import com.kazumaproject.markdownhelperkeyboard.R
@@ -57,11 +56,6 @@ class EnableKeyboardFragment : Fragment() {
 
     override fun onResume() {
         super.onResume()
-        (activity as? AppCompatActivity)?.supportActionBar?.apply {
-            title = ""
-            setDisplayHomeAsUpEnabled(false)
-        }
-
         isKeyboardBoardEnabled()?.let {
             if (it) {
                 navigateSafely(R.id.navigation_setting)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_landscape_setting/KeyboardSizeLandscapeFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_landscape_setting/KeyboardSizeLandscapeFragment.kt
@@ -70,11 +70,6 @@ class KeyboardSizeLandscapeFragment : Fragment() {
         updateControlsVisibility()
     }
 
-    override fun onResume() {
-        super.onResume()
-        (requireActivity() as AppCompatActivity).supportActionBar?.title = ""
-    }
-
     private fun setupViewPager() {
         val adapter = KeyboardViewPagerAdapter()
         binding.keyboardViewPager.adapter = adapter
@@ -572,7 +567,6 @@ class KeyboardSizeLandscapeFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
         _binding = null
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt
@@ -70,11 +70,6 @@ class KeyboardSettingFragment : Fragment() {
         updateControlsVisibility()
     }
 
-    override fun onResume() {
-        super.onResume()
-        (requireActivity() as AppCompatActivity).supportActionBar?.title = ""
-    }
-
     private fun setupViewPager() {
         val adapter = KeyboardViewPagerAdapter()
         binding.keyboardViewPager.adapter = adapter
@@ -600,7 +595,6 @@ class KeyboardSettingFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? AppCompatActivity)?.supportActionBar?.setDisplayHomeAsUpEnabled(false)
         _binding = null
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/shortcut_toolbar_size/ShortcutToolbarSizeSettingFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/shortcut_toolbar_size/ShortcutToolbarSizeSettingFragment.kt
@@ -13,7 +13,6 @@ import android.widget.LinearLayout
 import android.widget.SeekBar
 import androidx.annotation.AttrRes
 import androidx.appcompat.R as AppCompatR
-import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.AppCompatImageView
 import androidx.core.widget.doAfterTextChanged
 import androidx.fragment.app.Fragment
@@ -60,7 +59,6 @@ class ShortcutToolbarSizeSettingFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        (activity as? AppCompatActivity)?.supportActionBar?.hide()
         setupToolbar()
         setupControls()
         loadCurrentValues()
@@ -68,7 +66,6 @@ class ShortcutToolbarSizeSettingFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
-        (activity as? AppCompatActivity)?.supportActionBar?.show()
         _binding = null
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/system_user_dictionary/ui/SystemUserDictionaryBuilderFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/system_user_dictionary/ui/SystemUserDictionaryBuilderFragment.kt
@@ -92,11 +92,6 @@ class SystemUserDictionaryBuilderFragment : Fragment() {
         updateBuildStatus()
     }
 
-    override fun onResume() {
-        super.onResume()
-        requireActivity().title = ""
-    }
-
     private fun setupMenu() {
         val menuHost: MenuHost = requireActivity()
         menuHost.addMenuProvider(object : MenuProvider {

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -417,7 +417,7 @@
     <fragment
         android:id="@+id/enableKeyboardFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.enable_keyboard_setting.EnableKeyboardFragment"
-        android:label="fragment_enable_keyboard"
+        android:label="@string/welcome_title"
         tools:layout="@layout/fragment_enable_keyboard" />
     <fragment
         android:id="@+id/shortcutSettingFragment"
@@ -514,7 +514,7 @@
     <fragment
         android:id="@+id/systemUserDictionaryBuilderFragment"
         android:name="com.kazumaproject.markdownhelperkeyboard.system_user_dictionary.ui.SystemUserDictionaryBuilderFragment"
-        android:label=""
+        android:label="@string/system_user_dictionary_builder_title"
         tools:layout="@layout/fragment_system_user_dictionary_builder" />
     <fragment
         android:id="@+id/externalDictionarySettingsFragment"

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/CustomKeyboardEditorActionBarLifecycleContractTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/CustomKeyboardEditorActionBarLifecycleContractTest.kt
@@ -1,0 +1,57 @@
+package com.kazumaproject.markdownhelperkeyboard.custom_keyboard.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class CustomKeyboardEditorActionBarLifecycleContractTest {
+
+    @Test
+    fun keyboardEditorDoesNotClearDestinationActionBarWhenItsViewIsDestroyed() {
+        assertOnDestroyViewDoesNotMutateActionBar("KeyboardEditorFragment.kt")
+    }
+
+    @Test
+    fun keyEditorDoesNotClearDestinationActionBarWhenItsViewIsDestroyed() {
+        assertOnDestroyViewDoesNotMutateActionBar("KeyEditorFragment.kt")
+    }
+
+    @Test
+    fun keyboardListRestoresItsHeaderWheneverItResumes() {
+        val source = mainFile("KeyboardListFragment.kt").readText()
+        val onResumeBody = source.substringAfter("override fun onResume()")
+            .substringBefore("// [ADD] Function to set up the menu")
+
+        assertTrue(
+            onResumeBody.contains("title = getString(R.string.custom_layout_fragment_title)"),
+        )
+        assertFalse(
+            "KeyboardListFragment must leave the up indicator to NavigationUI",
+            onResumeBody.contains("setDisplayHomeAsUpEnabled"),
+        )
+        assertTrue(onResumeBody.contains("invalidateOptionsMenu()"))
+    }
+
+    private fun assertOnDestroyViewDoesNotMutateActionBar(fileName: String) {
+        val source = mainFile(fileName).readText()
+        val onDestroyViewBody = source.substringAfter("override fun onDestroyView()")
+            .substringBeforeLast("\n}")
+
+        assertFalse(
+            "$fileName must not overwrite the shared ActionBar after navigation has restored the destination header",
+            onDestroyViewBody.contains("supportActionBar"),
+        )
+    }
+
+    private fun mainFile(fileName: String): File {
+        val relativePath =
+            "java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/$fileName"
+        val candidates = listOf(
+            File("app/src/main/$relativePath"),
+            File("src/main/$relativePath"),
+        )
+        return candidates.firstOrNull(File::exists)
+            ?: error("Unable to locate $relativePath")
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/SharedActionBarNavigationContractTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/SharedActionBarNavigationContractTest.kt
@@ -1,0 +1,109 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class SharedActionBarNavigationContractTest {
+
+    @Test
+    fun fragmentTeardownDoesNotOverrideTheDestinationUpIndicator() {
+        listOf(
+            "ui/keyboard_size_setting/KeyboardSizeSettingFragment.kt",
+            "ui/keyboard_size_landscape_setting/KeyboardSizeLandscapeFragment.kt",
+        ).forEach { relativePath ->
+            val source = mainFile(relativePath).readText()
+            val onDestroyViewBody = source.substringAfter("override fun onDestroyView()")
+                .substringBeforeLast("\n}")
+
+            assertFalse(
+                "$relativePath must not overwrite the shared ActionBar during teardown",
+                onDestroyViewBody.contains("supportActionBar"),
+            )
+        }
+    }
+
+    @Test
+    fun mainActivityOwnsSharedActionBarVisibilityForEveryHiddenHeaderDestination() {
+        val source = mainFile("MainActivity.kt").readText()
+
+        assertTrue(source.contains("private val destinationsWithOwnToolbar = setOf("))
+        assertTrue(source.contains("R.id.candidateViewHeightSettingFragment"))
+        assertTrue(source.contains("R.id.candidateHeightLandscapeSettingFragment"))
+        assertTrue(source.contains("R.id.shortcutToolbarSizeSettingFragment"))
+        assertTrue(source.contains("private val destinationsWithoutSharedActionBar"))
+        assertTrue(source.contains("destinationsWithOwnToolbar + R.id.enableKeyboardFragment"))
+        assertTrue(source.contains("updateSharedActionBarVisibility(destination.id)"))
+        assertTrue(source.contains("destinationId in destinationsWithoutSharedActionBar"))
+        assertTrue(source.contains("supportActionBar?.hide()"))
+        assertTrue(source.contains("supportActionBar?.show()"))
+    }
+
+    @Test
+    fun fragmentsNeverClearTheSharedActionBarTitleAfterNavigation() {
+        val sourceRoot = projectFile("app/src/main/java", "src/main/java")
+        val blankSharedTitleAssignments = listOf(
+            Regex("""supportActionBar\?\.title\s*=\s*(?:""|null)"""),
+            Regex("""requireActivity\(\)\.title\s*=\s*(?:""|null)"""),
+            Regex(
+                """supportActionBar\?\.apply\s*\{[\s\S]{0,300}?title\s*=\s*(?:""|null)""",
+            ),
+        )
+        val offenders = sourceRoot.walkTopDown()
+            .filter { it.isFile && it.extension == "kt" }
+            .filter { file ->
+                val source = file.readText()
+                blankSharedTitleAssignments.any { it.containsMatchIn(source) }
+            }
+            .map { it.relativeTo(sourceRoot).invariantSeparatorsPath }
+            .toList()
+
+        assertTrue(
+            "Fragments must leave destination titles to NavigationUI: $offenders",
+            offenders.isEmpty(),
+        )
+    }
+
+    @Test
+    fun sharedNavigationDestinationsNeverDeclareAnEmptyLabel() {
+        val navigation = projectFile(
+            "app/src/main/res/navigation/mobile_navigation.xml",
+            "src/main/res/navigation/mobile_navigation.xml",
+        ).readText()
+
+        assertFalse(
+            "Shared ActionBar destinations need a non-empty NavigationUI title",
+            navigation.contains("android:label=\"\""),
+        )
+    }
+
+    @Test
+    fun customToolbarFragmentsDoNotToggleTheSharedActionBar() {
+        listOf(
+            "ui/candidate_view_height_setting/CandidateViewHeightSettingFragment.kt",
+            "ui/candidate_view_height_landscape_setting/CandidateHeightLandscapeSettingFragment.kt",
+            "ui/shortcut_toolbar_size/ShortcutToolbarSizeSettingFragment.kt",
+        ).forEach { relativePath ->
+            val source = mainFile(relativePath).readText()
+
+            assertFalse(
+                "$relativePath must leave shared ActionBar visibility to MainActivity",
+                source.contains("supportActionBar?.hide()") ||
+                    source.contains("supportActionBar?.show()"),
+            )
+        }
+    }
+
+    private fun mainFile(relativePath: String): File {
+        val sourcePath = "java/com/kazumaproject/markdownhelperkeyboard/setting_activity/$relativePath"
+        return projectFile("app/src/main/$sourcePath", "src/main/$sourcePath")
+    }
+
+    private fun projectFile(vararg candidates: String): File {
+        return candidates.asSequence()
+            .map(::File)
+            .firstOrNull(File::exists)
+            ?: error("Unable to locate any of ${candidates.toList()}")
+    }
+}


### PR DESCRIPTION
デバッグ中に別途発見した内容です。アプリ内の設定を周遊しているときに、左上の戻るボタンや上のタイトルラベルが消滅する場合がある不具合を修正しています。