### PR TITLE
fix key text defaults and preview height

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -133,6 +133,7 @@ import com.kazumaproject.core.domain.flick.FlickTextPreviewListener
 import com.kazumaproject.core.domain.flick.MutableRuntimeGestureSettingsSource
 import com.kazumaproject.core.domain.flick.RuntimeGestureSettings
 import com.kazumaproject.core.domain.key.Key
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.core.domain.listener.FlickListener
 import com.kazumaproject.core.domain.listener.KeyTouchCancelListener
 import com.kazumaproject.core.domain.listener.KeyTouchCancelReason
@@ -4876,12 +4877,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 keyboardView.setOnQwertyNumberModeRequestedListener {
                     switchTenkeyTwoStateNumberToQwertyNumber()
                 }
-                val defaultLetterSize = when (currentInputModeForSession) {
-                    InputMode.ModeJapanese -> 17f
-                    InputMode.ModeEnglish -> 12f
-                    InputMode.ModeNumber -> 16f
-                    else -> 17f
-                }
+                val defaultLetterSize =
+                    KeyTextSizeDefaults.tenKeySizeSp(currentInputModeForSession)
                 keyboardView.setKeyLetterSize(
                     (appPreference.key_letter_size ?: 0.0f) + defaultLetterSize
                 )
@@ -11918,8 +11915,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             keyWidthScalePercent = appPreference.flick_key_width_scale_percent ?: 160,
             keyHeightScalePercent = appPreference.flick_key_height_scale_percent ?: 160,
             iconScalePercent = appPreference.flick_key_icon_scale_percent ?: 80,
-            textSizeSp = appPreference.flick_key_text_size_sp ?: 16.0f,
-            specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp ?: 16.0f
+            textSizeSp = appPreference.flick_key_text_size_sp ?: KeyTextSizeDefaults.SumireKeySp,
+            specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp
+                ?: KeyTextSizeDefaults.SumireSpecialKeySp
         )
         flickView.applyPopupViewStyleSet(currentFlickPopupViewStyleSet())
         applyCurrentFlickGuidePreference(flickView)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -8,9 +8,10 @@ import androidx.preference.PreferenceManager
 import com.google.gson.Gson
 import com.google.gson.reflect.TypeToken
 import com.kazumaproject.core.data.clicked_symbol.SymbolMode
-import com.kazumaproject.core.domain.flick.FlickThresholdShape
 import com.kazumaproject.core.data.popup.TfbiFlickStartPositionMode
 import com.kazumaproject.core.data.popup.TfbiPopupPresentationMode
+import com.kazumaproject.core.domain.flick.FlickThresholdShape
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.custom_keyboard.data.CircularFlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
 import com.kazumaproject.custom_keyboard.data.buildEvenCircularRanges
@@ -525,10 +526,11 @@ object AppPreference {
     private val FLICK_KEY_HEIGHT_SCALE_PERCENT =
         Pair("flick_key_height_scale_percent_preference", 160)
     private val FLICK_KEY_ICON_SCALE_PERCENT = Pair("flick_key_icon_scale_percent_preference", 80)
-    private val FLICK_KEY_TEXT_SIZE_SP = Pair("flick_key_text_size_sp_preference", 16.0f)
+    private val FLICK_KEY_TEXT_SIZE_SP =
+        Pair("flick_key_text_size_sp_preference", KeyTextSizeDefaults.SumireKeySp)
 
     private val FLICK_SPECIAL_KEY_TEXT_SIZE_SP =
-        Pair("flick_special_key_text_size_sp_preference", 12.0f)
+        Pair("flick_special_key_text_size_sp_preference", KeyTextSizeDefaults.SumireSpecialKeySp)
 
     private val FLICK_DIRECTIONAL_POPUP_SIZE_SCALE_PERCENT =
         Pair("flick_directional_popup_size_scale_percent_preference", 100)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/KeyTextSizePreviewSizing.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/KeyTextSizePreviewSizing.kt
@@ -1,0 +1,13 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui
+
+import com.kazumaproject.markdownhelperkeyboard.ime_service.keyboard_layout_edit.KeyboardLayoutEditConstraints
+
+internal object KeyTextSizePreviewSizing {
+    fun heightPx(heightDp: Int, density: Float): Int {
+        val boundedHeightDp = heightDp.coerceIn(
+            KeyboardLayoutEditConstraints.MinHeightDp,
+            KeyboardLayoutEditConstraints.MaxHeightDp,
+        )
+        return (boundedHeightDp * density).toInt()
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateHeightPreviewUtils.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateHeightPreviewUtils.kt
@@ -19,6 +19,7 @@ import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.core.data.popup.QwertyPopupViewStyleSet
 import com.kazumaproject.core.domain.flick.FlickThresholdShape
 import com.kazumaproject.core.domain.key.Key
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.core.domain.listener.FlickListener
 import com.kazumaproject.core.domain.listener.LongPressListener
 import com.kazumaproject.core.domain.state.GestureType
@@ -494,7 +495,9 @@ private fun configureTenKeyPreview(
     tenKey.setUseQwertyNumberWhenThreeStateOff(
         appPreference.tenkey_switch_number_to_qwerty_number_preference
     )
-    tenKey.setKeyLetterSize((appPreference.key_letter_size ?: 0.0f) + 17f)
+    tenKey.setKeyLetterSize(
+        (appPreference.key_letter_size ?: 0.0f) + KeyTextSizeDefaults.TenKeyJapaneseSp
+    )
     tenKey.setKeyLetterSizeDelta((appPreference.key_letter_size ?: 0.0f).toInt())
     tenKey.setKeySizeScale(
         appPreference.tenkey_key_width_scale_percent ?: 100,
@@ -668,8 +671,9 @@ private fun configureFlickKeyboardPreview(
         keyWidthScalePercent = appPreference.flick_key_width_scale_percent ?: 160,
         keyHeightScalePercent = appPreference.flick_key_height_scale_percent ?: 160,
         iconScalePercent = appPreference.flick_key_icon_scale_percent ?: 80,
-        textSizeSp = appPreference.flick_key_text_size_sp ?: 16.0f,
-        specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp ?: 16.0f
+        textSizeSp = appPreference.flick_key_text_size_sp ?: KeyTextSizeDefaults.SumireKeySp,
+        specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp
+            ?: KeyTextSizeDefaults.SumireSpecialKeySp
     )
     flickView.applyPopupViewStyleSet(
         FlickPopupViewStyleSet(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/key_candidate_letter_size/KeyCandidateLetterSizeFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/key_candidate_letter_size/KeyCandidateLetterSizeFragment.kt
@@ -1,7 +1,6 @@
 package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.key_candidate_letter_size
 
 import android.annotation.SuppressLint
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -15,12 +14,13 @@ import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.kazumaproject.core.domain.extensions.dpToPx
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
 import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentKeyCandidateLetterSizeBinding
 import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionAdapter
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.KeyTextSizePreviewSizing
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -38,7 +38,7 @@ class KeyCandidateLetterSizeFragment : Fragment() {
     private val maxKeyTextSize = 40f
     private val minCandidateTextSize = 10f
     private val maxCandidateTextSize = 40f
-    private val defaultKeyTextSize = 17.0f
+    private val defaultKeyTextSize = KeyTextSizeDefaults.TenKeyJapaneseSp
     private val defaultCandidateTextSize = 14.0f
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -86,12 +86,9 @@ class KeyCandidateLetterSizeFragment : Fragment() {
         val heightPref = appPreference.keyboard_height ?: 280
         val widthPref = appPreference.keyboard_width ?: 280
         val density = resources.displayMetrics.density
-        val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
         val screenWidth = resources.displayMetrics.widthPixels
         val positionPref = appPreference.keyboard_position ?: true
-        val clampedHeight = heightPref.coerceIn(180, 420)
-
-        val heightPx = (clampedHeight * density).toInt()
+        val heightPx = KeyTextSizePreviewSizing.heightPx(heightPref, density)
 
         val widthPx = when {
             widthPref == 100 -> {
@@ -102,16 +99,6 @@ class KeyCandidateLetterSizeFragment : Fragment() {
                 (screenWidth * (widthPref / 100f)).toInt()
             }
         }
-        val keyboardHeight = if (isPortrait) {
-            heightPx + requireContext().dpToPx(
-                appPreference.candidate_view_empty_height_dp ?: 110
-            )
-        } else {
-            heightPx + requireContext().dpToPx(
-                appPreference.candidate_view_empty_height_dp ?: 110
-            )
-        }
-
         (binding.suggestionLetterSizeRecyclerview.layoutParams as? androidx.constraintlayout.widget.ConstraintLayout.LayoutParams)?.let { params ->
             params.width = widthPx
             if (positionPref) {
@@ -129,7 +116,7 @@ class KeyCandidateLetterSizeFragment : Fragment() {
 
         (binding.tenkeyLetterSizePreview.layoutParams as? androidx.constraintlayout.widget.ConstraintLayout.LayoutParams)?.let { params ->
             params.width = widthPx
-            params.height = keyboardHeight
+            params.height = heightPx
             params.bottomMargin = 56
             params.bottomToBottom =
                 androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/sumire_custom_key_setting/FlickKeyboardSizeSettingsFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/sumire_custom_key_setting/FlickKeyboardSizeSettingsFragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
 import com.kazumaproject.custom_keyboard.view.FlickKeyboardView
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
 
@@ -257,7 +258,7 @@ class FlickKeyboardSizeSettingsFragment : Fragment() {
 
         private const val MIN_TEXT_SIZE_SP = 8f
         private const val MAX_TEXT_SIZE_SP = 32f
-        private const val DEFAULT_TEXT_SIZE_SP = 16f
-        private const val DEFAULT_SPECIAL_TEXT_SIZE_SP = 12f
+        private const val DEFAULT_TEXT_SIZE_SP = KeyTextSizeDefaults.SumireKeySp
+        private const val DEFAULT_SPECIAL_TEXT_SIZE_SP = KeyTextSizeDefaults.SumireSpecialKeySp
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/sumire_flick_angle/HierarchicalFlickAngleMarginFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/sumire_flick_angle/HierarchicalFlickAngleMarginFragment.kt
@@ -13,6 +13,7 @@ import com.kazumaproject.custom_keyboard.data.KeyAction
 import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
 import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
 import com.kazumaproject.custom_keyboard.view.FlickKeyboardView
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentHierarchicalFlickAngleMarginBinding
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
 import dagger.hilt.android.AndroidEntryPoint
@@ -96,8 +97,10 @@ class HierarchicalFlickAngleMarginFragment : Fragment() {
                 keyWidthScalePercent = appPreference.flick_key_width_scale_percent ?: 160,
                 keyHeightScalePercent = appPreference.flick_key_height_scale_percent ?: 160,
                 iconScalePercent = appPreference.flick_key_icon_scale_percent ?: 80,
-                textSizeSp = appPreference.flick_key_text_size_sp ?: 16.0f,
-                specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp ?: 16.0f
+                textSizeSp = appPreference.flick_key_text_size_sp
+                    ?: KeyTextSizeDefaults.SumireKeySp,
+                specialKeyTextSizeSp = appPreference.flick_special_key_text_size_sp
+                    ?: KeyTextSizeDefaults.SumireSpecialKeySp
             )
             setOnKeyboardActionListener(object : FlickKeyboardView.OnKeyboardActionListener {
                 override fun onPress(action: KeyAction) = Unit

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/tenkey_letter_size_setting/TenKeyCandidateLetterSizeFragment.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/tenkey_letter_size_setting/TenKeyCandidateLetterSizeFragment.kt
@@ -1,7 +1,6 @@
 package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.tenkey_letter_size_setting
 
 import android.annotation.SuppressLint
-import android.content.res.Configuration
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.Menu
@@ -15,12 +14,13 @@ import androidx.core.view.MenuProvider
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.recyclerview.widget.LinearLayoutManager
-import com.kazumaproject.core.domain.extensions.dpToPx
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
 import com.kazumaproject.markdownhelperkeyboard.databinding.FragmentTenkeyCandidateLetterSizeBinding
 import com.kazumaproject.markdownhelperkeyboard.ime_service.adapters.SuggestionAdapter
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
+import com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.KeyTextSizePreviewSizing
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -40,7 +40,7 @@ class TenKeyCandidateLetterSizeFragment : Fragment() {
     // 定数定義 (KeyCandidateLetterSizeFragmentから引用)
     private val minKeyTextSize = 12f
     private val maxKeyTextSize = 40f
-    private val defaultKeyTextSize = 17.0f
+    private val defaultKeyTextSize = KeyTextSizeDefaults.TenKeyJapaneseSp
     private val minKeyScalePercent = 60
     private val maxKeyScalePercent = 140
     private val defaultKeyScalePercent = 100
@@ -97,12 +97,9 @@ class TenKeyCandidateLetterSizeFragment : Fragment() {
         val heightPref = appPreference.keyboard_height ?: 280
         val widthPref = appPreference.keyboard_width ?: 280
         val density = resources.displayMetrics.density
-        val isPortrait = resources.configuration.orientation == Configuration.ORIENTATION_PORTRAIT
         val screenWidth = resources.displayMetrics.widthPixels
         val positionPref = appPreference.keyboard_position ?: true
-        val clampedHeight = heightPref.coerceIn(180, 420)
-
-        val heightPx = (clampedHeight * density).toInt()
+        val heightPx = KeyTextSizePreviewSizing.heightPx(heightPref, density)
 
         val widthPx = when {
             widthPref == 100 -> {
@@ -112,16 +109,6 @@ class TenKeyCandidateLetterSizeFragment : Fragment() {
             else -> {
                 (screenWidth * (widthPref / 100f)).toInt()
             }
-        }
-
-        val keyboardHeight = if (isPortrait) {
-            heightPx + requireContext().dpToPx(
-                appPreference.candidate_view_empty_height_dp ?: 110
-            )
-        } else {
-            heightPx + requireContext().dpToPx(
-                appPreference.candidate_view_empty_height_dp ?: 110
-            )
         }
 
         // 候補ビュー（RecyclerView）のレイアウト調整
@@ -142,7 +129,7 @@ class TenKeyCandidateLetterSizeFragment : Fragment() {
         // TenKeyプレビューのレイアウト調整
         (binding.tenkeyLetterSizePreview.layoutParams as? androidx.constraintlayout.widget.ConstraintLayout.LayoutParams)?.let { params ->
             params.width = widthPx
-            params.height = keyboardHeight
+            params.height = heightPx
             params.bottomMargin = 56
             params.bottomToBottom =
                 androidx.constraintlayout.widget.ConstraintLayout.LayoutParams.PARENT_ID

--- a/app/src/main/res/layout/fragment_flick_keyboard_size_settings.xml
+++ b/app/src/main/res/layout/fragment_flick_keyboard_size_settings.xml
@@ -124,7 +124,7 @@
                 android:id="@+id/textTextSizeValue"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="14.0sp"
+                android:text="20.0sp"
                 android:textSize="16sp" />
         </LinearLayout>
 
@@ -152,7 +152,7 @@
                 android:id="@+id/textSpecialTextSizeValue"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="16.0sp"
+                android:text="12.0sp"
                 android:textSize="16sp" />
         </LinearLayout>
 

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreferenceKeyTextSizeDefaultsTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreferenceKeyTextSizeDefaultsTest.kt
@@ -1,0 +1,28 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity
+
+import android.content.Context
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ApplicationProvider
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class AppPreferenceKeyTextSizeDefaultsTest {
+
+    @Before
+    fun setUp() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        PreferenceManager.getDefaultSharedPreferences(context).edit().clear().commit()
+        AppPreference.init(context)
+    }
+
+    @Test
+    fun sumireKeyTextSizeUsesTheReadableDefault() {
+        assertEquals(20f, AppPreference.flick_key_text_size_sp)
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/KeyTextSizePreviewSizingTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/KeyTextSizePreviewSizingTest.kt
@@ -1,0 +1,18 @@
+package com.kazumaproject.markdownhelperkeyboard.setting_activity.ui
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyTextSizePreviewSizingTest {
+
+    @Test
+    fun previewHeightMatchesTheConfiguredKeyboardHeightWithoutCandidateStrip() {
+        assertEquals(440, KeyTextSizePreviewSizing.heightPx(heightDp = 220, density = 2f))
+    }
+
+    @Test
+    fun previewHeightUsesTheSameBoundsAsNormalKeyboardSizing() {
+        assertEquals(200, KeyTextSizePreviewSizing.heightPx(heightDp = 60, density = 2f))
+        assertEquals(840, KeyTextSizePreviewSizing.heightPx(heightDp = 500, density = 2f))
+    }
+}

--- a/core/src/main/java/com/kazumaproject/core/domain/key/KeyTextSizeDefaults.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/key/KeyTextSizeDefaults.kt
@@ -1,0 +1,17 @@
+package com.kazumaproject.core.domain.key
+
+import com.kazumaproject.core.domain.state.InputMode
+
+object KeyTextSizeDefaults {
+    const val TenKeyJapaneseSp = 20f
+    const val TenKeyEnglishSp = 12f
+    const val TenKeyNumberSp = 16f
+    const val SumireKeySp = 20f
+    const val SumireSpecialKeySp = 12f
+
+    fun tenKeySizeSp(inputMode: InputMode): Float = when (inputMode) {
+        InputMode.ModeJapanese -> TenKeyJapaneseSp
+        InputMode.ModeEnglish -> TenKeyEnglishSp
+        InputMode.ModeNumber -> TenKeyNumberSp
+    }
+}

--- a/core/src/test/java/com/kazumaproject/core/domain/key/KeyTextSizeDefaultsTest.kt
+++ b/core/src/test/java/com/kazumaproject/core/domain/key/KeyTextSizeDefaultsTest.kt
@@ -1,0 +1,20 @@
+package com.kazumaproject.core.domain.key
+
+import com.kazumaproject.core.domain.state.InputMode
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class KeyTextSizeDefaultsTest {
+
+    @Test
+    fun japaneseTenKeyAndSumireDefaultsAreReadable() {
+        assertEquals(20f, KeyTextSizeDefaults.tenKeySizeSp(InputMode.ModeJapanese))
+        assertEquals(20f, KeyTextSizeDefaults.SumireKeySp)
+    }
+
+    @Test
+    fun tenKeyKeepsModeSpecificDefaults() {
+        assertEquals(12f, KeyTextSizeDefaults.tenKeySizeSp(InputMode.ModeEnglish))
+        assertEquals(16f, KeyTextSizeDefaults.tenKeySizeSp(InputMode.ModeNumber))
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -89,6 +89,7 @@ import com.kazumaproject.custom_keyboard.layout.SegmentedBackgroundDrawable
 import com.kazumaproject.core.domain.flick.FlickTextPreviewEmitter
 import com.kazumaproject.core.domain.flick.FlickTextPreviewListener
 import com.kazumaproject.core.domain.flick.FlickTextSelection
+import com.kazumaproject.core.domain.key.KeyTextSizeDefaults
 import java.util.IdentityHashMap
 import kotlin.math.abs
 import kotlin.math.roundToInt
@@ -164,7 +165,7 @@ class FlickKeyboardView @JvmOverloads constructor(
             flickThresholdShape = settings.flickThresholdShape
         )
     }
-    private var defaultTextSize = 14f
+    private var defaultTextSize = KeyTextSizeDefaults.SumireKeySp
     private var specialKeyTextSizeSp = SPECIAL_KEY_BASE_TEXT_SIZE_SP
 
     /**

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardViewDefaultTextSizeTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardViewDefaultTextSizeTest.kt
@@ -1,0 +1,46 @@
+package com.kazumaproject.custom_keyboard.view
+
+import android.util.TypedValue
+import android.view.ContextThemeWrapper
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class FlickKeyboardViewDefaultTextSizeTest {
+
+    @Test
+    fun defaultLayoutRendersStandardKeysAtTheReadableDefault() {
+        val context = ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext(),
+            com.google.android.material.R.style.Theme_Material3_DayNight_NoActionBar,
+        )
+        val keyboard = FlickKeyboardView(context)
+        val layout = KeyboardDefaultLayouts.defaultLayout()
+        val standardKeyLabel = layout.keys.first { !it.isSpecialKey }.label
+        keyboard.setKeyboard(layout)
+        keyboard.measure(exactly(1080), exactly(1000))
+        keyboard.layout(0, 0, 1080, 1000)
+
+        val standardKey = (0 until keyboard.childCount)
+            .map(keyboard::getChildAt)
+            .filterIsInstance<AutoSizeButton>()
+            .first { it.text.toString() == standardKeyLabel }
+        val expectedSizePx = TypedValue.applyDimension(
+            TypedValue.COMPLEX_UNIT_SP,
+            20f,
+            context.resources.displayMetrics,
+        )
+
+        assertEquals(expectedSizePx, standardKey.textSize, 0.01f)
+    }
+
+    private fun exactly(size: Int): Int =
+        View.MeasureSpec.makeMeasureSpec(size, View.MeasureSpec.EXACTLY)
+}

--- a/docs/testing/issue-933.tdd.md
+++ b/docs/testing/issue-933.tdd.md
@@ -1,0 +1,45 @@
+# Issue #933 TDD evidence
+
+## Source and user journeys
+
+The journeys were derived from [Issue #933](https://github.com/KazumaProject/JapaneseKeyboard/issues/933) and its follow-up comments.
+
+- As a new user, I can read the default Japanese TenKey and Sumire/custom keyboard labels without first increasing their text size.
+- As a user adjusting TenKey text size, I see the keyboard preview at the height configured in keyboard-size settings, so I can judge the key-size/text-size ratio accurately.
+
+## Task report
+
+### Readable default key text
+
+- RED: `./gradlew.bat :core:testDebugUnitTest --tests "com.kazumaproject.core.domain.key.KeyTextSizeDefaultsTest"` failed to compile because `KeyTextSizeDefaults` did not exist.
+- RED: `./gradlew.bat :custom_keyboard:testDebugUnitTest --tests "com.kazumaproject.custom_keyboard.view.FlickKeyboardViewDefaultTextSizeTest"` ran the new test and failed its 20sp assertion against the previous 14sp view default.
+- GREEN: the core test passed after centralizing mode-specific defaults, and the custom keyboard test passed after applying the 20sp Sumire default to `FlickKeyboardView`.
+- GREEN: `./gradlew.bat :app:testLiteStandardDebugUnitTest --tests "com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreferenceKeyTextSizeDefaultsTest"` passed with an empty preference store.
+
+### Keyboard height in text-size previews
+
+- RED: `./gradlew.bat :app:testLiteStandardDebugUnitTest --tests "com.kazumaproject.markdownhelperkeyboard.setting_activity.ui.KeyTextSizePreviewSizingTest"` failed to compile because the shared preview sizing policy did not exist.
+- GREEN: the same test passed after using the normal keyboard range (100-420dp), excluding the separately rendered candidate strip, and applying the result in both TenKey text-size preview screens.
+
+## Test specification
+
+| # | What is guaranteed | Test | Type | Result |
+|---|---|---|---|---|
+| 1 | Japanese TenKey and Sumire normal-key defaults are 20sp | `KeyTextSizeDefaultsTest` | Unit | PASS |
+| 2 | English and number TenKey defaults remain 12sp and 16sp | `KeyTextSizeDefaultsTest` | Unit | PASS |
+| 3 | Empty preferences resolve the Sumire normal-key size to 20sp | `AppPreferenceKeyTextSizeDefaultsTest` | Robolectric | PASS |
+| 4 | A default Sumire layout renders an ordinary key at 20sp | `FlickKeyboardViewDefaultTextSizeTest` | Robolectric | PASS |
+| 5 | A 220dp keyboard setting produces a 220dp preview, without candidate-strip height | `KeyTextSizePreviewSizingTest` | Unit | PASS |
+| 6 | Text-size previews use the production 100-420dp height bounds | `KeyTextSizePreviewSizingTest` | Unit | PASS |
+
+## Verification, coverage, and known gaps
+
+- `:core:testDebugUnitTest`: 30 passed.
+- `:custom_keyboard:testDebugUnitTest`: 195 passed.
+- Issue-specific app tests: 3 passed.
+- `:app:assembleLiteStandardDebug`: passed and produced `app-lite-standard-debug.apk`.
+- `:app:lintLiteStandardDebug`: passed with 0 errors and 407 existing warnings.
+- The full app unit-test run executed 1,376 tests: 1,370 passed, 2 failed, and 4 were skipped. The two failures (`CandidateOrderOverrideMigrationTest` and `DoubleTapMigrationTest`) were reproduced in isolation and both fail because Robolectric cannot create their SQLite files under its temporary data directory; they do not exercise the files changed for Issue #933.
+- This project does not expose a coverage task or threshold for these Android modules, so no percentage was recorded. The six behavior guarantees above directly cover both requested fixes and their boundary values.
+
+No checkpoint commits were created because repository instructions reserve commits for the user. RED/GREEN command evidence is retained in this report for merge or squash review.


### PR DESCRIPTION
Fixes #933 

- デフォルトのキー文字サイズを少し大きくしました
- 文字サイズ設定画面において、キーボードの高さが反映されない問題を修正しました