### PR TITLE
高速マルチタッチ入力の安定化と回帰テスト拡張 / Stabilize rapid multi-touch input and expand regression coverage

### DIFF
--- a/.github/fast-input-matrix.json
+++ b/.github/fast-input-matrix.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "jobs": [
+    {
+      "surface": "TENKEY",
+      "job_key": "TENKEY",
+      "sumire_method": "ALL"
+    },
+    {
+      "surface": "GOJUON",
+      "job_key": "GOJUON",
+      "sumire_method": "ALL"
+    },
+    {
+      "surface": "SUMIRE",
+      "job_key": "SUMIRE-toggle",
+      "sumire_method": "toggle"
+    },
+    {
+      "surface": "SUMIRE",
+      "job_key": "SUMIRE-flick",
+      "sumire_method": "flick"
+    },
+    {
+      "surface": "SUMIRE",
+      "job_key": "SUMIRE-switch-mode-effective",
+      "sumire_method": "switch-mode-effective"
+    },
+    {
+      "surface": "QWERTY",
+      "job_key": "QWERTY",
+      "sumire_method": "ALL"
+    },
+    {
+      "surface": "ROMAJI",
+      "job_key": "ROMAJI",
+      "sumire_method": "ALL"
+    },
+    {
+      "surface": "CUSTOM",
+      "job_key": "CUSTOM",
+      "sumire_method": "ALL"
+    }
+  ]
+}

--- a/.github/scripts/fast-input-contract.sh
+++ b/.github/scripts/fast-input-contract.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+
+# Shared, sourceable validation for the fast-input test contract.
+# Keep this script compatible with the Bash shipped by macOS runners.
+
+fast_input_contract_error() {
+  echo "FAST_INPUT_CONTRACT_ERROR: $*" >&2
+  return 2
+}
+
+fast_input_contract_compact() {
+  printf '%s' "$1" | tr -d '[:space:]'
+}
+
+fast_input_contract_has_token() {
+  local token="$1"
+  local csv="$2"
+
+  case ",${csv}," in
+    *,"${token}",*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+fast_input_contract_normalize_csv() {
+  local raw="$1"
+  local kind="$2"
+  local compact
+  local token
+  local normalized=""
+  local -a tokens
+
+  compact="$(fast_input_contract_compact "$raw")"
+  if [ -z "$compact" ]; then
+    fast_input_contract_error "${kind} must not be empty"
+    return 2
+  fi
+
+  IFS=',' read -r -a tokens <<< "$compact"
+  for token in "${tokens[@]}"; do
+    if [ -z "$token" ]; then
+      fast_input_contract_error "${kind} contains an empty value"
+      return 2
+    fi
+
+    case "$kind" in
+      surfaces)
+        token="$(printf '%s' "$token" | tr '[:lower:]' '[:upper:]')"
+        case "$token" in
+          TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM) ;;
+          *)
+            fast_input_contract_error "unknown surface: ${token}"
+            return 2
+            ;;
+        esac
+        ;;
+      columns)
+        case "$token" in
+          1|2|3) ;;
+          *)
+            fast_input_contract_error "unknown column: ${token}"
+            return 2
+            ;;
+        esac
+        ;;
+      sumireMethods)
+        token="$(printf '%s' "$token" | tr '[:upper:]' '[:lower:]')"
+        case "$token" in
+          toggle|flick|switch-mode-effective) ;;
+          *)
+            fast_input_contract_error "unknown Sumire method: ${token}"
+            return 2
+            ;;
+        esac
+        ;;
+      *)
+        fast_input_contract_error "unknown contract field: ${kind}"
+        return 2
+        ;;
+    esac
+
+    if fast_input_contract_has_token "$token" "$normalized"; then
+      fast_input_contract_error "${kind} contains a duplicate value: ${token}"
+      return 2
+    fi
+
+    if [ -n "$normalized" ]; then
+      normalized="${normalized},"
+    fi
+    normalized="${normalized}${token}"
+  done
+
+  printf '%s' "$normalized"
+}
+
+fast_input_contract_normalize() {
+  local rounds="$1"
+  local surfaces="$2"
+  local columns="$3"
+  local sumire_methods="$4"
+  local compact_surfaces
+  local compact_methods
+  local normalized_surface_case
+  local normalized_method_case
+  local normalized_surfaces
+  local normalized_columns
+  local normalized_methods
+
+  case "$rounds" in
+    ''|*[!0-9]*)
+      fast_input_contract_error "rounds must be a positive integer: ${rounds}"
+      return 2
+      ;;
+  esac
+  if [ "$rounds" -le 0 ]; then
+    fast_input_contract_error "rounds must be greater than zero"
+    return 2
+  fi
+  if [ "$rounds" -gt 10 ]; then
+    fast_input_contract_error "rounds must be <= 10"
+    return 2
+  fi
+
+  compact_surfaces="$(fast_input_contract_compact "$surfaces")"
+  normalized_surface_case="$(printf '%s' "$compact_surfaces" | tr '[:lower:]' '[:upper:]')"
+  if [[ "$normalized_surface_case" == *,* && "$normalized_surface_case" == *ALL* ]]; then
+    fast_input_contract_error "surfaces cannot combine ALL with a surface name"
+    return 2
+  fi
+  case "$normalized_surface_case" in
+    ALL)
+      normalized_surfaces="ALL"
+      ;;
+    *)
+      normalized_surfaces="$(fast_input_contract_normalize_csv "$compact_surfaces" surfaces)" || return $?
+      ;;
+  esac
+
+  normalized_columns="$(fast_input_contract_normalize_csv "$columns" columns)" || return $?
+
+  compact_methods="$(fast_input_contract_compact "$sumire_methods")"
+  normalized_method_case="$(printf '%s' "$compact_methods" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$normalized_method_case" == *,* && "$normalized_method_case" == *all* ]]; then
+    fast_input_contract_error "sumireMethods cannot combine ALL with a method name"
+    return 2
+  fi
+  case "$normalized_method_case" in
+    all)
+      normalized_methods="ALL"
+      ;;
+    *)
+      normalized_methods="$(fast_input_contract_normalize_csv "$compact_methods" sumireMethods)" || return $?
+      ;;
+  esac
+
+  FAST_INPUT_CONTRACT_ROUNDS="$rounds"
+  FAST_INPUT_CONTRACT_SURFACES="$normalized_surfaces"
+  FAST_INPUT_CONTRACT_COLUMNS="$normalized_columns"
+  FAST_INPUT_CONTRACT_SUMIRE_METHODS="$normalized_methods"
+  export FAST_INPUT_CONTRACT_ROUNDS
+  export FAST_INPUT_CONTRACT_SURFACES
+  export FAST_INPUT_CONTRACT_COLUMNS
+  export FAST_INPUT_CONTRACT_SUMIRE_METHODS
+}

--- a/.github/scripts/ime-emulator-common.sh
+++ b/.github/scripts/ime-emulator-common.sh
@@ -224,6 +224,10 @@ ime_emulator_capture_diagnostics() {
     > "$diagnostic_dir/activity-top.txt" || true
   adb -s "$IME_EMULATOR_SERIAL" shell dumpsys activity processes \
     > "$diagnostic_dir/activity-processes.txt" || true
+  adb -s "$IME_EMULATOR_SERIAL" shell dumpsys meminfo \
+    > "$diagnostic_dir/meminfo.txt" || true
+  adb -s "$IME_EMULATOR_SERIAL" shell dumpsys procstats \
+    > "$diagnostic_dir/procstats.txt" || true
   adb -s "$IME_EMULATOR_SERIAL" shell dumpsys input_method \
     > "$diagnostic_dir/input-method.txt" || true
   adb -s "$IME_EMULATOR_SERIAL" shell dumpsys input \

--- a/.github/scripts/ime-emulator-common.sh
+++ b/.github/scripts/ime-emulator-common.sh
@@ -60,6 +60,24 @@ ime_emulator_wait_for_android_services() {
   return 1
 }
 
+ime_emulator_wait_for_device() {
+  local timeout_seconds="${IME_EMULATOR_DEVICE_WAIT_TIMEOUT_SECONDS:-120}"
+  local started_at="$SECONDS"
+  local device_state
+
+  while true; do
+    device_state="$(adb -s "$IME_EMULATOR_SERIAL" get-state 2>/dev/null || true)"
+    if [[ "$device_state" == "device" ]]; then
+      return 0
+    fi
+    if (($SECONDS - started_at >= timeout_seconds)); then
+      echo "ADB device $IME_EMULATOR_SERIAL did not become ready within ${timeout_seconds}s (state=${device_state:-unavailable})." >&2
+      return 124
+    fi
+    sleep 2
+  done
+}
+
 ime_emulator_android_runtime_config() {
   adb -s "$IME_EMULATOR_SERIAL" shell am get-config 2>/dev/null |
     tr -d '\r' |
@@ -82,7 +100,7 @@ ime_emulator_detach_at_keyboard() {
     > "$IME_EMULATOR_LOG_DIR/input-service-before-keyboard-detach.txt" || true
   adb_root_output="$(adb -s "$IME_EMULATOR_SERIAL" root 2>&1 || true)"
   echo "adb root: $adb_root_output" | tee -a "$IME_EMULATOR_READINESS_LOG"
-  if ! adb -s "$IME_EMULATOR_SERIAL" wait-for-device; then
+  if ! ime_emulator_wait_for_device; then
     echo "The emulator did not reconnect after restarting adbd as root." |
       tee -a "$IME_EMULATOR_READINESS_LOG"
     return 1

--- a/.github/scripts/ime-emulator-common.sh
+++ b/.github/scripts/ime-emulator-common.sh
@@ -214,8 +214,10 @@ ime_emulator_capture_diagnostics() {
   local diagnostic_dir="$IME_EMULATOR_LOG_DIR/$label"
   mkdir -p "$diagnostic_dir"
 
-  adb -s "$IME_EMULATOR_SERIAL" exec-out screencap -p \
-    > "$diagnostic_dir/screen.png" || true
+  if [[ "${IME_EMULATOR_CAPTURE_SCREENSHOTS:-true}" == "true" ]]; then
+    adb -s "$IME_EMULATOR_SERIAL" exec-out screencap -p \
+      > "$diagnostic_dir/screen.png" || true
+  fi
   adb -s "$IME_EMULATOR_SERIAL" shell dumpsys window windows \
     > "$diagnostic_dir/window.txt" || true
   adb -s "$IME_EMULATOR_SERIAL" shell dumpsys activity top \

--- a/.github/scripts/run-fast-input-regression-device.sh
+++ b/.github/scripts/run-fast-input-regression-device.sh
@@ -207,7 +207,7 @@ fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
   tail -n 1 |
   sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY)/\1/' || true)"
 fast_input_failure_excerpt="$(grep -h -E \
-  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|DeadObjectException|Error while injecting input event|timeout: sending signal|Terminated' \
+  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|Error while injecting input event|timeout: sending signal|Terminated' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null | head -n 12 | cut -c 1-1200 || true)"
 
@@ -220,6 +220,9 @@ elif ((fast_input_gradle_status == 0)) && [[ -n "$fast_input_summary_line" ]]; t
   fast_input_status="COMPLETED"
 else
   fast_input_status="FAILED"
+fi
+if [[ "$fast_input_status" == "COMPLETED" ]]; then
+  fast_input_failure_excerpt=""
 fi
 fast_input_exit_status="$fast_input_gradle_status"
 if ((fast_input_gradle_status == 0)) && [[ "$fast_input_status" != "COMPLETED" ]]; then

--- a/.github/scripts/run-fast-input-regression-device.sh
+++ b/.github/scripts/run-fast-input-regression-device.sh
@@ -97,6 +97,10 @@ capture_device_diagnostics() {
     > "$diagnostic_dir/activity-top.txt" || true
   adb -s "$fast_input_device_serial" shell dumpsys activity processes \
     > "$diagnostic_dir/activity-processes.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys meminfo \
+    > "$diagnostic_dir/meminfo.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys procstats \
+    > "$diagnostic_dir/procstats.txt" || true
   adb -s "$fast_input_device_serial" shell dumpsys input_method \
     > "$diagnostic_dir/input-method.txt" || true
   adb -s "$fast_input_device_serial" shell dumpsys input \
@@ -203,7 +207,7 @@ fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
   tail -n 1 |
   sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY)/\1/' || true)"
 fast_input_failure_excerpt="$(grep -h -E \
-  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|timeout: sending signal|Terminated|Killed' \
+  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|DeadObjectException|Error while injecting input event|timeout: sending signal|Terminated' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null | head -n 12 | cut -c 1-1200 || true)"
 

--- a/.github/scripts/run-fast-input-regression-device.sh
+++ b/.github/scripts/run-fast-input-regression-device.sh
@@ -16,36 +16,26 @@ fast_input_test_method="$fast_input_test_class#generatedTwoFingerInputAcrossAllK
 fast_input_started_at="$(date +%s)"
 fast_input_elapsed_seconds=0
 
+source "${BASH_SOURCE[0]%/*}/fast-input-contract.sh"
+fast_input_contract_normalize \
+  "$fast_input_rounds" \
+  "$fast_input_generated_surfaces" \
+  "$fast_input_generated_columns" \
+  "$fast_input_sumire_methods"
+fast_input_rounds="$FAST_INPUT_CONTRACT_ROUNDS"
+fast_input_generated_surfaces="$FAST_INPUT_CONTRACT_SURFACES"
+fast_input_generated_columns="$FAST_INPUT_CONTRACT_COLUMNS"
+fast_input_sumire_methods="$FAST_INPUT_CONTRACT_SUMIRE_METHODS"
+
 is_positive_integer() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
 }
 
-if ! is_positive_integer "$fast_input_rounds" || ((fast_input_rounds > 10)); then
-  echo "FAST_INPUT_ROUNDS must be an integer from 1 to 10."
-  exit 2
-fi
 if ! is_positive_integer "$fast_input_timeout_minutes" ||
   ((fast_input_timeout_minutes < 1 || fast_input_timeout_minutes > 120)); then
   echo "FAST_INPUT_TIMEOUT_MINUTES must be an integer from 1 to 120."
   exit 2
 fi
-surface_pattern='(TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM)'
-if [[ "$fast_input_generated_surfaces" != "ALL" &&
-  ! "$fast_input_generated_surfaces" =~ ^${surface_pattern}(,${surface_pattern})*$ ]]; then
-  echo "FAST_INPUT_GENERATED_SURFACES must be ALL or a comma-separated surface list."
-  exit 2
-fi
-if [[ ! "$fast_input_generated_columns" =~ ^[123](,[123])*$ ]]; then
-  echo "FAST_INPUT_GENERATED_COLUMNS must be a comma-separated list containing 1, 2, or 3."
-  exit 2
-fi
-sumire_method_pattern='(toggle|flick|switch-mode-effective)'
-if [[ "$fast_input_sumire_methods" != "ALL" &&
-  ! "$fast_input_sumire_methods" =~ ^${sumire_method_pattern}(,${sumire_method_pattern})*$ ]]; then
-  echo "FAST_INPUT_SUMIRE_METHODS must be ALL or a comma-separated method list."
-  exit 2
-fi
-
 if [[ -z "${ANDROID_HOME:-}" && -z "${ANDROID_SDK_ROOT:-}" ]]; then
   fast_input_adb_path="$(command -v adb || true)"
   if [[ -n "$fast_input_adb_path" ]]; then
@@ -87,6 +77,24 @@ run_fast_input_with_timeout() {
 mkdir -p "$fast_input_log_dir"
 export ANDROID_SERIAL="$fast_input_device_serial"
 
+fast_input_wait_for_device() {
+  local timeout_seconds="$1"
+  local started_at="$SECONDS"
+  local device_state
+
+  while true; do
+    device_state="$(adb -s "$fast_input_device_serial" get-state 2>/dev/null || true)"
+    if [[ "$device_state" == "device" ]]; then
+      return 0
+    fi
+    if (($SECONDS - started_at >= timeout_seconds)); then
+      echo "ADB device $fast_input_device_serial did not become ready within ${timeout_seconds}s (state=${device_state:-unavailable})." >&2
+      return 124
+    fi
+    sleep 2
+  done
+}
+
 capture_device_diagnostics() {
   local label="$1"
   local diagnostic_dir="$fast_input_log_dir/$label"
@@ -119,6 +127,7 @@ write_summary() {
   local status="$1"
   local summary_line="$2"
   local failure_excerpt="$3"
+  local summary_json_line="$4"
   {
     echo "deviceSerial=$fast_input_device_serial"
     echo "status=$status"
@@ -132,6 +141,9 @@ write_summary() {
     else
       echo "FAST_INPUT_MULTITOUCH_SUMMARY was not emitted."
     fi
+    if [[ -n "$summary_json_line" ]]; then
+      echo "$summary_json_line"
+    fi
     if [[ -n "$failure_excerpt" ]]; then
       echo "failure_excerpt=$failure_excerpt"
     fi
@@ -139,8 +151,8 @@ write_summary() {
 }
 
 adb start-server >/dev/null 2>&1 || true
-if ! adb -s "$fast_input_device_serial" wait-for-device; then
-  write_summary "SETUP_ERROR" "" "ADB could not reach $fast_input_device_serial."
+if ! fast_input_wait_for_device 120; then
+  write_summary "SETUP_ERROR" "" "ADB could not reach $fast_input_device_serial within 120 seconds." ""
   exit 3
 fi
 
@@ -149,7 +161,7 @@ device_sdk="$(adb -s "$fast_input_device_serial" shell getprop ro.build.version.
 echo "Physical device: serial=$fast_input_device_serial model=$device_model sdk=$device_sdk"
 if [[ "$device_model" != *"Pixel 6"* ]]; then
   capture_device_diagnostics "device-model-failure"
-  write_summary "SETUP_ERROR" "" "Expected Pixel 6, got [$device_model]."
+  write_summary "SETUP_ERROR" "" "Expected Pixel 6, got [$device_model]." ""
   exit 3
 fi
 
@@ -166,7 +178,7 @@ for attempt in {1..60}; do
 done
 if [[ "$device_ready" != true ]]; then
   capture_device_diagnostics "device-readiness-failure"
-  write_summary "SETUP_ERROR" "" "Android services did not become ready."
+  write_summary "SETUP_ERROR" "" "Android services did not become ready." ""
   exit 3
 fi
 
@@ -201,22 +213,38 @@ capture_device_diagnostics "final-device-state"
 adb -s "$fast_input_device_serial" logcat -d -v threadtime \
   > "$fast_input_log_dir/device-logcat.txt" || true
 
-fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
+fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY ' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
   tail -n 1 |
   sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY)/\1/' || true)"
+fast_input_summary_json_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY_JSON ' \
+  "$fast_input_log_dir/gradle-connected-android-test.log" \
+  "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
+  tail -n 1 |
+  sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY_JSON)/\1/' || true)"
 fast_input_failure_excerpt="$(grep -h -E \
   'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|Error while injecting input event|timeout: sending signal|Terminated' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null | head -n 12 | cut -c 1-1200 || true)"
+fast_input_trace_excerpt="$(grep -h -E 'FastInputTrace|FAST_INPUT_TRACE' \
+  "$fast_input_log_dir/gradle-connected-android-test.log" \
+  "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
+  tail -n 40 | cut -c 1-1200 || true)"
+if [[ -n "$fast_input_trace_excerpt" ]]; then
+  if [[ -n "$fast_input_failure_excerpt" ]]; then
+    fast_input_failure_excerpt+=$'\n'
+  fi
+  fast_input_failure_excerpt+="trace_excerpt=$fast_input_trace_excerpt"
+fi
 
 fast_input_finished_at="$(date +%s)"
 fast_input_elapsed_seconds=$((fast_input_finished_at - fast_input_started_at))
 
 if ((fast_input_gradle_status == 124 || fast_input_gradle_status == 137)); then
   fast_input_status="RESULT_TIMEOUT"
-elif ((fast_input_gradle_status == 0)) && [[ -n "$fast_input_summary_line" ]]; then
+elif ((fast_input_gradle_status == 0)) &&
+  [[ -n "$fast_input_summary_line" && -n "$fast_input_summary_json_line" ]]; then
   fast_input_status="COMPLETED"
 else
   fast_input_status="FAILED"
@@ -228,7 +256,11 @@ fast_input_exit_status="$fast_input_gradle_status"
 if ((fast_input_gradle_status == 0)) && [[ "$fast_input_status" != "COMPLETED" ]]; then
   fast_input_exit_status=1
 fi
-write_summary "$fast_input_status" "$fast_input_summary_line" "$fast_input_failure_excerpt"
+write_summary \
+  "$fast_input_status" \
+  "$fast_input_summary_line" \
+  "$fast_input_failure_excerpt" \
+  "$fast_input_summary_json_line"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {
@@ -246,6 +278,9 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo '```text'
     if [[ -n "$fast_input_summary_line" ]]; then
       echo "$fast_input_summary_line"
+      if [[ -n "$fast_input_summary_json_line" ]]; then
+        echo "$fast_input_summary_json_line"
+      fi
     else
       echo "FAST_INPUT_MULTITOUCH_SUMMARY was not emitted."
       if [[ -n "$fast_input_failure_excerpt" ]]; then

--- a/.github/scripts/run-fast-input-regression-device.sh
+++ b/.github/scripts/run-fast-input-regression-device.sh
@@ -2,12 +2,13 @@
 
 set -euo pipefail
 
+fast_input_device_serial="${ANDROID_SERIAL:-${FAST_INPUT_DEVICE_SERIAL:-23241FDF6003NG}}"
 fast_input_rounds="${FAST_INPUT_ROUNDS:-1}"
 fast_input_generated_surfaces="${FAST_INPUT_GENERATED_SURFACES:-ALL}"
 fast_input_generated_columns="${FAST_INPUT_GENERATED_COLUMNS:-1,2,3}"
 fast_input_sumire_methods="${FAST_INPUT_SUMIRE_METHODS:-ALL}"
-fast_input_timeout_minutes="${FAST_INPUT_TIMEOUT_MINUTES:-35}"
-fast_input_artifact_dir="${FAST_INPUT_ARTIFACT_DIR:-${GITHUB_WORKSPACE:-.}/fast-input-artifacts}"
+fast_input_timeout_minutes="${FAST_INPUT_TIMEOUT_MINUTES:-90}"
+fast_input_artifact_dir="${FAST_INPUT_ARTIFACT_DIR:-${GITHUB_WORKSPACE:-.}/fast-input-artifacts-device}"
 fast_input_log_dir="$fast_input_artifact_dir/logs"
 fast_input_summary_file="$fast_input_artifact_dir/summary-${FAST_INPUT_SUMMARY_SURFACE:-all}.txt"
 fast_input_test_class="com.kazumaproject.markdownhelperkeyboard.FastInputMatrixInstrumentedTest"
@@ -24,8 +25,8 @@ if ! is_positive_integer "$fast_input_rounds" || ((fast_input_rounds > 10)); the
   exit 2
 fi
 if ! is_positive_integer "$fast_input_timeout_minutes" ||
-  ((fast_input_timeout_minutes < 1 || fast_input_timeout_minutes > 40)); then
-  echo "FAST_INPUT_TIMEOUT_MINUTES must be an integer from 1 to 40."
+  ((fast_input_timeout_minutes < 1 || fast_input_timeout_minutes > 120)); then
+  echo "FAST_INPUT_TIMEOUT_MINUTES must be an integer from 1 to 120."
   exit 2
 fi
 surface_pattern='(TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM)'
@@ -45,40 +46,15 @@ if [[ "$fast_input_sumire_methods" != "ALL" &&
   exit 2
 fi
 
-mkdir -p "$fast_input_log_dir"
-export IME_EMULATOR_LOG_DIR="$fast_input_log_dir"
-export IME_EMULATOR_READINESS_LOG="$fast_input_log_dir/android-readiness.log"
-# The generated test is text-and-accessibility based. Keep the emulator diagnostic bundle
-# textual as well; screenshot capture is the failure path that caused the deleted CI run to hang.
-export IME_EMULATOR_CAPTURE_SCREENSHOTS=false
-source "${BASH_SOURCE[0]%/*}/ime-emulator-common.sh"
-
-write_summary() {
-  local status="$1"
-  local summary_line="$2"
-  local failure_excerpt="$3"
-  {
-    echo "surface=${FAST_INPUT_SUMMARY_SURFACE:-$fast_input_generated_surfaces}"
-    echo "status=$status"
-    echo "elapsedSeconds=$fast_input_elapsed_seconds"
-    echo "rounds=$fast_input_rounds"
-    echo "columns=$fast_input_generated_columns"
-    echo "sumireMethods=$fast_input_sumire_methods"
-    if [[ -n "$summary_line" ]]; then
-      echo "$summary_line"
-    else
-      echo "FAST_INPUT_MULTITOUCH_SUMMARY was not emitted."
+if [[ -z "${ANDROID_HOME:-}" && -z "${ANDROID_SDK_ROOT:-}" ]]; then
+  fast_input_adb_path="$(command -v adb || true)"
+  if [[ -n "$fast_input_adb_path" ]]; then
+    fast_input_sdk_root="$(cd "$(dirname "$fast_input_adb_path")/.." && pwd)"
+    if [[ -d "$fast_input_sdk_root/platform-tools" ]]; then
+      export ANDROID_HOME="$fast_input_sdk_root"
+      export ANDROID_SDK_ROOT="$fast_input_sdk_root"
     fi
-    if [[ -n "$failure_excerpt" ]]; then
-      echo "failure_excerpt=$failure_excerpt"
-    fi
-  } > "$fast_input_summary_file"
-}
-
-if ! ime_emulator_prepare; then
-  ime_emulator_capture_diagnostics "emulator-readiness-failure"
-  write_summary "SETUP_ERROR" "" "Emulator preparation failed."
-  exit 3
+  fi
 fi
 
 run_fast_input_with_timeout() {
@@ -108,6 +84,93 @@ run_fast_input_with_timeout() {
   wait "$command_pid"
 }
 
+mkdir -p "$fast_input_log_dir"
+export ANDROID_SERIAL="$fast_input_device_serial"
+
+capture_device_diagnostics() {
+  local label="$1"
+  local diagnostic_dir="$fast_input_log_dir/$label"
+  mkdir -p "$diagnostic_dir"
+  adb -s "$fast_input_device_serial" shell dumpsys window windows \
+    > "$diagnostic_dir/window.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys activity top \
+    > "$diagnostic_dir/activity-top.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys activity processes \
+    > "$diagnostic_dir/activity-processes.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys input_method \
+    > "$diagnostic_dir/input-method.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys input \
+    > "$diagnostic_dir/input.txt" || true
+  adb -s "$fast_input_device_serial" shell dumpsys display \
+    > "$diagnostic_dir/display.txt" || true
+  adb -s "$fast_input_device_serial" shell wm size \
+    > "$diagnostic_dir/wm-size.txt" || true
+  adb -s "$fast_input_device_serial" shell wm density \
+    > "$diagnostic_dir/wm-density.txt" || true
+  adb -s "$fast_input_device_serial" shell settings list secure \
+    > "$diagnostic_dir/settings-secure.txt" || true
+}
+
+write_summary() {
+  local status="$1"
+  local summary_line="$2"
+  local failure_excerpt="$3"
+  {
+    echo "deviceSerial=$fast_input_device_serial"
+    echo "status=$status"
+    echo "elapsedSeconds=$fast_input_elapsed_seconds"
+    echo "rounds=$fast_input_rounds"
+    echo "surfaces=$fast_input_generated_surfaces"
+    echo "columns=$fast_input_generated_columns"
+    echo "sumireMethods=$fast_input_sumire_methods"
+    if [[ -n "$summary_line" ]]; then
+      echo "$summary_line"
+    else
+      echo "FAST_INPUT_MULTITOUCH_SUMMARY was not emitted."
+    fi
+    if [[ -n "$failure_excerpt" ]]; then
+      echo "failure_excerpt=$failure_excerpt"
+    fi
+  } > "$fast_input_summary_file"
+}
+
+adb start-server >/dev/null 2>&1 || true
+if ! adb -s "$fast_input_device_serial" wait-for-device; then
+  write_summary "SETUP_ERROR" "" "ADB could not reach $fast_input_device_serial."
+  exit 3
+fi
+
+device_model="$(adb -s "$fast_input_device_serial" shell getprop ro.product.model | tr -d '\r' || true)"
+device_sdk="$(adb -s "$fast_input_device_serial" shell getprop ro.build.version.sdk | tr -d '\r' || true)"
+echo "Physical device: serial=$fast_input_device_serial model=$device_model sdk=$device_sdk"
+if [[ "$device_model" != *"Pixel 6"* ]]; then
+  capture_device_diagnostics "device-model-failure"
+  write_summary "SETUP_ERROR" "" "Expected Pixel 6, got [$device_model]."
+  exit 3
+fi
+
+device_ready=false
+for attempt in {1..60}; do
+  boot_completed="$(adb -s "$fast_input_device_serial" shell getprop sys.boot_completed | tr -d '\r' || true)"
+  input_method_service="$(adb -s "$fast_input_device_serial" shell service check input_method | tr -d '\r' || true)"
+  if [[ "$boot_completed" == "1" && "$input_method_service" == *"found"* ]]; then
+    device_ready=true
+    break
+  fi
+  echo "Device readiness attempt $attempt/60: boot=$boot_completed input_method=[$input_method_service]"
+  sleep 2
+done
+if [[ "$device_ready" != true ]]; then
+  capture_device_diagnostics "device-readiness-failure"
+  write_summary "SETUP_ERROR" "" "Android services did not become ready."
+  exit 3
+fi
+
+# The physical path intentionally has no KVM, AVD, AT-keyboard, or emulator-graphics setup.
+adb -s "$fast_input_device_serial" shell input keyevent KEYCODE_WAKEUP || true
+adb -s "$fast_input_device_serial" shell wm dismiss-keyguard || true
+adb -s "$fast_input_device_serial" logcat -c || true
+
 fast_input_gradle_args=(
   :app:connectedFullStandardDebugAndroidTest
   --stacktrace
@@ -128,10 +191,10 @@ fast_input_gradle_status=${PIPESTATUS[0]}
 set -e
 
 if ((fast_input_gradle_status != 0)); then
-  ime_emulator_capture_diagnostics "gradle-failure"
+  capture_device_diagnostics "gradle-failure"
 fi
-ime_emulator_capture_diagnostics "final-device-state"
-adb -s "$IME_EMULATOR_SERIAL" logcat -d -v threadtime \
+capture_device_diagnostics "final-device-state"
+adb -s "$fast_input_device_serial" logcat -d -v threadtime \
   > "$fast_input_log_dir/device-logcat.txt" || true
 
 fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
@@ -162,10 +225,11 @@ write_summary "$fast_input_status" "$fast_input_summary_line" "$fast_input_failu
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {
-    echo "## Fast Input Regression — ${FAST_INPUT_SUMMARY_SURFACE:-$fast_input_generated_surfaces}"
+    echo "## Fast Input Regression — physical Pixel 6"
     echo
     echo "- Mode: generated two-finger input only"
     echo "- Elapsed seconds: $fast_input_elapsed_seconds"
+    echo "- Device: $fast_input_device_serial ($device_model)"
     echo "- Rounds: $fast_input_rounds"
     echo "- Surfaces: $fast_input_generated_surfaces"
     echo "- Columns: $fast_input_generated_columns"

--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -140,7 +140,7 @@ fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
   tail -n 1 |
   sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY)/\1/' || true)"
 fast_input_failure_excerpt="$(grep -h -E \
-  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|DeadObjectException|Error while injecting input event|timeout: sending signal|Terminated' \
+  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|Error while injecting input event|timeout: sending signal|Terminated' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null | head -n 12 | cut -c 1-1200 || true)"
 
@@ -153,6 +153,9 @@ elif ((fast_input_gradle_status == 0)) && [[ -n "$fast_input_summary_line" ]]; t
   fast_input_status="COMPLETED"
 else
   fast_input_status="FAILED"
+fi
+if [[ "$fast_input_status" == "COMPLETED" ]]; then
+  fast_input_failure_excerpt=""
 fi
 fast_input_exit_status="$fast_input_gradle_status"
 if ((fast_input_gradle_status == 0)) && [[ "$fast_input_status" != "COMPLETED" ]]; then

--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -15,33 +15,24 @@ fast_input_test_method="$fast_input_test_class#generatedTwoFingerInputAcrossAllK
 fast_input_started_at="$(date +%s)"
 fast_input_elapsed_seconds=0
 
+source "${BASH_SOURCE[0]%/*}/fast-input-contract.sh"
+fast_input_contract_normalize \
+  "$fast_input_rounds" \
+  "$fast_input_generated_surfaces" \
+  "$fast_input_generated_columns" \
+  "$fast_input_sumire_methods"
+fast_input_rounds="$FAST_INPUT_CONTRACT_ROUNDS"
+fast_input_generated_surfaces="$FAST_INPUT_CONTRACT_SURFACES"
+fast_input_generated_columns="$FAST_INPUT_CONTRACT_COLUMNS"
+fast_input_sumire_methods="$FAST_INPUT_CONTRACT_SUMIRE_METHODS"
+
 is_positive_integer() {
   [[ "$1" =~ ^[1-9][0-9]*$ ]]
 }
 
-if ! is_positive_integer "$fast_input_rounds" || ((fast_input_rounds > 10)); then
-  echo "FAST_INPUT_ROUNDS must be an integer from 1 to 10."
-  exit 2
-fi
 if ! is_positive_integer "$fast_input_timeout_minutes" ||
   ((fast_input_timeout_minutes < 1 || fast_input_timeout_minutes > 40)); then
   echo "FAST_INPUT_TIMEOUT_MINUTES must be an integer from 1 to 40."
-  exit 2
-fi
-surface_pattern='(TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM)'
-if [[ "$fast_input_generated_surfaces" != "ALL" &&
-  ! "$fast_input_generated_surfaces" =~ ^${surface_pattern}(,${surface_pattern})*$ ]]; then
-  echo "FAST_INPUT_GENERATED_SURFACES must be ALL or a comma-separated surface list."
-  exit 2
-fi
-if [[ ! "$fast_input_generated_columns" =~ ^[123](,[123])*$ ]]; then
-  echo "FAST_INPUT_GENERATED_COLUMNS must be a comma-separated list containing 1, 2, or 3."
-  exit 2
-fi
-sumire_method_pattern='(toggle|flick|switch-mode-effective)'
-if [[ "$fast_input_sumire_methods" != "ALL" &&
-  ! "$fast_input_sumire_methods" =~ ^${sumire_method_pattern}(,${sumire_method_pattern})*$ ]]; then
-  echo "FAST_INPUT_SUMIRE_METHODS must be ALL or a comma-separated method list."
   exit 2
 fi
 
@@ -57,6 +48,7 @@ write_summary() {
   local status="$1"
   local summary_line="$2"
   local failure_excerpt="$3"
+  local summary_json_line="$4"
   {
     echo "surface=${FAST_INPUT_SUMMARY_SURFACE:-$fast_input_generated_surfaces}"
     echo "status=$status"
@@ -69,6 +61,9 @@ write_summary() {
     else
       echo "FAST_INPUT_MULTITOUCH_SUMMARY was not emitted."
     fi
+    if [[ -n "$summary_json_line" ]]; then
+      echo "$summary_json_line"
+    fi
     if [[ -n "$failure_excerpt" ]]; then
       echo "failure_excerpt=$failure_excerpt"
     fi
@@ -77,7 +72,7 @@ write_summary() {
 
 if ! ime_emulator_prepare; then
   ime_emulator_capture_diagnostics "emulator-readiness-failure"
-  write_summary "SETUP_ERROR" "" "Emulator preparation failed."
+  write_summary "SETUP_ERROR" "" "Emulator preparation failed." ""
   exit 3
 fi
 
@@ -134,22 +129,38 @@ ime_emulator_capture_diagnostics "final-device-state"
 adb -s "$IME_EMULATOR_SERIAL" logcat -d -v threadtime \
   > "$fast_input_log_dir/device-logcat.txt" || true
 
-fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
+fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY ' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
   tail -n 1 |
   sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY)/\1/' || true)"
+fast_input_summary_json_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY_JSON ' \
+  "$fast_input_log_dir/gradle-connected-android-test.log" \
+  "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
+  tail -n 1 |
+  sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY_JSON)/\1/' || true)"
 fast_input_failure_excerpt="$(grep -h -E \
   'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|Error while injecting input event|timeout: sending signal|Terminated' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null | head -n 12 | cut -c 1-1200 || true)"
+fast_input_trace_excerpt="$(grep -h -E 'FastInputTrace|FAST_INPUT_TRACE' \
+  "$fast_input_log_dir/gradle-connected-android-test.log" \
+  "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
+  tail -n 40 | cut -c 1-1200 || true)"
+if [[ -n "$fast_input_trace_excerpt" ]]; then
+  if [[ -n "$fast_input_failure_excerpt" ]]; then
+    fast_input_failure_excerpt+=$'\n'
+  fi
+  fast_input_failure_excerpt+="trace_excerpt=$fast_input_trace_excerpt"
+fi
 
 fast_input_finished_at="$(date +%s)"
 fast_input_elapsed_seconds=$((fast_input_finished_at - fast_input_started_at))
 
 if ((fast_input_gradle_status == 124 || fast_input_gradle_status == 137)); then
   fast_input_status="RESULT_TIMEOUT"
-elif ((fast_input_gradle_status == 0)) && [[ -n "$fast_input_summary_line" ]]; then
+elif ((fast_input_gradle_status == 0)) &&
+  [[ -n "$fast_input_summary_line" && -n "$fast_input_summary_json_line" ]]; then
   fast_input_status="COMPLETED"
 else
   fast_input_status="FAILED"
@@ -161,7 +172,11 @@ fast_input_exit_status="$fast_input_gradle_status"
 if ((fast_input_gradle_status == 0)) && [[ "$fast_input_status" != "COMPLETED" ]]; then
   fast_input_exit_status=1
 fi
-write_summary "$fast_input_status" "$fast_input_summary_line" "$fast_input_failure_excerpt"
+write_summary \
+  "$fast_input_status" \
+  "$fast_input_summary_line" \
+  "$fast_input_failure_excerpt" \
+  "$fast_input_summary_json_line"
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
   {
@@ -178,6 +193,9 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo '```text'
     if [[ -n "$fast_input_summary_line" ]]; then
       echo "$fast_input_summary_line"
+      if [[ -n "$fast_input_summary_json_line" ]]; then
+        echo "$fast_input_summary_json_line"
+      fi
     else
       echo "FAST_INPUT_MULTITOUCH_SUMMARY was not emitted."
       if [[ -n "$fast_input_failure_excerpt" ]]; then

--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -42,8 +42,13 @@ if ! ime_emulator_prepare; then
   exit 3
 fi
 
-fast_input_test_method=\
-"com.kazumaproject.markdownhelperkeyboard.FastInputMatrixInstrumentedTest#rapidInputFullMatrixOnPhysicalDevice"
+fast_input_test_class=\
+"com.kazumaproject.markdownhelperkeyboard.FastInputMatrixInstrumentedTest"
+fast_input_test_methods=\
+"$fast_input_test_class#generatedTwoFingerInputAcrossAllKeyboardsOnPhysicalDevice,"\
+"$fast_input_test_class#qwertyOverlappingTwoFingerInputOnPhysicalDevice,"\
+"$fast_input_test_class#sumireThreeColumnRateSweepOnPhysicalDevice,"\
+"$fast_input_test_class#rapidInputFullMatrixOnPhysicalDevice"
 
 set +e
 ./gradlew \
@@ -51,7 +56,7 @@ set +e
   --stacktrace \
   --no-daemon \
   --max-workers=2 \
-  "-Pandroid.testInstrumentationRunnerArguments.class=$fast_input_test_method" \
+  "-Pandroid.testInstrumentationRunnerArguments.class=$fast_input_test_methods" \
   "-Pandroid.testInstrumentationRunnerArguments.startCase=$fast_input_start_case" \
   "-Pandroid.testInstrumentationRunnerArguments.endCase=$fast_input_end_case" \
   "-Pandroid.testInstrumentationRunnerArguments.matrixRounds=$fast_input_rounds" \
@@ -74,11 +79,12 @@ if adb -s "$IME_EMULATOR_SERIAL" shell test -d "$fast_input_device_output"; then
 fi
 
 if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
-  fast_input_summary_line="$(
-    grep -h "FAST_INPUT_SUMMARY" \
+  fast_input_summary_lines="$(
+    grep -h -E \
+      'FAST_INPUT_(MULTITOUCH_|RATE_)?SUMMARY' \
       "$fast_input_log_dir/gradle-connected-android-test.log" \
       "$fast_input_log_dir/device-logcat.txt" 2>/dev/null |
-      tail -n 1 || true
+      tail -n 12 || true
   )"
   fast_input_failure_excerpt="$(
     grep -h -E \
@@ -96,8 +102,8 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "- Capture visuals: $fast_input_capture_visuals"
     echo
     echo '```text'
-    if [[ -n "$fast_input_summary_line" ]]; then
-      echo "$fast_input_summary_line"
+    if [[ -n "$fast_input_summary_lines" ]]; then
+      echo "$fast_input_summary_lines"
     else
       echo "FAST_INPUT_SUMMARY was not emitted."
       if [[ -n "$fast_input_failure_excerpt" ]]; then

--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -6,7 +6,7 @@ fast_input_rounds="${FAST_INPUT_ROUNDS:-1}"
 fast_input_generated_surfaces="${FAST_INPUT_GENERATED_SURFACES:-ALL}"
 fast_input_generated_columns="${FAST_INPUT_GENERATED_COLUMNS:-1,2,3}"
 fast_input_sumire_methods="${FAST_INPUT_SUMIRE_METHODS:-ALL}"
-fast_input_timeout_minutes="${FAST_INPUT_TIMEOUT_MINUTES:-35}"
+fast_input_timeout_minutes="${FAST_INPUT_TIMEOUT_MINUTES:-40}"
 fast_input_artifact_dir="${FAST_INPUT_ARTIFACT_DIR:-${GITHUB_WORKSPACE:-.}/fast-input-artifacts}"
 fast_input_log_dir="$fast_input_artifact_dir/logs"
 fast_input_summary_file="$fast_input_artifact_dir/summary-${FAST_INPUT_SUMMARY_SURFACE:-all}.txt"
@@ -140,7 +140,7 @@ fast_input_summary_line="$(grep -h -E 'FAST_INPUT_MULTITOUCH_SUMMARY' \
   tail -n 1 |
   sed -E 's/.*(FAST_INPUT_MULTITOUCH_SUMMARY)/\1/' || true)"
 fast_input_failure_excerpt="$(grep -h -E \
-  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|timeout: sending signal|Terminated|Killed' \
+  'FAST_INPUT_(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|category=(RESET_ERROR|SETUP_ERROR|INJECTION_ERROR|RESULT_TIMEOUT|INPUT_MISMATCH)|SetupException|AssertionError|FAILURE: Build failed|There were failing tests|DeadObjectException|Error while injecting input event|timeout: sending signal|Terminated' \
   "$fast_input_log_dir/gradle-connected-android-test.log" \
   "$fast_input_log_dir/device-logcat.txt" 2>/dev/null | head -n 12 | cut -c 1-1200 || true)"
 

--- a/.github/scripts/run-fast-input-regression.sh
+++ b/.github/scripts/run-fast-input-regression.sh
@@ -6,6 +6,9 @@ fast_input_rounds="${FAST_INPUT_ROUNDS:-1}"
 fast_input_capture_visuals="${FAST_INPUT_CAPTURE_VISUALS:-true}"
 fast_input_start_case="${FAST_INPUT_START_CASE:-1}"
 fast_input_end_case="${FAST_INPUT_END_CASE:-144}"
+fast_input_test_scope="${FAST_INPUT_TEST_SCOPE:-all}"
+fast_input_generated_surfaces="${FAST_INPUT_GENERATED_SURFACES:-ALL}"
+fast_input_generated_columns="${FAST_INPUT_GENERATED_COLUMNS:-1,2,3}"
 fast_input_artifact_dir="${GITHUB_WORKSPACE:-.}/fast-input-artifacts"
 fast_input_log_dir="$fast_input_artifact_dir/logs"
 fast_input_device_dir="$fast_input_artifact_dir/device"
@@ -31,6 +34,20 @@ if [[ "$fast_input_capture_visuals" != "true" &&
   echo "FAST_INPUT_CAPTURE_VISUALS must be true or false."
   exit 2
 fi
+if [[ "$fast_input_test_scope" != "all" &&
+  "$fast_input_test_scope" != "generated" ]]; then
+  echo "FAST_INPUT_TEST_SCOPE must be all or generated."
+  exit 2
+fi
+surface_pattern='(TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM)'
+if [[ ! "$fast_input_generated_surfaces" =~ ^(ALL|${surface_pattern}(,${surface_pattern})*)$ ]]; then
+  echo "FAST_INPUT_GENERATED_SURFACES must be ALL or a comma-separated surface list."
+  exit 2
+fi
+if [[ ! "$fast_input_generated_columns" =~ ^[123](,[123])*$ ]]; then
+  echo "FAST_INPUT_GENERATED_COLUMNS must be a comma-separated list containing 1, 2, or 3."
+  exit 2
+fi
 
 mkdir -p "$fast_input_log_dir" "$fast_input_device_dir"
 export IME_EMULATOR_LOG_DIR="$fast_input_log_dir"
@@ -44,23 +61,37 @@ fi
 
 fast_input_test_class=\
 "com.kazumaproject.markdownhelperkeyboard.FastInputMatrixInstrumentedTest"
-fast_input_test_methods=\
+if [[ "$fast_input_test_scope" == "generated" ]]; then
+  fast_input_test_methods=\
+"$fast_input_test_class#generatedTwoFingerInputAcrossAllKeyboardsOnPhysicalDevice"
+else
+  fast_input_test_methods=\
 "$fast_input_test_class#generatedTwoFingerInputAcrossAllKeyboardsOnPhysicalDevice,"\
 "$fast_input_test_class#qwertyOverlappingTwoFingerInputOnPhysicalDevice,"\
 "$fast_input_test_class#sumireThreeColumnRateSweepOnPhysicalDevice,"\
 "$fast_input_test_class#rapidInputFullMatrixOnPhysicalDevice"
+fi
+
+fast_input_gradle_args=(
+  :app:connectedFullStandardDebugAndroidTest
+  --stacktrace
+  --no-daemon
+  --max-workers=2
+  "-Pandroid.testInstrumentationRunnerArguments.class=$fast_input_test_methods"
+  "-Pandroid.testInstrumentationRunnerArguments.startCase=$fast_input_start_case"
+  "-Pandroid.testInstrumentationRunnerArguments.endCase=$fast_input_end_case"
+  "-Pandroid.testInstrumentationRunnerArguments.matrixRounds=$fast_input_rounds"
+  "-Pandroid.testInstrumentationRunnerArguments.captureVisuals=$fast_input_capture_visuals"
+  "-Pandroid.testInstrumentationRunnerArguments.matrixColumns=$fast_input_generated_columns"
+)
+if [[ "$fast_input_generated_surfaces" != "ALL" ]]; then
+  fast_input_gradle_args+=(
+    "-Pandroid.testInstrumentationRunnerArguments.matrixSurfaces=$fast_input_generated_surfaces"
+  )
+fi
 
 set +e
-./gradlew \
-  :app:connectedFullStandardDebugAndroidTest \
-  --stacktrace \
-  --no-daemon \
-  --max-workers=2 \
-  "-Pandroid.testInstrumentationRunnerArguments.class=$fast_input_test_methods" \
-  "-Pandroid.testInstrumentationRunnerArguments.startCase=$fast_input_start_case" \
-  "-Pandroid.testInstrumentationRunnerArguments.endCase=$fast_input_end_case" \
-  "-Pandroid.testInstrumentationRunnerArguments.matrixRounds=$fast_input_rounds" \
-  "-Pandroid.testInstrumentationRunnerArguments.captureVisuals=$fast_input_capture_visuals" \
+./gradlew "${fast_input_gradle_args[@]}" \
   2>&1 | tee "$fast_input_log_dir/gradle-connected-android-test.log"
 fast_input_gradle_status=${PIPESTATUS[0]}
 set -e
@@ -100,6 +131,9 @@ if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
     echo "- Cases: $fast_input_start_case-$fast_input_end_case"
     echo "- Rounds: $fast_input_rounds"
     echo "- Capture visuals: $fast_input_capture_visuals"
+    echo "- Test scope: $fast_input_test_scope"
+    echo "- Generated surfaces: $fast_input_generated_surfaces"
+    echo "- Generated columns: $fast_input_generated_columns"
     echo
     echo '```text'
     if [[ -n "$fast_input_summary_lines" ]]; then

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       rounds:
-        description: Number of repetitions for every configuration
+        description: Number of repetitions for every generated configuration
         required: true
         type: choice
         default: '1'
@@ -12,29 +12,6 @@ on:
           - '1'
           - '3'
           - '10'
-      capture_visuals:
-        description: Save empty and active screenshots for every configuration
-        required: true
-        type: boolean
-        default: true
-      start_case:
-        description: First matrix case to run (1-144)
-        required: true
-        type: string
-        default: '1'
-      end_case:
-        description: Last matrix case to run (1-144)
-        required: true
-        type: string
-        default: '144'
-      test_scope:
-        description: Run the complete suite or only generated multi-touch input
-        required: true
-        type: choice
-        default: all
-        options:
-          - all
-          - generated
       generated_surfaces:
         description: ALL or comma-separated TENKEY,GOJUON,SUMIRE,QWERTY,ROMAJI,CUSTOM
         required: true
@@ -50,13 +27,71 @@ permissions:
   contents: read
 
 jobs:
-  fast-input-regression:
-    name: Pixel 6 Pro API 35
+  select-fast-input-jobs:
+    name: Select Fast Input jobs
     runs-on: ubuntu-latest
-    # The full physical-input suite intentionally runs 756 generated cases plus the
-    # existing 144-configuration and 800-trial regressions. Leave enough headroom for
-    # slower hosted emulators and optional multi-round dispatches.
-    timeout-minutes: 360
+    outputs:
+      matrix: ${{ steps.select.outputs.matrix }}
+    steps:
+      - name: Build requested job matrix
+        id: select
+        env:
+          REQUESTED_SURFACES: ${{ inputs.generated_surfaces }}
+        run: |
+          set -euo pipefail
+          requested_surfaces="${REQUESTED_SURFACES//[[:space:]]/}"
+          requested_surfaces="${requested_surfaces^^}"
+          if [[ -z "$requested_surfaces" ]]; then
+            echo "generated_surfaces must not be empty."
+            exit 1
+          fi
+
+          all_matrix='[
+            {"surface":"TENKEY","job_key":"TENKEY","sumire_method":"ALL"},
+            {"surface":"GOJUON","job_key":"GOJUON","sumire_method":"ALL"},
+            {"surface":"SUMIRE","job_key":"SUMIRE-toggle","sumire_method":"toggle"},
+            {"surface":"SUMIRE","job_key":"SUMIRE-flick","sumire_method":"flick"},
+            {"surface":"SUMIRE","job_key":"SUMIRE-switch-mode-effective","sumire_method":"switch-mode-effective"},
+            {"surface":"QWERTY","job_key":"QWERTY","sumire_method":"ALL"},
+            {"surface":"ROMAJI","job_key":"ROMAJI","sumire_method":"ALL"},
+            {"surface":"CUSTOM","job_key":"CUSTOM","sumire_method":"ALL"}
+          ]'
+
+          if [[ "$requested_surfaces" != "ALL" ]]; then
+            IFS=',' read -r -a requested_surface_list <<< "$requested_surfaces"
+            for surface in "${requested_surface_list[@]}"; do
+              case "$surface" in
+                TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM) ;;
+                *)
+                  echo "Unknown generated surface: $surface"
+                  exit 1
+                  ;;
+              esac
+            done
+          fi
+
+          selected_matrix="$(jq -c --arg requested "$requested_surfaces" '
+            if $requested == "ALL" then .
+            else
+              ($requested | split(",")) as $surfaces |
+              map(select(.surface as $surface | ($surfaces | index($surface)) != null))
+            end
+          ' <<< "$all_matrix")"
+          if [[ "$selected_matrix" == "[]" ]]; then
+            echo "No fast-input jobs selected for generated_surfaces=$requested_surfaces."
+            exit 1
+          fi
+          echo "matrix={\"include\":$selected_matrix}" >> "$GITHUB_OUTPUT"
+
+  fast-input-regression:
+    needs: select-fast-input-jobs
+    name: Pixel 6 Pro API 35 — ${{ matrix.job_key }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 2
+      matrix: ${{ fromJSON(needs.select-fast-input-jobs.outputs.matrix) }}
+    timeout-minutes: 45
     env:
       ZENZ_MODEL_CACHE_DIR: ${{ github.workspace }}/.zenz-model-cache
       ZENZ_DEBUG_NATIVE_ABIS: x86_64
@@ -103,16 +138,14 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      - name: Run the fast-input matrix
+      - name: Run generated two-finger input matrix
         uses: reactivecircus/android-emulator-runner@v2
         env:
           FAST_INPUT_ROUNDS: ${{ inputs.rounds }}
-          FAST_INPUT_CAPTURE_VISUALS: ${{ inputs.capture_visuals }}
-          FAST_INPUT_START_CASE: ${{ inputs.start_case }}
-          FAST_INPUT_END_CASE: ${{ inputs.end_case }}
-          FAST_INPUT_TEST_SCOPE: ${{ inputs.test_scope }}
-          FAST_INPUT_GENERATED_SURFACES: ${{ inputs.generated_surfaces }}
+          FAST_INPUT_GENERATED_SURFACES: ${{ matrix.surface }}
           FAST_INPUT_GENERATED_COLUMNS: ${{ inputs.generated_columns }}
+          FAST_INPUT_SUMIRE_METHODS: ${{ matrix.sumire_method }}
+          FAST_INPUT_SUMMARY_SURFACE: ${{ matrix.job_key }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         with:
           api-level: 35
@@ -128,10 +161,6 @@ jobs:
           enable-hw-keyboard: false
           disable-animations: false
           disable-spellchecker: true
-          # android-emulator-runner only adds hw.keyboard=yes when this input is true.
-          # Explicitly override the Pixel profile as the first line of defense. The
-          # test script also detaches x86_64 ranchu's translated PS/2 keyboard.
-          # Keep this folded into one command because the action parses each line separately.
           pre-emulator-launch-script: >-
             avd_config="${ANDROID_AVD_HOME}/test.avd/config.ini" &&
             sed -i '/^[[:space:]]*hw\.keyboard[[:space:]]*=/d' "$avd_config" &&
@@ -142,15 +171,97 @@ jobs:
             -noaudio -no-boot-anim -camera-back none
           script: bash .github/scripts/run-fast-input-regression.sh
 
-      - name: Upload test results and screenshots
+      - name: Upload generated test logs and ADB diagnostics
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: fast-input-regression-${{ github.run_id }}-${{ github.run_attempt }}
-          path: |
-            fast-input-artifacts/
-            app/build/reports/androidTests/connected/
-            app/build/outputs/androidTest-results/connected/
+          name: fast-input-regression-${{ matrix.job_key }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: fast-input-artifacts/
           if-no-files-found: warn
           retention-days: 14
           compression-level: 0
+
+      - name: Upload generated test summary
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: fast-input-summary-${{ matrix.job_key }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: fast-input-artifacts/summary-${{ matrix.job_key }}.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+  fast-input-regression-summary:
+    name: Fast Input Regression Summary
+    if: always()
+    needs: fast-input-regression
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download per-surface summaries
+        uses: actions/download-artifact@v7
+        with:
+          pattern: fast-input-summary-*
+          path: fast-input-summaries
+          merge-multiple: true
+
+      - name: Publish and validate aggregate result
+        env:
+          MATRIX_RESULT: ${{ needs.fast-input-regression.result }}
+          REQUESTED_SURFACES: ${{ inputs.generated_surfaces }}
+          REQUESTED_COLUMNS: ${{ inputs.generated_columns }}
+          REQUESTED_ROUNDS: ${{ inputs.rounds }}
+        run: |
+          set -euo pipefail
+          if [[ "$REQUESTED_SURFACES" == "ALL" ]]; then
+            expected_surfaces=(TENKEY GOJUON SUMIRE QWERTY ROMAJI CUSTOM)
+          else
+            IFS=',' read -r -a expected_surfaces <<< "$REQUESTED_SURFACES"
+          fi
+          IFS=',' read -r -a expected_columns <<< "$REQUESTED_COLUMNS"
+          expected_trials=$((REQUESTED_ROUNDS * ${#expected_columns[@]} * 6 * 7))
+          {
+            echo "## Fast Input Regression — aggregate"
+            echo
+            echo "- Matrix result: ${MATRIX_RESULT}"
+            echo "- Requested surfaces: ${REQUESTED_SURFACES}"
+            echo "- Requested columns: ${REQUESTED_COLUMNS}"
+            echo "- Rounds: ${REQUESTED_ROUNDS}"
+            echo "- Expected trials per surface: ${expected_trials}"
+            echo
+            echo '```text'
+            while IFS= read -r summary_file; do
+              cat "$summary_file"
+            done < <(find fast-input-summaries -type f -name 'summary-*.txt' -print 2>/dev/null | sort)
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$MATRIX_RESULT" != success ]]; then
+            echo "The generated two-finger matrix did not succeed: $MATRIX_RESULT"
+            exit 1
+          fi
+
+          validate_summary() {
+            local job_key="$1"
+            local summary_file="fast-input-summaries/summary-${job_key}.txt"
+            if [[ ! -f "$summary_file" ]]; then
+              echo "Missing summary for requested job: $job_key"
+              exit 1
+            fi
+            grep -Fxq 'status=COMPLETED' "$summary_file"
+            grep -Eq "^FAST_INPUT_MULTITOUCH_SUMMARY .*trials=${expected_trials}/${expected_trials} " "$summary_file"
+            grep -Eq "^FAST_INPUT_MULTITOUCH_SUMMARY .*pass=${expected_trials} " "$summary_file"
+            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*resetErrors=0 ' "$summary_file"
+            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*setupErrors=0 ' "$summary_file"
+            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*injectionErrors=0 ' "$summary_file"
+            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*inputMismatches=0 ' "$summary_file"
+            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*resultTimeouts=0 ' "$summary_file"
+          }
+
+          for surface in "${expected_surfaces[@]}"; do
+            if [[ "$surface" == SUMIRE ]]; then
+              validate_summary "SUMIRE-toggle"
+              validate_summary "SUMIRE-flick"
+              validate_summary "SUMIRE-switch-mode-effective"
+            else
+              validate_summary "$surface"
+            fi
+          done

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -35,7 +35,10 @@ jobs:
   fast-input-regression:
     name: Pixel 6 Pro API 35
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    # The full physical-input suite intentionally runs 756 generated cases plus the
+    # existing 144-configuration and 800-trial regressions. Leave enough headroom for
+    # slower hosted emulators and optional multi-round dispatches.
+    timeout-minutes: 360
     env:
       ZENZ_MODEL_CACHE_DIR: ${{ github.workspace }}/.zenz-model-cache
       ZENZ_DEBUG_NATIVE_ABIS: x86_64

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -27,6 +27,24 @@ on:
         required: true
         type: string
         default: '144'
+      test_scope:
+        description: Run the complete suite or only generated multi-touch input
+        required: true
+        type: choice
+        default: all
+        options:
+          - all
+          - generated
+      generated_surfaces:
+        description: ALL or comma-separated TENKEY,GOJUON,SUMIRE,QWERTY,ROMAJI,CUSTOM
+        required: true
+        type: string
+        default: ALL
+      generated_columns:
+        description: Comma-separated generated-test candidate columns (1,2,3)
+        required: true
+        type: string
+        default: '1,2,3'
 
 permissions:
   contents: read
@@ -92,6 +110,9 @@ jobs:
           FAST_INPUT_CAPTURE_VISUALS: ${{ inputs.capture_visuals }}
           FAST_INPUT_START_CASE: ${{ inputs.start_case }}
           FAST_INPUT_END_CASE: ${{ inputs.end_case }}
+          FAST_INPUT_TEST_SCOPE: ${{ inputs.test_scope }}
+          FAST_INPUT_GENERATED_SURFACES: ${{ inputs.generated_surfaces }}
+          FAST_INPUT_GENERATED_COLUMNS: ${{ inputs.generated_columns }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         with:
           api-level: 35

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -32,43 +32,39 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.select.outputs.matrix }}
+      rounds: ${{ steps.select.outputs.rounds }}
+      surfaces: ${{ steps.select.outputs.surfaces }}
+      columns: ${{ steps.select.outputs.columns }}
+      jobs: ${{ steps.select.outputs.jobs }}
     steps:
+      - name: Checkout workflow contract
+        uses: actions/checkout@v6
+
       - name: Build requested job matrix
         id: select
         env:
+          REQUESTED_ROUNDS: ${{ inputs.rounds }}
           REQUESTED_SURFACES: ${{ inputs.generated_surfaces }}
+          REQUESTED_COLUMNS: ${{ inputs.generated_columns }}
         run: |
           set -euo pipefail
-          requested_surfaces="${REQUESTED_SURFACES//[[:space:]]/}"
-          requested_surfaces="${requested_surfaces^^}"
-          if [[ -z "$requested_surfaces" ]]; then
-            echo "generated_surfaces must not be empty."
-            exit 1
-          fi
+          source .github/scripts/fast-input-contract.sh
+          fast_input_contract_normalize \
+            "$REQUESTED_ROUNDS" \
+            "$REQUESTED_SURFACES" \
+            "$REQUESTED_COLUMNS" \
+            ALL
+          requested_rounds="$FAST_INPUT_CONTRACT_ROUNDS"
+          requested_surfaces="$FAST_INPUT_CONTRACT_SURFACES"
+          requested_columns="$FAST_INPUT_CONTRACT_COLUMNS"
 
-          all_matrix='[
-            {"surface":"TENKEY","job_key":"TENKEY","sumire_method":"ALL"},
-            {"surface":"GOJUON","job_key":"GOJUON","sumire_method":"ALL"},
-            {"surface":"SUMIRE","job_key":"SUMIRE-toggle","sumire_method":"toggle"},
-            {"surface":"SUMIRE","job_key":"SUMIRE-flick","sumire_method":"flick"},
-            {"surface":"SUMIRE","job_key":"SUMIRE-switch-mode-effective","sumire_method":"switch-mode-effective"},
-            {"surface":"QWERTY","job_key":"QWERTY","sumire_method":"ALL"},
-            {"surface":"ROMAJI","job_key":"ROMAJI","sumire_method":"ALL"},
-            {"surface":"CUSTOM","job_key":"CUSTOM","sumire_method":"ALL"}
-          ]'
-
-          if [[ "$requested_surfaces" != "ALL" ]]; then
-            IFS=',' read -r -a requested_surface_list <<< "$requested_surfaces"
-            for surface in "${requested_surface_list[@]}"; do
-              case "$surface" in
-                TENKEY|GOJUON|SUMIRE|QWERTY|ROMAJI|CUSTOM) ;;
-                *)
-                  echo "Unknown generated surface: $surface"
-                  exit 1
-                  ;;
-              esac
-            done
-          fi
+          jq -e '
+            .schemaVersion == 1 and
+            (.jobs | type == "array") and
+            (.jobs | length > 0) and
+            all(.jobs[]; (.surface and .job_key and .sumire_method))
+          ' .github/fast-input-matrix.json >/dev/null
+          all_matrix="$(jq -c '.jobs' .github/fast-input-matrix.json)"
 
           selected_matrix="$(jq -c --arg requested "$requested_surfaces" '
             if $requested == "ALL" then .
@@ -81,6 +77,11 @@ jobs:
             echo "No fast-input jobs selected for generated_surfaces=$requested_surfaces."
             exit 1
           fi
+          selected_jobs="$(jq -c '[.[] | {job_key, surface, sumire_method}]' <<< "$selected_matrix")"
+          echo "rounds=$requested_rounds" >> "$GITHUB_OUTPUT"
+          echo "surfaces=$requested_surfaces" >> "$GITHUB_OUTPUT"
+          echo "columns=$requested_columns" >> "$GITHUB_OUTPUT"
+          echo "jobs=$selected_jobs" >> "$GITHUB_OUTPUT"
           echo "matrix={\"include\":$selected_matrix}" >> "$GITHUB_OUTPUT"
 
   fast-input-regression:
@@ -141,9 +142,9 @@ jobs:
       - name: Run generated two-finger input matrix
         uses: reactivecircus/android-emulator-runner@v2
         env:
-          FAST_INPUT_ROUNDS: ${{ inputs.rounds }}
+          FAST_INPUT_ROUNDS: ${{ needs.select-fast-input-jobs.outputs.rounds }}
           FAST_INPUT_GENERATED_SURFACES: ${{ matrix.surface }}
-          FAST_INPUT_GENERATED_COLUMNS: ${{ inputs.generated_columns }}
+          FAST_INPUT_GENERATED_COLUMNS: ${{ needs.select-fast-input-jobs.outputs.columns }}
           FAST_INPUT_SUMIRE_METHODS: ${{ matrix.sumire_method }}
           FAST_INPUT_SUMMARY_SURFACE: ${{ matrix.job_key }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
@@ -193,7 +194,7 @@ jobs:
   fast-input-regression-summary:
     name: Fast Input Regression Summary
     if: always()
-    needs: fast-input-regression
+    needs: [select-fast-input-jobs, fast-input-regression]
     runs-on: ubuntu-latest
     steps:
       - name: Download per-surface summaries
@@ -206,18 +207,12 @@ jobs:
       - name: Publish and validate aggregate result
         env:
           MATRIX_RESULT: ${{ needs.fast-input-regression.result }}
-          REQUESTED_SURFACES: ${{ inputs.generated_surfaces }}
-          REQUESTED_COLUMNS: ${{ inputs.generated_columns }}
-          REQUESTED_ROUNDS: ${{ inputs.rounds }}
+          REQUESTED_SURFACES: ${{ needs.select-fast-input-jobs.outputs.surfaces }}
+          REQUESTED_COLUMNS: ${{ needs.select-fast-input-jobs.outputs.columns }}
+          REQUESTED_ROUNDS: ${{ needs.select-fast-input-jobs.outputs.rounds }}
+          REQUESTED_JOBS_JSON: ${{ needs.select-fast-input-jobs.outputs.jobs }}
         run: |
           set -euo pipefail
-          if [[ "$REQUESTED_SURFACES" == "ALL" ]]; then
-            expected_surfaces=(TENKEY GOJUON SUMIRE QWERTY ROMAJI CUSTOM)
-          else
-            IFS=',' read -r -a expected_surfaces <<< "$REQUESTED_SURFACES"
-          fi
-          IFS=',' read -r -a expected_columns <<< "$REQUESTED_COLUMNS"
-          expected_trials=$((REQUESTED_ROUNDS * ${#expected_columns[@]} * 6 * 7))
           {
             echo "## Fast Input Regression — aggregate"
             echo
@@ -225,7 +220,7 @@ jobs:
             echo "- Requested surfaces: ${REQUESTED_SURFACES}"
             echo "- Requested columns: ${REQUESTED_COLUMNS}"
             echo "- Rounds: ${REQUESTED_ROUNDS}"
-            echo "- Expected trials per surface: ${expected_trials}"
+            echo "- Trial counts: validated from each generated summary JSON"
             echo
             echo '```text'
             while IFS= read -r summary_file; do
@@ -241,27 +236,53 @@ jobs:
 
           validate_summary() {
             local job_key="$1"
-            local summary_file="fast-input-summaries/summary-${job_key}.txt"
+            local expected_surface="$2"
+            local expected_sumire_method="$3"
+            local summary_file="fast-input-summaries/summary-$job_key.txt"
             if [[ ! -f "$summary_file" ]]; then
               echo "Missing summary for requested job: $job_key"
               exit 1
             fi
             grep -Fxq 'status=COMPLETED' "$summary_file"
-            grep -Eq "^FAST_INPUT_MULTITOUCH_SUMMARY .*trials=${expected_trials}/${expected_trials} " "$summary_file"
-            grep -Eq "^FAST_INPUT_MULTITOUCH_SUMMARY .*pass=${expected_trials} " "$summary_file"
-            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*resetErrors=0 ' "$summary_file"
-            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*setupErrors=0 ' "$summary_file"
-            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*injectionErrors=0 ' "$summary_file"
-            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*inputMismatches=0 ' "$summary_file"
-            grep -Eq '^FAST_INPUT_MULTITOUCH_SUMMARY .*resultTimeouts=0 ' "$summary_file"
+            local summary_json_line
+            summary_json_line="$(grep -E '^FAST_INPUT_MULTITOUCH_SUMMARY_JSON ' \
+              "$summary_file" | tail -n 1 || true)"
+            if [[ -z "$summary_json_line" ]]; then
+              echo "Missing generated summary JSON for requested job: $job_key"
+              exit 1
+            fi
+            local summary_json
+            summary_json="$(printf '%s' "$summary_json_line" |
+              sed -E 's/^FAST_INPUT_MULTITOUCH_SUMMARY_JSON //')"
+            jq -e \
+              --arg expected_rounds "$REQUESTED_ROUNDS" \
+              --arg expected_columns "$REQUESTED_COLUMNS" \
+              --arg expected_surface "$expected_surface" \
+              --arg expected_sumire_method "$expected_sumire_method" '
+                .schemaVersion == 1 and
+                .status == "PASS" and
+                .plannedTrials == .completedTrials and
+                .pass == .plannedTrials and
+                .resetErrors == 0 and
+                .setupErrors == 0 and
+                .injectionErrors == 0 and
+                .inputMismatches == 0 and
+                .resultTimeouts == 0 and
+                .failures == 0 and
+                .rounds == ($expected_rounds | tonumber) and
+                (.columns | map(tostring) | join(",")) == $expected_columns and
+                (.surface | split(",") | index($expected_surface)) != null and
+                ($expected_sumire_method == "" or
+                  (.sumireMethods | split(",") | index($expected_sumire_method)) != null)
+              ' <<< "$summary_json"
           }
 
-          for surface in "${expected_surfaces[@]}"; do
-            if [[ "$surface" == SUMIRE ]]; then
-              validate_summary "SUMIRE-toggle"
-              validate_summary "SUMIRE-flick"
-              validate_summary "SUMIRE-switch-mode-effective"
+          while IFS=$'\t' read -r job_key surface sumire_method; do
+            if [[ "$sumire_method" == "ALL" ]]; then
+              validate_summary "$job_key" "$surface" ""
             else
-              validate_summary "$surface"
+              validate_summary "$job_key" "$surface" "$sumire_method"
             fi
-          done
+          done < <(
+            jq -r '.[] | [.job_key, .surface, .sumire_method] | @tsv' <<< "$REQUESTED_JOBS_JSON"
+          )

--- a/.github/workflows/fast-input-regression.yml
+++ b/.github/workflows/fast-input-regression.yml
@@ -152,14 +152,14 @@ jobs:
           target: google_apis
           arch: x86_64
           profile: pixel_6_pro
-          cores: 2
-          ram-size: 3072M
-          heap-size: 512M
+          cores: 4
+          ram-size: 4096M
+          heap-size: 1024M
           disk-size: 8192M
           ndk: 29.0.14206865
           cmake: 3.22.1
           enable-hw-keyboard: false
-          disable-animations: false
+          disable-animations: true
           disable-spellchecker: true
           pre-emulator-launch-script: >-
             avd_config="${ANDROID_AVD_HOME}/test.avd/config.ini" &&

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -11,13 +11,17 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.graphics.Bitmap
+import android.graphics.Point
 import android.graphics.PointF
 import android.graphics.Rect
 import android.hardware.display.DisplayManager
 import android.os.Bundle
 import android.os.Debug
+import android.os.Handler
+import android.os.Looper
 import android.os.ParcelFileDescriptor
 import android.os.PowerManager
+import android.os.ResultReceiver
 import android.os.SystemClock
 import android.provider.Settings
 import android.text.Spanned
@@ -49,6 +53,7 @@ import java.io.FileOutputStream
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
+import java.util.concurrent.atomic.AtomicReference
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -62,8 +67,8 @@ import kotlin.random.Random
  * Device instrumentation regression tests for rapid input while the IME candidate area changes.
  *
  * They can run on a physical device or an emulator. Emulator results must not be reported as
- * physical-device results. These tests intentionally do not change the product's touch routing.
- * They also preserve and restore every preference, including the independently persisted
+ * physical-device results. The generated test uses the same production touch routing as normal
+ * input and preserves and restores every preference, including the independently persisted
  * empty-candidate height and the visible-candidate height for each column count.
  */
 @RunWith(AndroidJUnit4::class)
@@ -1556,7 +1561,7 @@ class FastInputMatrixInstrumentedTest {
     fun generatedTwoFingerInputAcrossAllKeyboardsOnPhysicalDevice() {
         val arguments = InstrumentationRegistry.getArguments()
         val rounds = arguments.getString("matrixRounds")?.toIntOrNull()
-            ?: DEFAULT_MATRIX_ROUNDS
+            ?: DEFAULT_GENERATED_MATRIX_ROUNDS
         require(rounds > 0)
         val requestedSurfaceNames = arguments.getString("matrixSurfaces")
             ?.split(',')
@@ -1565,12 +1570,20 @@ class FastInputMatrixInstrumentedTest {
             ?.map(String::uppercase)
             ?.toSet()
             .orEmpty()
-        val surfaces = if (requestedSurfaceNames.isEmpty()) {
-            RapidInputSurface.entries
-        } else {
-            val unknownNames = requestedSurfaceNames - RapidInputSurface.entries.map { it.name }.toSet()
-            require(unknownNames.isEmpty()) { "Unknown matrixSurfaces: $unknownNames" }
-            RapidInputSurface.entries.filter { it.name in requestedSurfaceNames }
+        val surfaces = when {
+            requestedSurfaceNames.isEmpty() || requestedSurfaceNames == setOf("ALL") -> {
+                RapidInputSurface.entries
+            }
+
+            else -> {
+                require("ALL" !in requestedSurfaceNames) {
+                    "matrixSurfaces cannot combine ALL with a surface name"
+                }
+                val unknownNames = requestedSurfaceNames -
+                    RapidInputSurface.entries.map { it.name }.toSet()
+                require(unknownNames.isEmpty()) { "Unknown matrixSurfaces: $unknownNames" }
+                RapidInputSurface.entries.filter { it.name in requestedSurfaceNames }
+            }
         }
         val requestedColumnTokens = arguments.getString("matrixColumns")
             ?.split(',')
@@ -1592,133 +1605,251 @@ class FastInputMatrixInstrumentedTest {
             }
             requestedColumns
         }
+        val requestedSumireMethodNames = arguments.getString("matrixSumireMethods")
+            ?.split(',')
+            ?.map(String::trim)
+            ?.filter(String::isNotEmpty)
+            ?.toSet()
+            .orEmpty()
+        val sumireInputMethods = when {
+            requestedSumireMethodNames.isEmpty() || requestedSumireMethodNames == setOf("ALL") -> {
+                RAPID_SUMIRE_INPUT_METHODS
+            }
 
+            else -> {
+                require("ALL" !in requestedSumireMethodNames) {
+                    "matrixSumireMethods cannot combine ALL with a method name"
+                }
+                val unknownNames = requestedSumireMethodNames -
+                    RAPID_SUMIRE_INPUT_METHODS.toSet()
+                require(unknownNames.isEmpty()) {
+                    "Unknown matrixSumireMethods: $unknownNames"
+                }
+                RAPID_SUMIRE_INPUT_METHODS.filter { it in requestedSumireMethodNames }
+            }
+        }
         runPhysicalDeviceSession("generated-multitouch") { session ->
             val keyboardLayoutDao = EntryPointAccessors.fromApplication(
                 session.context.applicationContext,
                 KanaKanjiEngineEntryPoint::class.java,
             ).keyboardLayoutDao()
-            val customFixture = installRapidInputCustomFixture(keyboardLayoutDao)
             val failures = mutableListOf<String>()
-            val screenshots = mutableSetOf<String>()
+            val setupErrors = mutableListOf<String>()
+            val categoryCounts = RapidResultCategory.entries
+                .associateWith { 0 }
+                .toMutableMap()
             var completedTrials = 0
             var scenario: ActivityScenario<FastInputHostActivity>? = null
+            var customFixture: RapidInputCustomFixture? = null
+            val expectedTrials = surfaces.sumOf { surface ->
+                val methodCount = if (surface == RapidInputSurface.SUMIRE) {
+                    sumireInputMethods.size
+                } else {
+                    1
+                }
+                methodCount * candidateColumns.size * rounds *
+                    RAPID_SCENARIOS_PER_SURFACE * RAPID_MULTITOUCH_INTERVALS_MS.size
+            }
 
             try {
+                customFixture = installRapidInputCustomFixture(keyboardLayoutDao)
                 scenario = launchHost(session.context)
+                val activeScenario = requireNotNull(scenario)
                 for (surface in surfaces) {
-                    for (columns in candidateColumns) {
-                        applyRapidInputSurfacePreferences(
-                            preferences = session.preferences,
-                            surface = surface,
-                            customFixtureStableId = customFixture.stableId,
-                            candidateColumns = columns,
-                        )
-                        ensureTargetImeSelected(session)
-                        restartInput(scenario)
-                        SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                    val methodsForSurface: List<String?> = if (
+                        surface == RapidInputSurface.SUMIRE
+                    ) {
+                        sumireInputMethods
+                    } else {
+                        listOf(null)
+                    }
+                    for (sumireInputMethod in methodsForSurface) {
+                        for (columns in candidateColumns) {
+                            applyRapidInputSurfacePreferences(
+                                preferences = session.preferences,
+                                surface = surface,
+                                customFixtureStableId = requireNotNull(customFixture).stableId,
+                                candidateColumns = columns,
+                                sumireInputMethod = sumireInputMethod,
+                            )
+                            ensureTargetImeSelected(session)
 
-                        repeat(rounds) { zeroBasedRound ->
-                            val round = zeroBasedRound + 1
-                            val generatedScenarios = buildRapidInputScenarios(surface, round)
-                            for (orientation in TestOrientation.entries) {
-                                rotateAndVerify(orientation)
-                                prepareEmptyEditor(scenario, surface)
-                                SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
-                                assertDeviceReady(
-                                    session.context,
-                                    session.targetIme,
-                                    scenario,
-                                )
+                            repeat(rounds) { zeroBasedRound ->
+                                val round = zeroBasedRound + 1
+                                val generatedScenarios = buildRapidInputScenarios(surface, round)
+                                for (orientation in TestOrientation.entries) {
+                                    rotateAndVerify(orientation)
+                                    restartInput(activeScenario)
+                                    awaitRapidInputSurfaceReady(surface)
+                                    SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                                    assertDeviceReady(
+                                        session.context,
+                                        session.targetIme,
+                                        activeScenario,
+                                    )
 
-                                for (scenarioIndex in generatedScenarios.indices) {
-                                    val inputScenario = generatedScenarios[scenarioIndex]
-                                    for (intervalIndex in RAPID_MULTITOUCH_INTERVALS_MS.indices) {
-                                        val intervalMs = RAPID_MULTITOUCH_INTERVALS_MS[intervalIndex]
-                                        val dimensions = rapidTrialDimensions(
-                                            scenarioIndex = scenarioIndex,
-                                            intervalIndex = intervalIndex,
-                                        )
-                                        if (dimensions.orientation != orientation) continue
+                                    for (scenarioIndex in generatedScenarios.indices) {
+                                        val inputScenario = generatedScenarios[scenarioIndex]
+                                        for (intervalIndex in RAPID_MULTITOUCH_INTERVALS_MS.indices) {
+                                            val intervalMs = RAPID_MULTITOUCH_INTERVALS_MS[intervalIndex]
+                                            val dimensions = rapidTrialDimensions(
+                                                scenarioIndex = scenarioIndex,
+                                                intervalIndex = intervalIndex,
+                                            )
+                                            if (dimensions.orientation != orientation) continue
 
-                                        val trial = buildString {
-                                            append("surface=${surface.name} ")
-                                            append("columns=$columns ")
-                                            append("round=$round ")
-                                            append("scenario=${inputScenario.name} ")
-                                            append("seed=${inputScenario.seed} ")
-                                            append("orientation=${dimensions.orientation.name} ")
-                                            append("editor=${dimensions.editorState.name} ")
-                                            append("release=${dimensions.releaseOrder.name} ")
-                                            append("intervalMs=$intervalMs")
-                                        }
-                                        Log.i(TAG, "MULTITOUCH_TRIAL\t$trial")
-                                        sendProgress("FAST_INPUT_MULTITOUCH_TRIAL $trial\n")
+                                            val trial = buildString {
+                                                append("surface=${surface.name} ")
+                                                sumireInputMethod?.let {
+                                                    append("sumireMethod=$it ")
+                                                }
+                                                append("columns=$columns ")
+                                                append("round=$round ")
+                                                append("scenario=${inputScenario.name} ")
+                                                append("seed=${inputScenario.seed} ")
+                                                append("orientation=${dimensions.orientation.name} ")
+                                                append("editor=${dimensions.editorState.name} ")
+                                                append("release=${dimensions.releaseOrder.name} ")
+                                                append("intervalMs=$intervalMs")
+                                            }
+                                            Log.i(TAG, "MULTITOUCH_TRIAL\t$trial")
+                                            sendProgress("FAST_INPUT_MULTITOUCH_TRIAL $trial\n")
 
-                                        prepareEmptyEditor(scenario, surface)
-                                        val prefix = prepareRapidEditorState(
-                                            scenario = scenario,
-                                            surface = surface,
-                                            editorState = dimensions.editorState,
-                                        )
-                                        val points = resolveRapidInputPoints(
-                                            surface = surface,
-                                            operations = inputScenario.operations,
-                                        )
-                                        val expected = prefix + inputScenario.expected
-                                        val injected = when (dimensions.releaseOrder) {
-                                            RapidReleaseOrder.ROLLING_OLDER_FIRST ->
-                                                injectRollingTwoFingerSequence(
-                                                    operations = inputScenario.operations,
-                                                    points = points,
-                                                    downIntervalMs = intervalMs,
+                                            var expected = if (
+                                                dimensions.editorState == RapidEditorState.WARM
+                                            ) {
+                                                surface.warmExpected + inputScenario.expected
+                                            } else {
+                                                inputScenario.expected
+                                            }
+                                            var actual = runCatching { readText(activeScenario) }
+                                                .getOrDefault("")
+                                            var outcome: RapidTrialOutcome
+                                            try {
+                                                resetRapidInputTrial(activeScenario)
+                                                val prefix = prepareRapidEditorState(
+                                                    scenario = activeScenario,
+                                                    surface = surface,
+                                                    editorState = dimensions.editorState,
                                                 )
-
-                                            RapidReleaseOrder.PAIRED_NEWER_FIRST ->
-                                                injectPairedTwoFingerSequence(
+                                                expected = prefix + inputScenario.expected
+                                                val points = resolveRapidInputPoints(
+                                                    surface = surface,
                                                     operations = inputScenario.operations,
-                                                    points = points,
-                                                    downIntervalMs = intervalMs,
                                                 )
-                                        }
-                                        val actual = awaitTextSettled(scenario)
-                                        val category = classifyRapidInputResult(
-                                            expected = expected,
-                                            actual = actual,
-                                            allEventsInjected = injected,
-                                        )
-                                        completedTrials += 1
+                                                val injected = when (dimensions.releaseOrder) {
+                                                    RapidReleaseOrder.ROLLING_OLDER_FIRST ->
+                                                        injectRollingTwoFingerSequence(
+                                                            operations = inputScenario.operations,
+                                                            points = points,
+                                                            downIntervalMs = intervalMs,
+                                                        )
 
-                                        val result = buildString {
-                                            append("surface=${surface.name} ")
-                                            append("columns=$columns ")
-                                            append("round=$round ")
-                                            append("scenario=${inputScenario.name} ")
-                                            append("seed=${inputScenario.seed} ")
-                                            append("orientation=${dimensions.orientation.name} ")
-                                            append("editor=${dimensions.editorState.name} ")
-                                            append("release=${dimensions.releaseOrder.name} ")
-                                            append("intervalMs=$intervalMs ")
-                                            append("operations=${inputScenario.operations.size} ")
-                                            append("category=${category.name} ")
-                                            append("events=$injected ")
-                                            append("expectedLength=${expected.length} ")
-                                            append("actualLength=${actual.length} ")
-                                            append("firstMismatch=")
-                                            append(firstMismatchIndex(expected, actual))
-                                            append(" expected=[$expected] actual=[$actual]")
-                                        }
-                                        Log.i(TAG, "MULTITOUCH_RESULT\t$result")
-                                        sendProgress("FAST_INPUT_MULTITOUCH_RESULT $result\n")
+                                                    RapidReleaseOrder.PAIRED_NEWER_FIRST ->
+                                                        injectPairedTwoFingerSequence(
+                                                            operations = inputScenario.operations,
+                                                            points = points,
+                                                            downIntervalMs = intervalMs,
+                                                        )
+                                                }
+                                                actual = awaitTextSettled(
+                                                    scenario = activeScenario,
+                                                    failOnTimeout = true,
+                                                )
+                                                outcome = RapidTrialOutcome(
+                                                    category = classifyRapidInputResult(
+                                                        expected = expected,
+                                                        actual = actual,
+                                                        allEventsInjected = injected,
+                                                    ),
+                                                    expected = expected,
+                                                    actual = actual,
+                                                    allEventsInjected = injected,
+                                                )
+                                            } catch (error: RapidResetException) {
+                                                outcome = RapidTrialOutcome(
+                                                    category = RapidResultCategory.RESET_ERROR,
+                                                    expected = expected,
+                                                    actual = runCatching { readText(activeScenario) }
+                                                        .getOrDefault(actual),
+                                                    allEventsInjected = false,
+                                                    error = error.message,
+                                                )
+                                            } catch (error: ResultTimeoutException) {
+                                                outcome = RapidTrialOutcome(
+                                                    category = RapidResultCategory.RESULT_TIMEOUT,
+                                                    expected = expected,
+                                                    actual = runCatching { readText(activeScenario) }
+                                                        .getOrDefault(actual),
+                                                    allEventsInjected = false,
+                                                    error = error.message,
+                                                )
+                                            } catch (error: SetupException) {
+                                                outcome = RapidTrialOutcome(
+                                                    category = RapidResultCategory.SETUP_ERROR,
+                                                    expected = expected,
+                                                    actual = runCatching { readText(activeScenario) }
+                                                        .getOrDefault(actual),
+                                                    allEventsInjected = false,
+                                                    error = error.message,
+                                                )
+                                            } catch (error: Throwable) {
+                                                outcome = RapidTrialOutcome(
+                                                    category = RapidResultCategory.SETUP_ERROR,
+                                                    expected = expected,
+                                                    actual = runCatching { readText(activeScenario) }
+                                                        .getOrDefault(actual),
+                                                    allEventsInjected = false,
+                                                    error = error.message ?: error::class.java.simpleName,
+                                                )
+                                            }
+                                            completedTrials += 1
+                                            categoryCounts[outcome.category] =
+                                                categoryCounts.getValue(outcome.category) + 1
 
-                                        if (category != RapidResultCategory.PASS) {
-                                            failures += result
-                                            val screenshotToken =
-                                                "multitouch-${surface.name.lowercase()}-c$columns-" +
-                                                    "${inputScenario.name.lowercase()}-" +
-                                                    dimensions.releaseOrder.name.lowercase()
-                                            if (screenshots.add(screenshotToken)) {
-                                                saveScreenshot(session, screenshotToken)
+                                            val result = buildString {
+                                                append(trial)
+                                                append(" operations=${inputScenario.operations.size} ")
+                                                append("category=${outcome.category.name} ")
+                                                append("events=${outcome.allEventsInjected} ")
+                                                append("expectedLength=${outcome.expected.length} ")
+                                                append("actualLength=${outcome.actual.length} ")
+                                                append("firstMismatch=")
+                                                val mismatchIndex = firstMismatchIndex(
+                                                    outcome.expected,
+                                                    outcome.actual,
+                                                )
+                                                append(mismatchIndex)
+                                                append(" expected=[${outcome.expected}] actual=[${outcome.actual}]")
+                                                if (outcome.category != RapidResultCategory.PASS) {
+                                                    val warmPrefixLength = if (
+                                                        dimensions.editorState == RapidEditorState.WARM
+                                                    ) {
+                                                        surface.warmExpected.length
+                                                    } else {
+                                                        0
+                                                    }
+                                                    append(" mismatchOperationIndex=")
+                                                    append(
+                                                        (mismatchIndex - warmPrefixLength)
+                                                            .takeIf { it >= 0 } ?: -1
+                                                    )
+                                                    append(" operationTrace=")
+                                                    append(
+                                                        inputScenario.operations.mapIndexed { index, operation ->
+                                                            "$index:${operation.token}:${operation.directionOrTap.name}"
+                                                        }.joinToString(",")
+                                                    )
+                                                }
+                                                outcome.error?.let { error ->
+                                                    append(" error=[${error.replace('\n', ' ')}]")
+                                                }
+                                            }
+                                            Log.i(TAG, "MULTITOUCH_RESULT\t$result")
+                                            sendProgress("FAST_INPUT_MULTITOUCH_RESULT $result\n")
+
+                                            if (outcome.category != RapidResultCategory.PASS) {
+                                                failures += result
                                             }
                                         }
                                     }
@@ -1727,18 +1858,46 @@ class FastInputMatrixInstrumentedTest {
                         }
                     }
                 }
+            } catch (error: Throwable) {
+                val failure =
+                    "surfaces=${surfaces.joinToString(",")} error=" +
+                        (error.message ?: error::class.java.simpleName)
+                setupErrors += failure
+                Log.e(TAG, "FAST_INPUT_SETUP_ERROR $failure", error)
+                sendProgress("FAST_INPUT_SETUP_ERROR $failure\n")
             } finally {
                 scenario?.close()
-                runBlocking { keyboardLayoutDao.deleteLayout(customFixture.id) }
+                customFixture?.let { fixture ->
+                    runCatching { runBlocking { keyboardLayoutDao.deleteLayout(fixture.id) } }
+                        .onFailure { error ->
+                            val failure = "Unable to delete generated custom fixture: ${error.message}"
+                            setupErrors += failure
+                            Log.e(TAG, "FAST_INPUT_SETUP_ERROR $failure", error)
+                        }
+                }
             }
 
-            val expectedTrials = surfaces.size * candidateColumns.size * rounds *
-                RAPID_SCENARIOS_PER_SURFACE * RAPID_MULTITOUCH_INTERVALS_MS.size
+            val passCount = categoryCounts.getValue(RapidResultCategory.PASS)
+            val inputMismatchCount = categoryCounts.getValue(RapidResultCategory.INPUT_MISMATCH)
+            val injectionErrorCount = categoryCounts.getValue(RapidResultCategory.INJECTION_ERROR)
+            val resetErrorCount = categoryCounts.getValue(RapidResultCategory.RESET_ERROR)
+            val resultTimeoutCount = categoryCounts.getValue(RapidResultCategory.RESULT_TIMEOUT)
+            val setupErrorCount =
+                categoryCounts.getValue(RapidResultCategory.SETUP_ERROR) + setupErrors.size
+            val failureCount = failures.size + setupErrors.size
             val summary = buildString {
                 append("FAST_INPUT_MULTITOUCH_SUMMARY ")
+                append("surfaces=${surfaces.joinToString(",")} ")
+                append("sumireMethods=${sumireInputMethods.joinToString(",")} ")
                 append("trials=$completedTrials/$expectedTrials ")
                 append("rounds=$rounds columns=${candidateColumns.joinToString(",")} ")
-                append("failures=${failures.size}\n")
+                append("pass=$passCount ")
+                append("resetErrors=$resetErrorCount ")
+                append("setupErrors=$setupErrorCount ")
+                append("injectionErrors=$injectionErrorCount ")
+                append("inputMismatches=$inputMismatchCount ")
+                append("resultTimeouts=$resultTimeoutCount ")
+                append("failures=$failureCount\n")
             }
             Log.i(TAG, summary.trim())
             sendProgress(summary)
@@ -1749,8 +1908,17 @@ class FastInputMatrixInstrumentedTest {
                         append("Generated multitouch failures:\n")
                         append(failures.joinToString(separator = "\n", limit = 30))
                     }
+                    if (setupErrors.isNotEmpty()) {
+                        append("Generated multitouch setup errors:\n")
+                        append(setupErrors.joinToString(separator = "\n", limit = 30))
+                    }
                 },
-                completedTrials == expectedTrials && failures.isEmpty(),
+                completedTrials == expectedTrials &&
+                    resetErrorCount == 0 &&
+                    setupErrorCount == 0 &&
+                    injectionErrorCount == 0 &&
+                    inputMismatchCount == 0 &&
+                    resultTimeoutCount == 0,
             )
         }
     }
@@ -2192,6 +2360,7 @@ class FastInputMatrixInstrumentedTest {
         surface: RapidInputSurface,
         customFixtureStableId: String,
         candidateColumns: Int,
+        sumireInputMethod: String?,
     ) {
         val baseKeyboard = when (surface) {
             RapidInputSurface.TENKEY -> TestKeyboard.TENKEY
@@ -2220,6 +2389,14 @@ class FastInputMatrixInstrumentedTest {
             .putInt("long_press_timeout_preference", 2000)
             .putString("keyboard_order_preference", surface.keyboardOrder)
             .putBoolean("save_last_used_keyboard", surface == RapidInputSurface.CUSTOM)
+        if (surface == RapidInputSurface.SUMIRE) {
+            editor
+                .putString(
+                    "sumire_input_method_preference",
+                    sumireInputMethod ?: "toggle",
+                )
+                .putString("sumire_keyboard_style_preference", "default")
+        }
         if (surface == RapidInputSurface.CUSTOM) {
             editor
                 .putBoolean("remember_last_custom_keyboard_preference", true)
@@ -2674,9 +2851,7 @@ class FastInputMatrixInstrumentedTest {
     ): RapidResultCategory = when {
         !allEventsInjected -> RapidResultCategory.INJECTION_ERROR
         actual == expected -> RapidResultCategory.PASS
-        actual.length < expected.length -> RapidResultCategory.MISSING
-        actual.length > expected.length -> RapidResultCategory.EXTRA
-        else -> RapidResultCategory.MISMATCH
+        else -> RapidResultCategory.INPUT_MISMATCH
     }
 
     private fun firstMismatchIndex(expected: String, actual: String): Int {
@@ -3165,6 +3340,85 @@ class FastInputMatrixInstrumentedTest {
         )
     }
 
+    private fun resetRapidInputTrial(
+        scenario: ActivityScenario<FastInputHostActivity>,
+    ) {
+        try {
+            awaitHostWindowFocus(scenario)
+            val token =
+                "${SystemClock.uptimeMillis()}-${IME_RESET_TOKEN_SEQUENCE.incrementAndGet()}"
+            val resetSignal = CountDownLatch(1)
+            val response = AtomicReference<FastInputResetResponse?>()
+            val receiver = object : ResultReceiver(Handler(Looper.getMainLooper())) {
+                override fun onReceiveResult(resultCode: Int, resultData: Bundle?) {
+                    if (
+                        resultData?.getString(FastInputTestProtocol.EXTRA_RESET_TOKEN) == token
+                    ) {
+                        response.set(
+                            FastInputResetResponse(
+                                resultCode = resultCode,
+                                error = resultData.getString(
+                                    FastInputTestProtocol.EXTRA_RESET_ERROR
+                                ),
+                            )
+                        )
+                        resetSignal.countDown()
+                    }
+                }
+            }
+
+            scenario.onActivity { activity ->
+                activity.resetEditorForFastInputTest(token, receiver)
+            }
+            if (!resetSignal.await(RESET_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                throw RapidResetException(
+                    "IME reset ACK timed out after ${RESET_TIMEOUT_MS}ms (token=$token)"
+                )
+            }
+            val resetResponse = response.get()
+                ?: throw RapidResetException("IME reset ACK was empty (token=$token)")
+            if (resetResponse.resultCode != FastInputTestProtocol.RESET_ACK) {
+                throw RapidResetException(
+                    "IME rejected reset (token=$token error=${resetResponse.error})"
+                )
+            }
+
+            val deadline = SystemClock.uptimeMillis() + RESET_TIMEOUT_MS
+            var stableSamples = 0
+            var lastState = "host activity unavailable"
+            while (SystemClock.uptimeMillis() < deadline) {
+                var emptyAndFocused = false
+                scenario.onActivity { activity ->
+                    val editor = activity.editText
+                    emptyAndFocused = editor.text.isNullOrEmpty() &&
+                        editor.hasFocus() &&
+                        editor.isShown
+                    lastState =
+                        "empty=${editor.text.isNullOrEmpty()} focused=${editor.hasFocus()} " +
+                            "shown=${editor.isShown}"
+                }
+                if (emptyAndFocused) {
+                    stableSamples += 1
+                    if (stableSamples >= EDITOR_CONNECTION_STABLE_SAMPLES) return
+                } else {
+                    stableSamples = 0
+                }
+                SystemClock.sleep(POLL_MS)
+            }
+            throw RapidResetException(
+                "Editor was not empty and stable after IME reset " +
+                    "within ${RESET_TIMEOUT_MS}ms ($lastState)"
+            )
+        } catch (error: RapidResetException) {
+            throw error
+        } catch (error: Throwable) {
+            throw RapidResetException(
+                "Fast-input trial reset failed: ${error.message ?: error::class.java.simpleName}",
+                error,
+            )
+        }
+    }
+
     private fun prepareEmptyEditor(
         scenario: ActivityScenario<FastInputHostActivity>,
         rapidSurface: RapidInputSurface? = null,
@@ -3319,7 +3573,8 @@ class FastInputMatrixInstrumentedTest {
     }
 
     private fun awaitTextSettled(
-        scenario: ActivityScenario<FastInputHostActivity>
+        scenario: ActivityScenario<FastInputHostActivity>,
+        failOnTimeout: Boolean = false,
     ): String {
         var previous: String? = null
         var stableSamples = 0
@@ -3335,7 +3590,13 @@ class FastInputMatrixInstrumentedTest {
             }
             SystemClock.sleep(POLL_MS)
         }
-        return readText(scenario)
+        val latest = readText(scenario)
+        if (failOnTimeout) {
+            throw ResultTimeoutException(
+                "Editor text did not settle within ${RESULT_TIMEOUT_MS}ms; actual=[$latest]"
+            )
+        }
+        return latest
     }
 
     private fun awaitStableGeometry(
@@ -3493,21 +3754,28 @@ class FastInputMatrixInstrumentedTest {
         throw SetupException("Timed out waiting for visible key id=$idName")
     }
 
+    private fun displayBounds(): ScreenRect {
+        val display = instrumentation.targetContext
+            .getSystemService(DisplayManager::class.java)
+            .displays
+            .minByOrNull { it.displayId }
+            ?: throw SetupException("No display is available")
+        val size = Point()
+        display.getRealSize(size)
+        return ScreenRect(0, 0, size.x, size.y).also {
+            check(it.isValid) { "Display returned invalid dimensions: $size" }
+        }
+    }
+
     private fun awaitScreenAlignedNodeBounds(idName: String): ScreenRect {
         val deadline = SystemClock.uptimeMillis() + SETUP_TIMEOUT_MS
         var previous: ScreenRect? = null
         var stableSamples = 0
         while (SystemClock.uptimeMillis() < deadline) {
             val nodeBounds = findVisibleNodeById(idName)?.screenRect()
-            val screenshot = uiAutomation.takeScreenshot()
-            val screenBounds = screenshot?.let { shot ->
-                val bounds = ScreenRect(0, 0, shot.width, shot.height)
-                shot.recycle()
-                bounds
-            }
+            val screenBounds = displayBounds()
             if (
                 nodeBounds != null &&
-                screenBounds != null &&
                 nodeBounds == nodeBounds.intersect(screenBounds)
             ) {
                 if (nodeBounds == previous) {
@@ -4023,15 +4291,11 @@ class FastInputMatrixInstrumentedTest {
 
     private fun rotateAndVerify(orientation: TestOrientation) {
         fun hasExpectedAspectRatio(): Boolean {
-            val screenshot = uiAutomation.takeScreenshot()
-            return screenshot?.let {
-                val matches = when (orientation) {
-                    TestOrientation.PORTRAIT -> it.height >= it.width
-                    TestOrientation.LANDSCAPE -> it.width > it.height
-                }
-                it.recycle()
-                matches
-            } ?: false
+            val bounds = displayBounds()
+            return when (orientation) {
+                TestOrientation.PORTRAIT -> bounds.height >= bounds.width
+                TestOrientation.LANDSCAPE -> bounds.width > bounds.height
+            }
         }
 
         if (hasExpectedAspectRatio()) {
@@ -4945,10 +5209,11 @@ class FastInputMatrixInstrumentedTest {
 
     private enum class RapidResultCategory {
         PASS,
-        MISSING,
-        EXTRA,
-        MISMATCH,
+        INPUT_MISMATCH,
         INJECTION_ERROR,
+        RESET_ERROR,
+        SETUP_ERROR,
+        RESULT_TIMEOUT,
     }
 
     private data class RapidKanaRow(
@@ -5004,6 +5269,19 @@ class FastInputMatrixInstrumentedTest {
         val injected: Boolean,
     )
 
+    private data class RapidTrialOutcome(
+        val category: RapidResultCategory,
+        val expected: String,
+        val actual: String,
+        val allEventsInjected: Boolean,
+        val error: String? = null,
+    )
+
+    private data class FastInputResetResponse(
+        val resultCode: Int,
+        val error: String?,
+    )
+
     private enum class RateCategory {
         EXPECTED,
         YA_NA,
@@ -5042,6 +5320,15 @@ class FastInputMatrixInstrumentedTest {
         cause: Throwable? = null
     ) : RuntimeException(message, cause)
 
+    private class RapidResetException(
+        message: String,
+        cause: Throwable? = null,
+    ) : RuntimeException(message, cause)
+
+    private class ResultTimeoutException(
+        message: String,
+    ) : RuntimeException(message)
+
     companion object {
         private const val TAG = "FastInputMatrix"
         private const val KEYBOARD_SIZE_CUSTOM_LABEL = "SIZE-CI"
@@ -5074,6 +5361,7 @@ class FastInputMatrixInstrumentedTest {
         )
         private const val SEQUENCE_REPETITIONS = 8
         private const val DEFAULT_MATRIX_ROUNDS = 3
+        private const val DEFAULT_GENERATED_MATRIX_ROUNDS = 1
         private const val DEFAULT_RATE_TRIALS = 10
         private const val TAP_HOLD_MS = 18L
         private const val TAP_GAP_MS = 12L
@@ -5116,6 +5404,8 @@ class FastInputMatrixInstrumentedTest {
         private const val IME_SWITCH_RETRY_MS = 1_000L
         private const val IME_SWITCH_STABILITY_MS = 750L
         private val IME_RESTART_TOKEN_SEQUENCE = AtomicLong(0L)
+        private val IME_RESET_TOKEN_SEQUENCE = AtomicLong(0L)
+        private const val RESET_TIMEOUT_MS = 5_000L
         private const val TOTAL_CASES = 3 * 3 * 2 * 2 * 2 * 2
         private const val CASES_PER_ORIENTATION = TOTAL_CASES / 2
         private const val RATE_CONFIGURATIONS = 2 * 2 * 2 * 2
@@ -5135,6 +5425,11 @@ class FastInputMatrixInstrumentedTest {
         private const val RAPID_MIN_FLICK_DISTANCE_DP = 48f
         private val RAPID_POINTER_IDS = intArrayOf(7, 19)
         private val RAPID_CANDIDATE_COLUMNS = listOf(1, 2, 3)
+        private val RAPID_SUMIRE_INPUT_METHODS = listOf(
+            "toggle",
+            "flick",
+            "switch-mode-effective",
+        )
         private val RAPID_MULTITOUCH_INTERVALS_MS =
             longArrayOf(120L, 60L, 30L, 16L, 8L, 4L, 0L)
         // The built-in dakuten key cycles つ through small-tsu before づ, so keep

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -5567,10 +5567,10 @@ class FastInputMatrixInstrumentedTest {
         private const val MAX_CANDIDATE_TEXTS = 8
         private const val SETUP_TIMEOUT_MS = 2_000L
         private const val RESULT_TIMEOUT_MS = 1_000L
-        // Hosted emulators can spend over one second applying candidate updates after the last
-        // injected event. This remains a strict settle timeout; it does not accept a partial or
-        // incorrect editor value.
-        private const val RAPID_RESULT_TIMEOUT_MS = 3_000L
+        // Hosted emulators can spend several seconds applying candidate updates after the last
+        // injected event, especially for long Romaji sequences. This remains a strict bounded
+        // settle timeout; it does not accept a partial or incorrect editor value.
+        private const val RAPID_RESULT_TIMEOUT_MS = 10_000L
         private const val ORIENTATION_TIMEOUT_MS = 4_000L
         private const val ORIENTATION_SETTLE_MS = 500L
         private const val HOST_WINDOW_FOCUS_TIMEOUT_MS = 15_000L

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -4133,6 +4133,12 @@ class FastInputMatrixInstrumentedTest {
             block(session)
         } finally {
             restorePreferences(preferences, originalPreferences)
+            // A test can finish while rotation is frozen in landscape. Restoring the previous
+            // IME before unfreezing starts an asynchronous Gboard configuration change which can
+            // race the next test's `ime set` command. Let the display return to its stable state
+            // first, then restore the original IME.
+            uiAutomation.setRotation(UiAutomation.ROTATION_UNFREEZE)
+            SystemClock.sleep(ORIENTATION_SETTLE_MS)
             if (originalIme != null) {
                 runCatching { setIme(context, originalIme) }
                     .onFailure { reportImeRestoreFailure("restore default", originalIme, it) }
@@ -4144,7 +4150,6 @@ class FastInputMatrixInstrumentedTest {
                 runCatching { disableIme(targetIme) }
                     .onFailure { reportImeRestoreFailure("restore enabled state", targetIme, it) }
             }
-            uiAutomation.setRotation(UiAutomation.ROTATION_UNFREEZE)
             sendProgress(
                 "FAST_INPUT_RESTORED preferences=true ime=${originalIme ?: targetIme} " +
                     "rotation=unfrozen\n"
@@ -4221,13 +4226,20 @@ class FastInputMatrixInstrumentedTest {
         val deadline = SystemClock.uptimeMillis() + IME_SWITCH_TIMEOUT_MS
         while (SystemClock.uptimeMillis() < deadline) {
             shell("ime set $component")
+            var selectedSince = -1L
             val attemptDeadline = minOf(
                 deadline,
-                SystemClock.uptimeMillis() + IME_SWITCH_RETRY_MS
+                SystemClock.uptimeMillis() +
+                    IME_SWITCH_RETRY_MS +
+                    IME_SWITCH_STABILITY_MS
             )
             while (SystemClock.uptimeMillis() < attemptDeadline) {
                 if (sameComponent(currentIme(context), component)) {
-                    return
+                    val now = SystemClock.uptimeMillis()
+                    if (selectedSince < 0L) selectedSince = now
+                    if (now - selectedSince >= IME_SWITCH_STABILITY_MS) return
+                } else {
+                    selectedSince = -1L
                 }
                 SystemClock.sleep(POLL_MS)
             }
@@ -5010,6 +5022,7 @@ class FastInputMatrixInstrumentedTest {
         private const val IME_ENABLE_TIMEOUT_MS = 15_000L
         private const val IME_SWITCH_TIMEOUT_MS = 15_000L
         private const val IME_SWITCH_RETRY_MS = 1_000L
+        private const val IME_SWITCH_STABILITY_MS = 750L
         private const val TOTAL_CASES = 3 * 3 * 2 * 2 * 2 * 2
         private const val CASES_PER_ORIENTATION = TOTAL_CASES / 2
         private const val RATE_CONFIGURATIONS = 2 * 2 * 2 * 2

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -1734,6 +1734,7 @@ class FastInputMatrixInstrumentedTest {
                                             }
                                             var actual = runCatching { readText(activeScenario) }
                                                 .getOrDefault("")
+                                            var allEventsInjected = false
                                             var outcome: RapidTrialOutcome
                                             try {
                                                 resetRapidInputTrial(activeScenario)
@@ -1744,7 +1745,7 @@ class FastInputMatrixInstrumentedTest {
                                                     points = points,
                                                 )
                                                 expected = prefix + inputScenario.expected
-                                                val injected = when (dimensions.releaseOrder) {
+                                                allEventsInjected = when (dimensions.releaseOrder) {
                                                     RapidReleaseOrder.ROLLING_OLDER_FIRST ->
                                                         injectRollingTwoFingerSequence(
                                                             operations = inputScenario.operations,
@@ -1762,16 +1763,17 @@ class FastInputMatrixInstrumentedTest {
                                                 actual = awaitTextSettled(
                                                     scenario = activeScenario,
                                                     failOnTimeout = true,
+                                                    timeoutMs = RAPID_RESULT_TIMEOUT_MS,
                                                 )
                                                 outcome = RapidTrialOutcome(
                                                     category = classifyRapidInputResult(
                                                         expected = expected,
                                                         actual = actual,
-                                                        allEventsInjected = injected,
+                                                        allEventsInjected = allEventsInjected,
                                                     ),
                                                     expected = expected,
                                                     actual = actual,
-                                                    allEventsInjected = injected,
+                                                    allEventsInjected = allEventsInjected,
                                                 )
                                             } catch (error: RapidResetException) {
                                                 outcome = RapidTrialOutcome(
@@ -1784,11 +1786,15 @@ class FastInputMatrixInstrumentedTest {
                                                 )
                                             } catch (error: ResultTimeoutException) {
                                                 outcome = RapidTrialOutcome(
-                                                    category = RapidResultCategory.RESULT_TIMEOUT,
+                                                    category = if (allEventsInjected) {
+                                                        RapidResultCategory.RESULT_TIMEOUT
+                                                    } else {
+                                                        RapidResultCategory.INJECTION_ERROR
+                                                    },
                                                     expected = expected,
                                                     actual = runCatching { readText(activeScenario) }
                                                         .getOrDefault(actual),
-                                                    allEventsInjected = false,
+                                                    allEventsInjected = allEventsInjected,
                                                     error = error.message,
                                                 )
                                             } catch (error: SetupException) {
@@ -3590,10 +3596,11 @@ class FastInputMatrixInstrumentedTest {
     private fun awaitTextSettled(
         scenario: ActivityScenario<FastInputHostActivity>,
         failOnTimeout: Boolean = false,
+        timeoutMs: Long = RESULT_TIMEOUT_MS,
     ): String {
         var previous: String? = null
         var stableSamples = 0
-        val deadline = SystemClock.uptimeMillis() + RESULT_TIMEOUT_MS
+        val deadline = SystemClock.uptimeMillis() + timeoutMs
         while (SystemClock.uptimeMillis() < deadline) {
             val current = readText(scenario)
             if (current == previous) {
@@ -3608,7 +3615,7 @@ class FastInputMatrixInstrumentedTest {
         val latest = readText(scenario)
         if (failOnTimeout) {
             throw ResultTimeoutException(
-                "Editor text did not settle within ${RESULT_TIMEOUT_MS}ms; actual=[$latest]"
+                "Editor text did not settle within ${timeoutMs}ms; actual=[$latest]"
             )
         }
         return latest
@@ -5560,6 +5567,10 @@ class FastInputMatrixInstrumentedTest {
         private const val MAX_CANDIDATE_TEXTS = 8
         private const val SETUP_TIMEOUT_MS = 2_000L
         private const val RESULT_TIMEOUT_MS = 1_000L
+        // Hosted emulators can spend over one second applying candidate updates after the last
+        // injected event. This remains a strict settle timeout; it does not accept a partial or
+        // incorrect editor value.
+        private const val RAPID_RESULT_TIMEOUT_MS = 3_000L
         private const val ORIENTATION_TIMEOUT_MS = 4_000L
         private const val ORIENTATION_SETTLE_MS = 500L
         private const val HOST_WINDOW_FOCUS_TIMEOUT_MS = 15_000L

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -59,6 +59,8 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.json.JSONArray
+import org.json.JSONObject
 import kotlin.math.abs
 import kotlin.math.sign
 import kotlin.random.Random
@@ -78,6 +80,9 @@ class FastInputMatrixInstrumentedTest {
 
     private val uiAutomation: UiAutomation
         get() = instrumentation.uiAutomation
+
+    private var activeRapidTraceId: String? = null
+    private var activeRapidTraceEvents: MutableList<String>? = null
 
     @Test
     fun flickEditorPreviewFunctionalAndPerformanceOnPhysicalDevice() {
@@ -1560,16 +1565,29 @@ class FastInputMatrixInstrumentedTest {
     @Test
     fun generatedTwoFingerInputAcrossAllKeyboardsOnPhysicalDevice() {
         val arguments = InstrumentationRegistry.getArguments()
-        val rounds = arguments.getString("matrixRounds")?.toIntOrNull()
-            ?: DEFAULT_GENERATED_MATRIX_ROUNDS
-        require(rounds > 0)
-        val requestedSurfaceNames = arguments.getString("matrixSurfaces")
+        val rounds = arguments.getString("matrixRounds")?.let { token ->
+            val parsed = requireNotNull(token.toIntOrNull()) {
+                "matrixRounds must be numeric: $token"
+            }
+            require(parsed in 1..10) {
+                "matrixRounds must be from 1 to 10: $parsed"
+            }
+            parsed
+        } ?: DEFAULT_GENERATED_MATRIX_ROUNDS
+        val requestedSurfaceTokens = arguments.getString("matrixSurfaces")
             ?.split(',')
             ?.map(String::trim)
-            ?.filter(String::isNotEmpty)
+            ?.also { tokens ->
+                require(tokens.none { it.isEmpty() }) {
+                    "matrixSurfaces contains an empty value"
+                }
+            }
             ?.map(String::uppercase)
-            ?.toSet()
             .orEmpty()
+        require(requestedSurfaceTokens.size == requestedSurfaceTokens.toSet().size) {
+            "matrixSurfaces contains duplicate values: $requestedSurfaceTokens"
+        }
+        val requestedSurfaceNames = requestedSurfaceTokens.toSet()
         val surfaces = when {
             requestedSurfaceNames.isEmpty() || requestedSurfaceNames == setOf("ALL") -> {
                 RapidInputSurface.entries
@@ -1588,7 +1606,11 @@ class FastInputMatrixInstrumentedTest {
         val requestedColumnTokens = arguments.getString("matrixColumns")
             ?.split(',')
             ?.map(String::trim)
-            ?.filter(String::isNotEmpty)
+            ?.also { tokens ->
+                require(tokens.none { it.isEmpty() }) {
+                    "matrixColumns contains an empty value"
+                }
+            }
             .orEmpty()
         val requestedColumns = requestedColumnTokens
             .map { token ->
@@ -1596,7 +1618,9 @@ class FastInputMatrixInstrumentedTest {
                     "matrixColumns contains a non-numeric value: $token"
                 }
             }
-            .distinct()
+        require(requestedColumns.size == requestedColumns.toSet().size) {
+            "matrixColumns contains duplicate values after normalization: $requestedColumns"
+        }
         val candidateColumns = if (requestedColumns.isEmpty()) {
             RAPID_CANDIDATE_COLUMNS
         } else {
@@ -1605,19 +1629,29 @@ class FastInputMatrixInstrumentedTest {
             }
             requestedColumns
         }
-        val requestedSumireMethodNames = arguments.getString("matrixSumireMethods")
+        val requestedSumireMethodTokens = arguments.getString("matrixSumireMethods")
             ?.split(',')
             ?.map(String::trim)
-            ?.filter(String::isNotEmpty)
-            ?.toSet()
+            ?.also { tokens ->
+                require(tokens.none { it.isEmpty() }) {
+                    "matrixSumireMethods contains an empty value"
+                }
+            }
+            ?.map(String::lowercase)
             .orEmpty()
+        require(
+            requestedSumireMethodTokens.size == requestedSumireMethodTokens.toSet().size
+        ) {
+            "matrixSumireMethods contains duplicate values: $requestedSumireMethodTokens"
+        }
+        val requestedSumireMethodNames = requestedSumireMethodTokens.toSet()
         val sumireInputMethods = when {
-            requestedSumireMethodNames.isEmpty() || requestedSumireMethodNames == setOf("ALL") -> {
+            requestedSumireMethodNames.isEmpty() || requestedSumireMethodNames == setOf("all") -> {
                 RAPID_SUMIRE_INPUT_METHODS
             }
 
             else -> {
-                require("ALL" !in requestedSumireMethodNames) {
+                require("all" !in requestedSumireMethodNames) {
                     "matrixSumireMethods cannot combine ALL with a method name"
                 }
                 val unknownNames = requestedSumireMethodNames -
@@ -1708,7 +1742,19 @@ class FastInputMatrixInstrumentedTest {
                                             )
                                             if (dimensions.orientation != orientation) continue
 
+                                            val traceId = listOf(
+                                                surface.name.lowercase(),
+                                                sumireInputMethod ?: "none",
+                                                columns,
+                                                round,
+                                                inputScenario.name,
+                                                dimensions.orientation.name.lowercase(),
+                                                dimensions.editorState.name.lowercase(),
+                                                dimensions.releaseOrder.name.lowercase(),
+                                                intervalMs,
+                                            ).joinToString("-")
                                             val trial = buildString {
+                                                append("traceId=$traceId ")
                                                 append("surface=${surface.name} ")
                                                 sumireInputMethod?.let {
                                                     append("sumireMethod=$it ")
@@ -1732,12 +1778,24 @@ class FastInputMatrixInstrumentedTest {
                                             } else {
                                                 inputScenario.expected
                                             }
+                                            var rapidTrace = RapidInputTrace(
+                                                traceId = traceId,
+                                                surface = surface.name,
+                                                operations = inputScenario.operations,
+                                                pointerIds = RAPID_POINTER_IDS.toList(),
+                                                intervalMs = intervalMs,
+                                                releaseOrder = dimensions.releaseOrder,
+                                                expectedText = expected,
+                                            )
+                                            val traceEvents = mutableListOf<String>()
+                                            activeRapidTraceId = traceId
+                                            activeRapidTraceEvents = traceEvents
                                             var actual = runCatching { readText(activeScenario) }
                                                 .getOrDefault("")
                                             var allEventsInjected = false
                                             var outcome: RapidTrialOutcome
                                             try {
-                                                resetRapidInputTrial(activeScenario)
+                                                resetRapidInputTrial(activeScenario, traceId)
                                                 val prefix = prepareRapidEditorState(
                                                     scenario = activeScenario,
                                                     surface = surface,
@@ -1745,6 +1803,7 @@ class FastInputMatrixInstrumentedTest {
                                                     points = points,
                                                 )
                                                 expected = prefix + inputScenario.expected
+                                                rapidTrace = rapidTrace.copy(expectedText = expected)
                                                 allEventsInjected = when (dimensions.releaseOrder) {
                                                     RapidReleaseOrder.ROLLING_OLDER_FIRST ->
                                                         injectRollingTwoFingerSequence(
@@ -1764,6 +1823,7 @@ class FastInputMatrixInstrumentedTest {
                                                     scenario = activeScenario,
                                                     failOnTimeout = true,
                                                     timeoutMs = RAPID_RESULT_TIMEOUT_MS,
+                                                    expectedText = expected,
                                                 )
                                                 outcome = RapidTrialOutcome(
                                                     category = classifyRapidInputResult(
@@ -1782,6 +1842,15 @@ class FastInputMatrixInstrumentedTest {
                                                     actual = runCatching { readText(activeScenario) }
                                                         .getOrDefault(actual),
                                                     allEventsInjected = false,
+                                                    error = error.message,
+                                                )
+                                            } catch (error: ResultMismatchException) {
+                                                outcome = RapidTrialOutcome(
+                                                    category = RapidResultCategory.INPUT_MISMATCH,
+                                                    expected = expected,
+                                                    actual = runCatching { readText(activeScenario) }
+                                                        .getOrDefault(actual),
+                                                    allEventsInjected = allEventsInjected,
                                                     error = error.message,
                                                 )
                                             } catch (error: ResultTimeoutException) {
@@ -1816,6 +1885,12 @@ class FastInputMatrixInstrumentedTest {
                                                     error = error.message ?: error::class.java.simpleName,
                                                 )
                                             }
+                                            finally {
+                                                if (activeRapidTraceId == traceId) {
+                                                    activeRapidTraceId = null
+                                                    activeRapidTraceEvents = null
+                                                }
+                                            }
                                             completedTrials += 1
                                             categoryCounts[outcome.category] =
                                                 categoryCounts.getValue(outcome.category) + 1
@@ -1835,6 +1910,17 @@ class FastInputMatrixInstrumentedTest {
                                                 append(mismatchIndex)
                                                 append(" expected=[${outcome.expected}] actual=[${outcome.actual}]")
                                                 if (outcome.category != RapidResultCategory.PASS) {
+                                                    append(" tracePointers=")
+                                                    append(rapidTrace.pointerIds.joinToString(","))
+                                                    append(" traceExpected=[")
+                                                    append(rapidTrace.expectedText)
+                                                    append("] rawEventTrace=")
+                                                    append(
+                                                        traceEvents.joinToString(
+                                                            separator = "|",
+                                                            limit = 256,
+                                                        )
+                                                    )
                                                     val warmPrefixLength = if (
                                                         dimensions.editorState == RapidEditorState.WARM
                                                     ) {
@@ -1898,6 +1984,33 @@ class FastInputMatrixInstrumentedTest {
             val setupErrorCount =
                 categoryCounts.getValue(RapidResultCategory.SETUP_ERROR) + setupErrors.size
             val failureCount = failures.size + setupErrors.size
+            val matrixPassed = completedTrials == expectedTrials &&
+                passCount == expectedTrials &&
+                resetErrorCount == 0 &&
+                setupErrorCount == 0 &&
+                injectionErrorCount == 0 &&
+                inputMismatchCount == 0 &&
+                resultTimeoutCount == 0
+            val summaryJson = JSONObject()
+                .put("schemaVersion", 1)
+                .put("surface", surfaces.joinToString(","))
+                .put("sumireMethods", sumireInputMethods.joinToString(","))
+                .put("rounds", rounds)
+                .put("columns", JSONArray(candidateColumns))
+                .put("plannedTrials", expectedTrials)
+                .put("completedTrials", completedTrials)
+                .put("pass", passCount)
+                .put("resetErrors", resetErrorCount)
+                .put("setupErrors", setupErrorCount)
+                .put("injectionErrors", injectionErrorCount)
+                .put("inputMismatches", inputMismatchCount)
+                .put("resultTimeouts", resultTimeoutCount)
+                .put("failures", failureCount)
+                .put("status", if (matrixPassed) "PASS" else "FAIL")
+            val summaryJsonLine = buildString {
+                append("FAST_INPUT_MULTITOUCH_SUMMARY_JSON ")
+                append(summaryJson.toString())
+            }
             val summary = buildString {
                 append("FAST_INPUT_MULTITOUCH_SUMMARY ")
                 append("surfaces=${surfaces.joinToString(",")} ")
@@ -1913,7 +2026,9 @@ class FastInputMatrixInstrumentedTest {
                 append("failures=$failureCount\n")
             }
             Log.i(TAG, summary.trim())
+            Log.i(TAG, summaryJsonLine)
             sendProgress(summary)
+            sendProgress("$summaryJsonLine\n")
             assertTrue(
                 buildString {
                     append(summary)
@@ -1926,12 +2041,7 @@ class FastInputMatrixInstrumentedTest {
                         append(setupErrors.joinToString(separator = "\n", limit = 30))
                     }
                 },
-                completedTrials == expectedTrials &&
-                    resetErrorCount == 0 &&
-                    setupErrorCount == 0 &&
-                    injectionErrorCount == 0 &&
-                    inputMismatchCount == 0 &&
-                    resultTimeoutCount == 0,
+                matrixPassed,
             )
         }
     }
@@ -3359,6 +3469,7 @@ class FastInputMatrixInstrumentedTest {
 
     private fun resetRapidInputTrial(
         scenario: ActivityScenario<FastInputHostActivity>,
+        traceId: String,
     ) {
         try {
             awaitHostWindowFocus(scenario)
@@ -3385,7 +3496,7 @@ class FastInputMatrixInstrumentedTest {
             }
 
             scenario.onActivity { activity ->
-                activity.resetEditorForFastInputTest(token, receiver)
+                activity.resetEditorForFastInputTest(token, receiver, traceId)
             }
             if (!resetSignal.await(RESET_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
                 throw RapidResetException(
@@ -3597,7 +3708,17 @@ class FastInputMatrixInstrumentedTest {
         scenario: ActivityScenario<FastInputHostActivity>,
         failOnTimeout: Boolean = false,
         timeoutMs: Long = RESULT_TIMEOUT_MS,
+        expectedText: String? = null,
     ): String {
+        if (expectedText != null) {
+            return awaitExpectedTextSettled(
+                scenario = scenario,
+                expectedText = expectedText,
+                failOnTimeout = failOnTimeout,
+                timeoutMs = timeoutMs,
+            )
+        }
+
         var previous: String? = null
         var stableSamples = 0
         val deadline = SystemClock.uptimeMillis() + timeoutMs
@@ -3616,6 +3737,56 @@ class FastInputMatrixInstrumentedTest {
         if (failOnTimeout) {
             throw ResultTimeoutException(
                 "Editor text did not settle within ${timeoutMs}ms; actual=[$latest]"
+            )
+        }
+        return latest
+    }
+
+    private fun awaitExpectedTextSettled(
+        scenario: ActivityScenario<FastInputHostActivity>,
+        expectedText: String,
+        failOnTimeout: Boolean,
+        timeoutMs: Long,
+    ): String {
+        val deadline = SystemClock.uptimeMillis() + timeoutMs
+        val policy = FastInputTextSettlePolicy(
+            expectedText = expectedText,
+            stableSamplesRequired = TEXT_STABLE_SAMPLES,
+        )
+        var latest = readText(scenario)
+        while (SystemClock.uptimeMillis() < deadline) {
+            latest = readText(scenario)
+            if (policy.observe(latest)) {
+                // Keep a short second quiet window after the expected value appears. This catches
+                // a queued extra commit without adding any wait between the injected touch events.
+                val postDeadline = minOf(
+                    deadline,
+                    SystemClock.uptimeMillis() + RAPID_POST_EXPECTED_SETTLE_MS,
+                )
+                val postPolicy = FastInputTextSettlePolicy(
+                    expectedText = expectedText,
+                    stableSamplesRequired = TEXT_STABLE_SAMPLES,
+                )
+                while (SystemClock.uptimeMillis() < postDeadline) {
+                    latest = readText(scenario)
+                    if (latest != expectedText) {
+                        throw ResultMismatchException(
+                            "Editor text changed after reaching expected value; " +
+                                "expected=[$expectedText] actual=[$latest]",
+                        )
+                    }
+                    if (postPolicy.observe(latest)) return latest
+                    SystemClock.sleep(POLL_MS)
+                }
+            }
+            SystemClock.sleep(POLL_MS)
+        }
+
+        latest = readText(scenario)
+        if (failOnTimeout) {
+            throw ResultTimeoutException(
+                "Editor text did not reach expected value within ${timeoutMs}ms; " +
+                    "expected=[$expectedText] actual=[$latest]",
             )
         }
         return latest
@@ -4412,6 +4583,32 @@ class FastInputMatrixInstrumentedTest {
             0,
             InputDevice.SOURCE_TOUCHSCREEN,
             0
+        )
+        activeRapidTraceEvents?.add(
+            buildString {
+                append("traceId=")
+                append(activeRapidTraceId)
+                append(" stage=inject action=")
+                append(MotionEvent.actionToString(actionMasked))
+                append(" actionIndex=")
+                append(actionIndex)
+                append(" eventTime=")
+                append(eventTime)
+                append(" synchronous=")
+                append(synchronous)
+                append(" pointers=")
+                append(
+                    pointers.joinToString("|") { pointer ->
+                        buildString {
+                            append(pointer.id)
+                            append("@")
+                            append(pointer.point.x)
+                            append(",")
+                            append(pointer.point.y)
+                        }
+                    }
+                )
+            }
         )
         return try {
             uiAutomation.injectInputEvent(event, synchronous)
@@ -5408,6 +5605,16 @@ class FastInputMatrixInstrumentedTest {
         val seed: Int,
     )
 
+    private data class RapidInputTrace(
+        val traceId: String,
+        val surface: String,
+        val operations: List<RapidOperation>,
+        val pointerIds: List<Int>,
+        val intervalMs: Long,
+        val releaseOrder: RapidReleaseOrder,
+        val expectedText: String,
+    )
+
     private data class RapidTrialDimensions(
         val releaseOrder: RapidReleaseOrder,
         val orientation: TestOrientation,
@@ -5507,6 +5714,10 @@ class FastInputMatrixInstrumentedTest {
         message: String,
     ) : RuntimeException(message)
 
+    private class ResultMismatchException(
+        message: String,
+    ) : RuntimeException(message)
+
     companion object {
         private const val TAG = "FastInputMatrix"
         private const val KEYBOARD_SIZE_CUSTOM_LABEL = "SIZE-CI"
@@ -5571,6 +5782,7 @@ class FastInputMatrixInstrumentedTest {
         // injected event, especially for long Romaji sequences. This remains a strict bounded
         // settle timeout; it does not accept a partial or incorrect editor value.
         private const val RAPID_RESULT_TIMEOUT_MS = 10_000L
+        private const val RAPID_POST_EXPECTED_SETTLE_MS = 256L
         private const val ORIENTATION_TIMEOUT_MS = 4_000L
         private const val ORIENTATION_SETTLE_MS = 500L
         private const val HOST_WINDOW_FOCUS_TIMEOUT_MS = 15_000L

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -34,8 +34,10 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyType
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.CustomKeyboardLayout
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.FlickMapping
 import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.KeyDefinition
 import com.kazumaproject.markdownhelperkeyboard.ime_service.di.KanaKanjiEngineEntryPoint
 import dagger.hilt.android.EntryPointAccessors
@@ -46,6 +48,9 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
+import kotlin.math.abs
+import kotlin.math.sign
+import kotlin.random.Random
 
 /**
  * Device instrumentation regression tests for rapid input while the IME candidate area changes.
@@ -1542,6 +1547,195 @@ class FastInputMatrixInstrumentedTest {
     }
 
     @Test
+    fun generatedTwoFingerInputAcrossAllKeyboardsOnPhysicalDevice() {
+        val arguments = InstrumentationRegistry.getArguments()
+        val rounds = arguments.getString("matrixRounds")?.toIntOrNull()
+            ?: DEFAULT_MATRIX_ROUNDS
+        require(rounds > 0)
+        val requestedSurfaceNames = arguments.getString("matrixSurfaces")
+            ?.split(',')
+            ?.map(String::trim)
+            ?.filter(String::isNotEmpty)
+            ?.map(String::uppercase)
+            ?.toSet()
+            .orEmpty()
+        val surfaces = if (requestedSurfaceNames.isEmpty()) {
+            RapidInputSurface.entries
+        } else {
+            val unknownNames = requestedSurfaceNames - RapidInputSurface.entries.map { it.name }.toSet()
+            require(unknownNames.isEmpty()) { "Unknown matrixSurfaces: $unknownNames" }
+            RapidInputSurface.entries.filter { it.name in requestedSurfaceNames }
+        }
+        val requestedColumnTokens = arguments.getString("matrixColumns")
+            ?.split(',')
+            ?.map(String::trim)
+            ?.filter(String::isNotEmpty)
+            .orEmpty()
+        val requestedColumns = requestedColumnTokens
+            .map { token ->
+                requireNotNull(token.toIntOrNull()) {
+                    "matrixColumns contains a non-numeric value: $token"
+                }
+            }
+            .distinct()
+        val candidateColumns = if (requestedColumns.isEmpty()) {
+            RAPID_CANDIDATE_COLUMNS
+        } else {
+            require(requestedColumns.all { it in RAPID_CANDIDATE_COLUMNS }) {
+                "matrixColumns must contain only 1, 2, or 3: $requestedColumns"
+            }
+            requestedColumns
+        }
+
+        runPhysicalDeviceSession("generated-multitouch") { session ->
+            val keyboardLayoutDao = EntryPointAccessors.fromApplication(
+                session.context.applicationContext,
+                KanaKanjiEngineEntryPoint::class.java,
+            ).keyboardLayoutDao()
+            val customFixture = installRapidInputCustomFixture(keyboardLayoutDao)
+            val failures = mutableListOf<String>()
+            val screenshots = mutableSetOf<String>()
+            var completedTrials = 0
+            var scenario: ActivityScenario<FastInputHostActivity>? = null
+
+            try {
+                scenario = launchHost(session.context)
+                for (surface in surfaces) {
+                    for (columns in candidateColumns) {
+                        applyRapidInputSurfacePreferences(
+                            preferences = session.preferences,
+                            surface = surface,
+                            customFixtureStableId = customFixture.stableId,
+                            candidateColumns = columns,
+                        )
+                        ensureTargetImeSelected(session)
+                        restartInput(scenario)
+                        SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+
+                        repeat(rounds) { zeroBasedRound ->
+                            val round = zeroBasedRound + 1
+                            val generatedScenarios = buildRapidInputScenarios(surface, round)
+                            for (orientation in TestOrientation.entries) {
+                                rotateAndVerify(orientation)
+                                prepareEmptyEditor(scenario)
+                                SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                                assertDeviceReady(
+                                    session.context,
+                                    session.targetIme,
+                                    scenario,
+                                )
+
+                                for (scenarioIndex in generatedScenarios.indices) {
+                                    val inputScenario = generatedScenarios[scenarioIndex]
+                                    for (intervalIndex in RAPID_MULTITOUCH_INTERVALS_MS.indices) {
+                                        val intervalMs = RAPID_MULTITOUCH_INTERVALS_MS[intervalIndex]
+                                        val dimensions = rapidTrialDimensions(
+                                            scenarioIndex = scenarioIndex,
+                                            intervalIndex = intervalIndex,
+                                        )
+                                        if (dimensions.orientation != orientation) continue
+
+                                        prepareEmptyEditor(scenario)
+                                        val prefix = prepareRapidEditorState(
+                                            scenario = scenario,
+                                            surface = surface,
+                                            editorState = dimensions.editorState,
+                                        )
+                                        val points = resolveRapidInputPoints(
+                                            surface = surface,
+                                            operations = inputScenario.operations,
+                                        )
+                                        val expected = prefix + inputScenario.expected
+                                        val injected = when (dimensions.releaseOrder) {
+                                            RapidReleaseOrder.ROLLING_OLDER_FIRST ->
+                                                injectRollingTwoFingerSequence(
+                                                    operations = inputScenario.operations,
+                                                    points = points,
+                                                    downIntervalMs = intervalMs,
+                                                )
+
+                                            RapidReleaseOrder.PAIRED_NEWER_FIRST ->
+                                                injectPairedTwoFingerSequence(
+                                                    operations = inputScenario.operations,
+                                                    points = points,
+                                                    downIntervalMs = intervalMs,
+                                                )
+                                        }
+                                        val actual = awaitTextSettled(scenario)
+                                        val category = classifyRapidInputResult(
+                                            expected = expected,
+                                            actual = actual,
+                                            allEventsInjected = injected,
+                                        )
+                                        completedTrials += 1
+
+                                        val result = buildString {
+                                            append("surface=${surface.name} ")
+                                            append("columns=$columns ")
+                                            append("round=$round ")
+                                            append("scenario=${inputScenario.name} ")
+                                            append("seed=${inputScenario.seed} ")
+                                            append("orientation=${dimensions.orientation.name} ")
+                                            append("editor=${dimensions.editorState.name} ")
+                                            append("release=${dimensions.releaseOrder.name} ")
+                                            append("intervalMs=$intervalMs ")
+                                            append("operations=${inputScenario.operations.size} ")
+                                            append("category=${category.name} ")
+                                            append("events=$injected ")
+                                            append("expectedLength=${expected.length} ")
+                                            append("actualLength=${actual.length} ")
+                                            append("firstMismatch=")
+                                            append(firstMismatchIndex(expected, actual))
+                                            append(" expected=[$expected] actual=[$actual]")
+                                        }
+                                        Log.i(TAG, "MULTITOUCH_RESULT\t$result")
+                                        sendProgress("FAST_INPUT_MULTITOUCH_RESULT $result\n")
+
+                                        if (category != RapidResultCategory.PASS) {
+                                            failures += result
+                                            val screenshotToken =
+                                                "multitouch-${surface.name.lowercase()}-c$columns-" +
+                                                    "${inputScenario.name.lowercase()}-" +
+                                                    dimensions.releaseOrder.name.lowercase()
+                                            if (screenshots.add(screenshotToken)) {
+                                                saveScreenshot(session, screenshotToken)
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            } finally {
+                scenario?.close()
+                runBlocking { keyboardLayoutDao.deleteLayout(customFixture.id) }
+            }
+
+            val expectedTrials = surfaces.size * candidateColumns.size * rounds *
+                RAPID_SCENARIOS_PER_SURFACE * RAPID_MULTITOUCH_INTERVALS_MS.size
+            val summary = buildString {
+                append("FAST_INPUT_MULTITOUCH_SUMMARY ")
+                append("trials=$completedTrials/$expectedTrials ")
+                append("rounds=$rounds columns=${candidateColumns.joinToString(",")} ")
+                append("failures=${failures.size}\n")
+            }
+            Log.i(TAG, summary.trim())
+            sendProgress(summary)
+            assertTrue(
+                buildString {
+                    append(summary)
+                    if (failures.isNotEmpty()) {
+                        append("Generated multitouch failures:\n")
+                        append(failures.joinToString(separator = "\n", limit = 30))
+                    }
+                },
+                completedTrials == expectedTrials && failures.isEmpty(),
+            )
+        }
+    }
+
+    @Test
     fun emptyCandidatePresentationStaysHiddenAfterImeReopenOnCustomKeyboard() {
         runPhysicalDeviceSession("custom-empty-candidate-reopen") { session ->
             var scenario: ActivityScenario<FastInputHostActivity>? = null
@@ -1917,6 +2111,560 @@ class FastInputMatrixInstrumentedTest {
             allEventsInjected = injected,
             geometry = warm.renderTransition(after)
         )
+    }
+
+    private fun installRapidInputCustomFixture(
+        dao: com.kazumaproject.markdownhelperkeyboard.custom_keyboard.database.KeyboardLayoutDao,
+    ): RapidInputCustomFixture = runBlocking {
+        val stableId = "rapid-input-ci-${System.currentTimeMillis()}"
+        val keys = RAPID_KANA_ROWS.mapIndexed { index, row ->
+            KeyDefinition(
+                ownerLayoutId = 0,
+                label = row.label,
+                row = index / 3,
+                column = index % 3,
+                keyType = KeyType.STANDARD_FLICK,
+                isSpecialKey = false,
+                keyIdentifier = row.token,
+            )
+        } + KeyDefinition(
+            ownerLayoutId = 0,
+            label = RAPID_DAKUTEN_LABEL,
+            row = 2,
+            column = 1,
+            keyType = KeyType.NORMAL,
+            isSpecialKey = false,
+            keyIdentifier = RAPID_DAKUTEN_TOKEN,
+            action = "ToggleDakutenOnly",
+        )
+        val flicksMap = RAPID_KANA_ROWS.associate { row ->
+            row.token to RapidDirection.entries.map { direction ->
+                FlickMapping(
+                    ownerKeyId = 0,
+                    stateIndex = 0,
+                    flickDirection = direction.persistedDirection,
+                    actionType = "INPUT_TEXT",
+                    actionValue = row.outputs[direction.ordinal],
+                )
+            }
+        }
+        val id = dao.insertFullKeyboardLayout(
+            layout = CustomKeyboardLayout(
+                name = "Generated Fast Input CI",
+                columnCount = 3,
+                rowCount = 3,
+                isDirectMode = false,
+                sortOrder = dao.getMaxSortOrder() + 1,
+                stableId = stableId,
+            ),
+            keys = keys,
+            flicksMap = flicksMap,
+            circularFlicksMap = emptyMap(),
+            twoStepFlicksMap = emptyMap(),
+            longPressFlicksMap = emptyMap(),
+            twoStepLongPressFlicksMap = emptyMap(),
+        )
+        RapidInputCustomFixture(id = id, stableId = stableId)
+    }
+
+    private fun applyRapidInputSurfacePreferences(
+        preferences: SharedPreferences,
+        surface: RapidInputSurface,
+        customFixtureStableId: String,
+        candidateColumns: Int,
+    ) {
+        val baseKeyboard = when (surface) {
+            RapidInputSurface.TENKEY -> TestKeyboard.TENKEY
+            RapidInputSurface.SUMIRE, RapidInputSurface.GOJUON,
+            RapidInputSurface.CUSTOM -> TestKeyboard.SUMIRE
+            RapidInputSurface.QWERTY, RapidInputSurface.ROMAJI -> TestKeyboard.QWERTY
+        }
+        applyCasePreferences(
+            preferences = preferences,
+            case = TestCase(
+                keyboard = baseKeyboard,
+                columns = candidateColumns,
+                candidateTabVisible = true,
+                toolbarVisible = true,
+                toolbarIntegrated = true,
+                orientation = TestOrientation.PORTRAIT,
+            ),
+        )
+
+        val editor = preferences.edit()
+            .putBoolean("tenkey_show_switch_ime_button_preference", false)
+            .putBoolean("gojuon_keyboard_type_migrated_v1", true)
+            .putBoolean("qwerty_glide_input_preference", false)
+            .putInt("flick_sensitivity_preference", 100)
+            .putString("flick_threshold_shape_preference", "radial")
+            .putInt("long_press_timeout_preference", 2000)
+            .putString("keyboard_order_preference", surface.keyboardOrder)
+            .putBoolean("save_last_used_keyboard", surface == RapidInputSurface.CUSTOM)
+        if (surface == RapidInputSurface.CUSTOM) {
+            editor
+                .putBoolean("remember_last_custom_keyboard_preference", true)
+                .putString("last_used_custom_keyboard_stable_id", customFixtureStableId)
+        }
+        check(editor.commit()) { "Failed to configure rapid-input surface $surface" }
+    }
+
+    private fun buildRapidInputScenarios(
+        surface: RapidInputSurface,
+        round: Int,
+    ): List<RapidInputScenario> = when (surface) {
+        RapidInputSurface.TENKEY,
+        RapidInputSurface.SUMIRE,
+        RapidInputSurface.CUSTOM -> buildKanaRapidInputScenarios(surface, round)
+        RapidInputSurface.GOJUON -> buildGojuonRapidInputScenarios(round)
+        RapidInputSurface.QWERTY -> buildQwertyRapidInputScenarios(round)
+        RapidInputSurface.ROMAJI -> buildRomajiRapidInputScenarios(round)
+    }.also { scenarios ->
+        check(scenarios.size == RAPID_SCENARIOS_PER_SURFACE) {
+            "$surface produced ${scenarios.size} scenarios"
+        }
+    }
+
+    private fun buildKanaRapidInputScenarios(
+        surface: RapidInputSurface,
+        round: Int,
+    ): List<RapidInputScenario> {
+        val allDirections = RapidDirection.entries
+        val directionCoverage = RAPID_KANA_ROWS.flatMapIndexed { rowIndex, _ ->
+            allDirections.map { direction -> RapidOperation.Kana(rowIndex, direction) }
+        }
+        val dakutenCoverage = RAPID_DAKUTEN_ROW_INDICES.flatMap { rowIndex ->
+            allDirections.flatMap { direction ->
+                listOf(
+                    RapidOperation.Kana(rowIndex, direction),
+                    RapidOperation.Dakuten,
+                )
+            }
+        }
+        val repeatedBursts = RAPID_KANA_ROWS.flatMapIndexed { rowIndex, _ ->
+            val direction = allDirections[(rowIndex + round) % allDirections.size]
+            List(RAPID_REPEAT_BURST_LENGTH) { RapidOperation.Kana(rowIndex, direction) }
+        }
+        val alternating = List(RAPID_GENERATED_OPERATION_COUNT) { index ->
+            RapidOperation.Kana(
+                rowIndex = if (index % 2 == 0) index % 3 else 3 + (index % 3),
+                direction = allDirections[(index * 2 + round) % allDirections.size],
+            )
+        }
+        val permutations = (0 until 2).map { variant ->
+            val seed = rapidSeed(surface, round, variant)
+            directionCoverage.shuffled(Random(seed)).let { shuffled ->
+                rapidScenario("permuted-$variant", shuffled, seed)
+            }
+        }
+        return listOf(
+            rapidScenario("direction-coverage", directionCoverage),
+            rapidScenario("dakuten-coverage", dakutenCoverage),
+            rapidScenario("repeated-bursts", repeatedBursts),
+            rapidScenario("alternating-rows", alternating),
+        )
+            .plus(permutations)
+    }
+
+    private fun buildGojuonRapidInputScenarios(round: Int): List<RapidInputScenario> {
+        val base = RAPID_GOJUON_BASE_KEYS.map { key -> key.toOperation() }
+        val voiced = RAPID_GOJUON_VOICED_KEYS.map { key -> key.toOperation() }
+        val modifiers = RAPID_GOJUON_MODIFIER_KEYS.map { key -> key.toOperation() }
+        val mixed = buildList {
+            repeat(2) { index ->
+                addAll(if (index % 2 == 0) base.take(18) else voiced)
+                addAll(modifiers)
+            }
+        }
+        return listOf(
+            rapidScenario("base-coverage", base),
+            rapidScenario("voiced-coverage", voiced),
+            rapidScenario("small-handakuten", modifiers),
+            rapidScenario("mixed-modifiers", mixed),
+            shuffledRapidScenario("permuted-base", base, rapidSeed(RapidInputSurface.GOJUON, round, 0)),
+            shuffledRapidScenario("permuted-all", base + voiced + modifiers, rapidSeed(RapidInputSurface.GOJUON, round, 1)),
+        )
+    }
+
+    private fun buildQwertyRapidInputScenarios(round: Int): List<RapidInputScenario> {
+        val alphabet = RAPID_QWERTY_LETTERS.map(::qwertyOperation)
+        val keyboardRows = RAPID_QWERTY_ROWS.flatMap { row -> row.map(::qwertyOperation) }
+        val repeated = RAPID_QWERTY_REPEAT_KEYS.flatMap { char ->
+            List(RAPID_REPEAT_BURST_LENGTH) { qwertyOperation(char) }
+        }
+        val alternating = List(RAPID_GENERATED_OPERATION_COUNT) { index ->
+            qwertyOperation(
+                if (index % 2 == 0) {
+                    RAPID_QWERTY_ROWS[0][index % RAPID_QWERTY_ROWS[0].length]
+                } else {
+                    RAPID_QWERTY_ROWS[2][index % RAPID_QWERTY_ROWS[2].length]
+                }
+            )
+        }
+        return listOf(
+            rapidScenario("alphabet-forward", alphabet),
+            rapidScenario("alphabet-reverse", alphabet.reversed()),
+            rapidScenario("keyboard-rows", keyboardRows),
+            rapidScenario("repeated-bursts", repeated),
+            rapidScenario("alternating-rows", alternating),
+            shuffledRapidScenario(
+                "permuted-alphabet",
+                alphabet + alphabet,
+                rapidSeed(RapidInputSurface.QWERTY, round, 0),
+            ),
+        )
+    }
+
+    private fun buildRomajiRapidInputScenarios(round: Int): List<RapidInputScenario> =
+        List(RAPID_SCENARIOS_PER_SURFACE) { variant ->
+            val seed = rapidSeed(RapidInputSurface.ROMAJI, round, variant)
+            val ordered = when (variant) {
+                0 -> RAPID_ROMAJI_SYLLABLES
+                1 -> RAPID_ROMAJI_SYLLABLES.reversed()
+                else -> RAPID_ROMAJI_SYLLABLES.shuffled(Random(seed))
+            }
+            val selected = if (variant < 2) ordered else ordered.take(RAPID_ROMAJI_SYLLABLES_PER_TRACE)
+            val source = selected.joinToString(separator = "") { it.roman }
+            RapidInputScenario(
+                name = "syllables-$variant",
+                operations = source.map(::qwertyOperation),
+                expected = selected.joinToString(separator = "") { it.kana },
+                seed = seed,
+            )
+        }
+
+    private fun rapidScenario(
+        name: String,
+        operations: List<RapidOperation>,
+        seed: Int = RAPID_COVERAGE_SEED,
+    ) = RapidInputScenario(
+        name = name,
+        operations = operations,
+        expected = expectedRapidInputText(operations),
+        seed = seed,
+    )
+
+    private fun shuffledRapidScenario(
+        name: String,
+        operations: List<RapidOperation>,
+        seed: Int,
+    ) = rapidScenario(name, operations.shuffled(Random(seed)), seed)
+
+    private fun qwertyOperation(char: Char) = RapidOperation.Direct(
+        token = "qwerty-$char",
+        locator = NodeLocator.Id("key_$char"),
+        direction = RapidDirection.TAP,
+        output = char.toString(),
+    )
+
+    private fun rapidSeed(surface: RapidInputSurface, round: Int, variant: Int): Int =
+        RAPID_BASE_SEED + surface.ordinal * 10_000 + round * 100 + variant
+
+    private fun expectedRapidInputText(operations: List<RapidOperation>): String {
+        val expected = StringBuilder()
+        operations.forEach { operation ->
+            when (operation) {
+                is RapidOperation.Kana -> expected.append(
+                    RAPID_KANA_ROWS[operation.rowIndex].outputs[operation.direction.ordinal]
+                )
+
+                RapidOperation.Dakuten -> {
+                    check(expected.isNotEmpty()) { "Dakuten operation requires preceding text" }
+                    val last = expected.last()
+                    expected.setCharAt(
+                        expected.lastIndex,
+                        RAPID_DAKUTEN_TRANSFORMS[last]
+                            ?: error("No dakuten oracle mapping for [$last]"),
+                    )
+                }
+
+                is RapidOperation.Direct -> expected.append(operation.output)
+            }
+        }
+        return expected.toString()
+    }
+
+    private fun rapidTrialDimensions(
+        scenarioIndex: Int,
+        intervalIndex: Int,
+    ) = RapidTrialDimensions(
+        releaseOrder = RapidReleaseOrder.entries[(scenarioIndex + intervalIndex) % 2],
+        orientation = TestOrientation.entries[(scenarioIndex / 2 + intervalIndex) % 2],
+        editorState = RapidEditorState.entries[(scenarioIndex + intervalIndex / 2) % 2],
+    )
+
+    private fun prepareRapidEditorState(
+        scenario: ActivityScenario<FastInputHostActivity>,
+        surface: RapidInputSurface,
+        editorState: RapidEditorState,
+    ): String {
+        if (editorState == RapidEditorState.COLD) return ""
+        val operation = surface.warmOperation
+        val points = resolveRapidInputPoints(surface, listOf(operation)).getValue(operation.token)
+        check(injectRapidSingleGesture(operation, points)) {
+            "Unable to prime warm editor state for $surface"
+        }
+        val actual = awaitTextSettled(scenario)
+        check(actual == surface.warmExpected) {
+            "Warm-state prime mismatch for $surface: " +
+                "expected=[${surface.warmExpected}] actual=[$actual]"
+        }
+        return actual
+    }
+
+    private fun resolveRapidInputPoints(
+        surface: RapidInputSurface,
+        operations: List<RapidOperation>,
+    ): Map<String, RapidTouchPoints> {
+        val requiredTokens = operations.mapTo(linkedSetOf()) { it.token }
+        val deadline = SystemClock.uptimeMillis() + SETUP_TIMEOUT_MS
+        var lastError = "keyboard root unavailable"
+        while (SystemClock.uptimeMillis() < deadline) {
+            try {
+                val root = findVisibleNodeById(surface.rootViewId)
+                    ?: throw SetupException("${surface.rootViewId} is not visible")
+                return requiredTokens.associateWith { token ->
+                    val operation = operations.first { it.token == token }
+                    val bounds = findRequiredKey(
+                        keyboardRoot = root,
+                        locator = surface.locatorFor(operation),
+                    ).screenRect()
+                    RapidTouchPoints(
+                        start = bounds.center,
+                        ends = RapidDirection.entries.associateWith { direction ->
+                            direction.endPoint(
+                                bounds = bounds,
+                                minimumDistancePx = RAPID_MIN_FLICK_DISTANCE_DP *
+                                    instrumentation.targetContext.resources.displayMetrics.density,
+                            )
+                        },
+                    )
+                }
+            } catch (error: SetupException) {
+                lastError = error.message.orEmpty()
+                SystemClock.sleep(GEOMETRY_SAMPLE_MS)
+            }
+        }
+        throw SetupException("Unable to resolve generated input keys: $lastError")
+    }
+
+    private fun injectRollingTwoFingerSequence(
+        operations: List<RapidOperation>,
+        points: Map<String, RapidTouchPoints>,
+        downIntervalMs: Long,
+    ): Boolean {
+        if (operations.isEmpty()) return true
+        val streamDownTime = SystemClock.uptimeMillis()
+        var currentPointerId = RAPID_POINTER_IDS.first()
+        var availablePointerId = RAPID_POINTER_IDS.last()
+        var currentDownAt = streamDownTime
+        var currentOperation = operations.first()
+        var currentPoint = points.getValue(currentOperation.token).start
+        var allInjected = injectPointerEvent(
+            downTime = streamDownTime,
+            eventTime = streamDownTime,
+            actionMasked = MotionEvent.ACTION_DOWN,
+            actionIndex = 0,
+            PointerSpec(currentPointerId, currentPoint),
+        )
+        currentPoint = moveRapidPointerIfNeeded(
+            downTime = streamDownTime,
+            operation = currentOperation,
+            points = points,
+            pointer = PointerSpec(currentPointerId, currentPoint),
+            intervalMs = downIntervalMs,
+        ).also { allInjected = it.injected && allInjected }.point
+
+        operations.drop(1).forEach { nextOperation ->
+            sleepUntil(currentDownAt + downIntervalMs)
+            val nextDownAt = SystemClock.uptimeMillis()
+            val nextStart = points.getValue(nextOperation.token).start
+            allInjected = injectPointerEvent(
+                downTime = streamDownTime,
+                eventTime = nextDownAt,
+                actionMasked = MotionEvent.ACTION_POINTER_DOWN,
+                actionIndex = 1,
+                PointerSpec(currentPointerId, currentPoint),
+                PointerSpec(availablePointerId, nextStart),
+            ) && allInjected
+            rapidEventDelay(downIntervalMs)
+            allInjected = injectPointerEvent(
+                downTime = streamDownTime,
+                eventTime = SystemClock.uptimeMillis(),
+                actionMasked = MotionEvent.ACTION_POINTER_UP,
+                actionIndex = 0,
+                PointerSpec(currentPointerId, currentPoint),
+                PointerSpec(availablePointerId, nextStart),
+            ) && allInjected
+
+            val releasedPointerId = currentPointerId
+            currentPointerId = availablePointerId
+            availablePointerId = releasedPointerId
+            currentDownAt = nextDownAt
+            currentOperation = nextOperation
+            currentPoint = moveRapidPointerIfNeeded(
+                downTime = streamDownTime,
+                operation = currentOperation,
+                points = points,
+                pointer = PointerSpec(currentPointerId, nextStart),
+                intervalMs = downIntervalMs,
+            ).also { allInjected = it.injected && allInjected }.point
+        }
+
+        SystemClock.sleep(RAPID_FINAL_HOLD_MS)
+        allInjected = injectPointerEvent(
+            downTime = streamDownTime,
+            eventTime = SystemClock.uptimeMillis(),
+            actionMasked = MotionEvent.ACTION_UP,
+            actionIndex = 0,
+            PointerSpec(currentPointerId, currentPoint),
+        ) && allInjected
+        rapidInterGestureDelay(downIntervalMs)
+        return allInjected
+    }
+
+    private fun injectPairedTwoFingerSequence(
+        operations: List<RapidOperation>,
+        points: Map<String, RapidTouchPoints>,
+        downIntervalMs: Long,
+    ): Boolean {
+        var allInjected = true
+        operations.chunked(2).forEach { pair ->
+            if (pair.size == 1) {
+                val operation = pair.single()
+                val touchPoints = points.getValue(operation.token)
+                allInjected = injectRapidSingleGesture(operation, touchPoints) && allInjected
+                return@forEach
+            }
+
+            val firstOperation = pair[0]
+            val secondOperation = pair[1]
+            val firstTouchPoints = points.getValue(firstOperation.token)
+            val secondTouchPoints = points.getValue(secondOperation.token)
+            val downTime = SystemClock.uptimeMillis()
+            var firstPoint = firstTouchPoints.start
+            var secondPoint = secondTouchPoints.start
+
+            allInjected = injectPointerEvent(
+                downTime = downTime,
+                eventTime = downTime,
+                actionMasked = MotionEvent.ACTION_DOWN,
+                actionIndex = 0,
+                PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
+            ) && allInjected
+            firstPoint = moveRapidPointerIfNeeded(
+                downTime = downTime,
+                operation = firstOperation,
+                points = points,
+                pointer = PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
+                intervalMs = downIntervalMs,
+            ).also { allInjected = it.injected && allInjected }.point
+
+            sleepUntil(downTime + downIntervalMs)
+            allInjected = injectPointerEvent(
+                downTime = downTime,
+                eventTime = SystemClock.uptimeMillis(),
+                actionMasked = MotionEvent.ACTION_POINTER_DOWN,
+                actionIndex = 1,
+                PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
+                PointerSpec(RAPID_POINTER_IDS[1], secondPoint),
+            ) && allInjected
+
+            val secondEnd = secondOperation.directionOrTap.endPoint(secondTouchPoints)
+            if (secondEnd != secondPoint) {
+                rapidEventDelay(downIntervalMs)
+                secondPoint = secondEnd
+                allInjected = injectPointerEvent(
+                    downTime = downTime,
+                    eventTime = SystemClock.uptimeMillis(),
+                    actionMasked = MotionEvent.ACTION_MOVE,
+                    actionIndex = 0,
+                    PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
+                    PointerSpec(RAPID_POINTER_IDS[1], secondPoint),
+                ) && allInjected
+            }
+            SystemClock.sleep(RAPID_FINAL_HOLD_MS)
+            allInjected = injectPointerEvent(
+                downTime = downTime,
+                eventTime = SystemClock.uptimeMillis(),
+                actionMasked = MotionEvent.ACTION_POINTER_UP,
+                actionIndex = 1,
+                PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
+                PointerSpec(RAPID_POINTER_IDS[1], secondPoint),
+            ) && allInjected
+            allInjected = injectPointerEvent(
+                downTime = downTime,
+                eventTime = SystemClock.uptimeMillis(),
+                actionMasked = MotionEvent.ACTION_UP,
+                actionIndex = 0,
+                PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
+            ) && allInjected
+            rapidInterGestureDelay(downIntervalMs)
+        }
+        return allInjected
+    }
+
+    private fun injectRapidSingleGesture(
+        operation: RapidOperation,
+        touchPoints: RapidTouchPoints,
+    ): Boolean {
+        val start = touchPoints.start
+        val end = operation.directionOrTap.endPoint(touchPoints)
+        return if (start == end) injectTap(start) else injectFlick(start, end)
+    }
+
+    private fun moveRapidPointerIfNeeded(
+        downTime: Long,
+        operation: RapidOperation,
+        points: Map<String, RapidTouchPoints>,
+        pointer: PointerSpec,
+        intervalMs: Long,
+    ): RapidMoveResult {
+        val end = operation.directionOrTap.endPoint(points.getValue(operation.token))
+        if (end == pointer.point) return RapidMoveResult(pointer.point, true)
+        rapidEventDelay(intervalMs)
+        val injected = injectPointerEvent(
+            downTime = downTime,
+            eventTime = SystemClock.uptimeMillis(),
+            actionMasked = MotionEvent.ACTION_MOVE,
+            actionIndex = 0,
+            PointerSpec(pointer.id, end),
+        )
+        return RapidMoveResult(end, injected)
+    }
+
+    private fun sleepUntil(targetUptimeMs: Long) {
+        val remaining = targetUptimeMs - SystemClock.uptimeMillis()
+        if (remaining > 0L) SystemClock.sleep(remaining)
+    }
+
+    private fun rapidEventDelay(intervalMs: Long) {
+        val delayMs = (intervalMs / 4).coerceAtMost(RAPID_MAX_EVENT_DELAY_MS)
+        if (delayMs > 0L) SystemClock.sleep(delayMs)
+    }
+
+    private fun rapidInterGestureDelay(intervalMs: Long) {
+        val delayMs = (intervalMs / 2).coerceAtMost(TAP_GAP_MS)
+        if (delayMs > 0L) SystemClock.sleep(delayMs)
+    }
+
+    private fun classifyRapidInputResult(
+        expected: String,
+        actual: String,
+        allEventsInjected: Boolean,
+    ): RapidResultCategory = when {
+        !allEventsInjected -> RapidResultCategory.INJECTION_ERROR
+        actual == expected -> RapidResultCategory.PASS
+        actual.length < expected.length -> RapidResultCategory.MISSING
+        actual.length > expected.length -> RapidResultCategory.EXTRA
+        else -> RapidResultCategory.MISMATCH
+    }
+
+    private fun firstMismatchIndex(expected: String, actual: String): Int {
+        val commonLength = minOf(expected.length, actual.length)
+        for (index in 0 until commonLength) {
+            if (expected[index] != actual[index]) return index
+        }
+        return if (expected.length == actual.length) -1 else commonLength
     }
 
     private fun installKeyboardSizeCustomFixture(
@@ -2580,6 +3328,10 @@ class FastInputMatrixInstrumentedTest {
                 is NodeLocator.Label ->
                     node.text?.toString() == locator.label ||
                         node.contentDescription?.toString() == locator.label
+
+                is NodeLocator.AnyLabel ->
+                    node.text?.toString() in locator.labels ||
+                        node.contentDescription?.toString() in locator.labels
             }
         } ?: throw SetupException("Key ${locator.render()} is not visible")
     }
@@ -3586,6 +4338,10 @@ class FastInputMatrixInstrumentedTest {
         data class Label(val label: String) : NodeLocator {
             override fun render(): String = "label/$label"
         }
+
+        data class AnyLabel(val labels: Set<String>) : NodeLocator {
+            override fun render(): String = "label/${labels.joinToString("|")}"
+        }
     }
 
     private enum class KeyboardSizeFamily {
@@ -3945,6 +4701,206 @@ class FastInputMatrixInstrumentedTest {
         val point: PointF
     )
 
+    private enum class RapidInputSurface(
+        val rootViewId: String,
+        val keyboardOrder: String,
+        val warmExpected: String,
+    ) {
+        TENKEY(
+            "keyboard_view",
+            """["TENKEY","GOJUON","SUMIRE","QWERTY","ROMAJI","CUSTOM"]""",
+            "あ",
+        ),
+        GOJUON(
+            "gojuon_view",
+            """["GOJUON","TENKEY","SUMIRE","QWERTY","ROMAJI","CUSTOM"]""",
+            "あ",
+        ),
+        SUMIRE(
+            "custom_layout_default",
+            """["SUMIRE","TENKEY","GOJUON","QWERTY","ROMAJI","CUSTOM"]""",
+            "あ",
+        ),
+        QWERTY(
+            "qwerty_view",
+            """["QWERTY","TENKEY","GOJUON","SUMIRE","ROMAJI","CUSTOM"]""",
+            "a",
+        ),
+        ROMAJI(
+            "qwerty_view",
+            """["ROMAJI","TENKEY","GOJUON","SUMIRE","QWERTY","CUSTOM"]""",
+            "あ",
+        ),
+        CUSTOM(
+            "custom_layout_default",
+            """["CUSTOM","TENKEY","GOJUON","SUMIRE","QWERTY","ROMAJI"]""",
+            "あ",
+        );
+
+        val warmOperation: RapidOperation
+            get() = when (this) {
+                TENKEY, SUMIRE, CUSTOM -> RapidOperation.Kana(0, RapidDirection.TAP)
+                GOJUON -> RAPID_GOJUON_BASE_KEYS.first().toOperation()
+                QWERTY, ROMAJI -> RapidOperation.Direct(
+                    token = "qwerty-a",
+                    locator = NodeLocator.Id("key_a"),
+                    direction = RapidDirection.TAP,
+                    output = warmExpected,
+                )
+            }
+
+        fun locatorFor(operation: RapidOperation): NodeLocator = when (operation) {
+            is RapidOperation.Kana -> {
+                val row = RAPID_KANA_ROWS[operation.rowIndex]
+                when (this) {
+                    TENKEY -> NodeLocator.Id(row.tenKeyViewId)
+                    SUMIRE, CUSTOM -> NodeLocator.Label(row.label)
+                    GOJUON, QWERTY, ROMAJI -> error(
+                        "Kana-row operation is not valid for $this"
+                    )
+                }
+            }
+
+            RapidOperation.Dakuten -> when (this) {
+                TENKEY -> NodeLocator.Id("key_small_letter")
+                SUMIRE -> NodeLocator.AnyLabel(setOf("^_^", " 小゛゜", "小゛゜"))
+                CUSTOM -> NodeLocator.Label(RAPID_DAKUTEN_LABEL)
+                GOJUON, QWERTY, ROMAJI -> error(
+                    "Dakuten key operation is not valid for $this"
+                )
+            }
+
+            is RapidOperation.Direct -> operation.locator
+        }
+    }
+
+    private enum class RapidDirection(
+        val persistedDirection: FlickDirection,
+        private val normalizedX: Float,
+        private val normalizedY: Float,
+    ) {
+        TAP(FlickDirection.TAP, 0f, 0f),
+        LEFT(FlickDirection.UP_LEFT_FAR, -0.70f, 0f),
+        UP(FlickDirection.UP, 0f, -0.70f),
+        RIGHT(FlickDirection.UP_RIGHT_FAR, 0.70f, 0f),
+        DOWN(FlickDirection.DOWN, 0f, 0.70f);
+
+        fun endPoint(bounds: ScreenRect, minimumDistancePx: Float): PointF {
+            fun delta(size: Int, factor: Float): Float = if (factor == 0f) {
+                0f
+            } else {
+                factor.sign * maxOf(size * abs(factor), minimumDistancePx)
+            }
+            return PointF(
+                bounds.center.x + delta(bounds.width, normalizedX),
+                bounds.center.y + delta(bounds.height, normalizedY),
+            )
+        }
+
+        fun endPoint(points: RapidTouchPoints): PointF = points.ends.getValue(this)
+    }
+
+    private sealed interface RapidOperation {
+        val token: String
+        val directionOrTap: RapidDirection
+
+        data class Kana(
+            val rowIndex: Int,
+            val direction: RapidDirection,
+        ) : RapidOperation {
+            override val token: String
+                get() = RAPID_KANA_ROWS[rowIndex].token
+            override val directionOrTap: RapidDirection
+                get() = direction
+        }
+
+        data object Dakuten : RapidOperation {
+            override val token: String = RAPID_DAKUTEN_TOKEN
+            override val directionOrTap: RapidDirection = RapidDirection.TAP
+        }
+
+        data class Direct(
+            override val token: String,
+            val locator: NodeLocator,
+            val direction: RapidDirection,
+            val output: String,
+        ) : RapidOperation {
+            override val directionOrTap: RapidDirection
+                get() = direction
+        }
+    }
+
+    private enum class RapidReleaseOrder {
+        ROLLING_OLDER_FIRST,
+        PAIRED_NEWER_FIRST,
+    }
+
+    private enum class RapidEditorState {
+        COLD,
+        WARM,
+    }
+
+    private enum class RapidResultCategory {
+        PASS,
+        MISSING,
+        EXTRA,
+        MISMATCH,
+        INJECTION_ERROR,
+    }
+
+    private data class RapidKanaRow(
+        val token: String,
+        val tenKeyViewId: String,
+        val label: String,
+        val outputs: List<String>,
+    )
+
+    private data class RapidInputScenario(
+        val name: String,
+        val operations: List<RapidOperation>,
+        val expected: String,
+        val seed: Int,
+    )
+
+    private data class RapidTrialDimensions(
+        val releaseOrder: RapidReleaseOrder,
+        val orientation: TestOrientation,
+        val editorState: RapidEditorState,
+    )
+
+    private data class RapidGojuonKey(
+        val viewId: String,
+        val output: String,
+        val direction: RapidDirection = RapidDirection.TAP,
+    ) {
+        fun toOperation() = RapidOperation.Direct(
+            token = "gojuon-$viewId",
+            locator = NodeLocator.Id(viewId),
+            direction = direction,
+            output = output,
+        )
+    }
+
+    private data class RapidRomajiSyllable(
+        val roman: String,
+        val kana: String,
+    )
+
+    private data class RapidInputCustomFixture(
+        val id: Long,
+        val stableId: String,
+    )
+
+    private data class RapidTouchPoints(
+        val start: PointF,
+        val ends: Map<RapidDirection, PointF>,
+    )
+
+    private data class RapidMoveResult(
+        val point: PointF,
+        val injected: Boolean,
+    )
+
     private enum class RateCategory {
         EXPECTED,
         YA_NA,
@@ -4060,5 +5016,149 @@ class FastInputMatrixInstrumentedTest {
         private const val RATE_CONFIGURATIONS_PER_ORIENTATION =
             RATE_CONFIGURATIONS / 2
         private val RATE_INTERVALS_MS = longArrayOf(120L, 80L, 60L, 40L, 30L)
+        private const val RAPID_DAKUTEN_TOKEN = "rapid-dakuten"
+        private const val RAPID_DAKUTEN_LABEL = "小゛゜"
+        private const val RAPID_SCENARIOS_PER_SURFACE = 6
+        private const val RAPID_GENERATED_OPERATION_COUNT = 48
+        private const val RAPID_REPEAT_BURST_LENGTH = 8
+        private const val RAPID_ROMAJI_SYLLABLES_PER_TRACE = 24
+        private const val RAPID_BASE_SEED = 0x5A17
+        private const val RAPID_COVERAGE_SEED = 0
+        private const val RAPID_FINAL_HOLD_MS = 8L
+        private const val RAPID_MAX_EVENT_DELAY_MS = 4L
+        private const val RAPID_MIN_FLICK_DISTANCE_DP = 48f
+        private val RAPID_POINTER_IDS = intArrayOf(7, 19)
+        private val RAPID_CANDIDATE_COLUMNS = listOf(1, 2, 3)
+        private val RAPID_MULTITOUCH_INTERVALS_MS =
+            longArrayOf(120L, 60L, 30L, 16L, 8L, 4L, 0L)
+        // The built-in dakuten key cycles つ through small-tsu before づ, so keep
+        // this oracle to kana that have an unambiguous one-press dakuten result.
+        private val RAPID_DAKUTEN_ROW_INDICES = intArrayOf(1, 2, 5)
+        private val RAPID_KANA_ROWS = listOf(
+            RapidKanaRow("rapid-a", "key_1", "あ", listOf("あ", "い", "う", "え", "お")),
+            RapidKanaRow("rapid-ka", "key_2", "か", listOf("か", "き", "く", "け", "こ")),
+            RapidKanaRow("rapid-sa", "key_3", "さ", listOf("さ", "し", "す", "せ", "そ")),
+            RapidKanaRow("rapid-ta", "key_4", "た", listOf("た", "ち", "つ", "て", "と")),
+            RapidKanaRow("rapid-na", "key_5", "な", listOf("な", "に", "ぬ", "ね", "の")),
+            RapidKanaRow("rapid-ha", "key_6", "は", listOf("は", "ひ", "ふ", "へ", "ほ")),
+        )
+        private val RAPID_DAKUTEN_TRANSFORMS = mapOf(
+            'か' to 'が', 'き' to 'ぎ', 'く' to 'ぐ', 'け' to 'げ', 'こ' to 'ご',
+            'さ' to 'ざ', 'し' to 'じ', 'す' to 'ず', 'せ' to 'ぜ', 'そ' to 'ぞ',
+            'た' to 'だ', 'ち' to 'ぢ', 'つ' to 'づ', 'て' to 'で', 'と' to 'ど',
+            'は' to 'ば', 'ひ' to 'び', 'ふ' to 'ぶ', 'へ' to 'べ', 'ほ' to 'ぼ',
+        )
+        private const val RAPID_QWERTY_LETTERS = "abcdefghijklmnopqrstuvwxyz"
+        private val RAPID_QWERTY_ROWS = listOf("qwertyuiop", "asdfghjkl", "zxcvbnm")
+        private const val RAPID_QWERTY_REPEAT_KEYS = "asdfjklyuiop"
+        private val RAPID_GOJUON_BASE_KEYS = buildList {
+            fun addRow(firstId: Int, outputs: String) {
+                outputs.forEachIndexed { index, output ->
+                    add(RapidGojuonKey("key_${firstId + index}", output.toString()))
+                }
+            }
+            addRow(51, "あいうえお")
+            addRow(46, "かきくけこ")
+            addRow(41, "さしすせそ")
+            addRow(36, "たちつてと")
+            addRow(31, "なにぬねの")
+            addRow(26, "はひふへほ")
+            addRow(21, "まみむめも")
+            add(RapidGojuonKey("key_16", "や"))
+            add(RapidGojuonKey("key_18", "ゆ"))
+            add(RapidGojuonKey("key_20", "よ"))
+            addRow(11, "らりるれろ")
+            add(RapidGojuonKey("key_6", "わ"))
+            add(RapidGojuonKey("key_7", "を"))
+            add(RapidGojuonKey("key_8", "ん"))
+        }
+        private val RAPID_GOJUON_VOICED_KEYS = buildList {
+            fun addVoicedRow(firstId: Int, outputs: String) {
+                outputs.forEachIndexed { index, output ->
+                    add(
+                        RapidGojuonKey(
+                            viewId = "key_${firstId + index}",
+                            output = output.toString(),
+                            direction = RapidDirection.LEFT,
+                        )
+                    )
+                }
+            }
+            addVoicedRow(46, "がぎぐげご")
+            addVoicedRow(41, "ざじずぜぞ")
+            addVoicedRow(36, "だぢづでど")
+            addVoicedRow(26, "ばびぶべぼ")
+        }
+        private val RAPID_GOJUON_MODIFIER_KEYS = buildList {
+            "ぱぴぷぺぽ".forEachIndexed { index, output ->
+                add(
+                    RapidGojuonKey(
+                        viewId = "key_${26 + index}",
+                        output = output.toString(),
+                        direction = RapidDirection.RIGHT,
+                    )
+                )
+            }
+            "ぁぃぅぇぉ".forEachIndexed { index, output ->
+                add(
+                    RapidGojuonKey(
+                        viewId = "key_${51 + index}",
+                        output = output.toString(),
+                        direction = RapidDirection.UP,
+                    )
+                )
+            }
+            add(RapidGojuonKey("key_38", "っ", RapidDirection.UP))
+            add(RapidGojuonKey("key_16", "ゃ", RapidDirection.UP))
+            add(RapidGojuonKey("key_18", "ゅ", RapidDirection.UP))
+            add(RapidGojuonKey("key_20", "ょ", RapidDirection.UP))
+        }
+        private val RAPID_ROMAJI_SYLLABLES = listOf(
+            RapidRomajiSyllable("a", "あ"),
+            RapidRomajiSyllable("i", "い"),
+            RapidRomajiSyllable("u", "う"),
+            RapidRomajiSyllable("e", "え"),
+            RapidRomajiSyllable("o", "お"),
+            RapidRomajiSyllable("ka", "か"),
+            RapidRomajiSyllable("ki", "き"),
+            RapidRomajiSyllable("ku", "く"),
+            RapidRomajiSyllable("ke", "け"),
+            RapidRomajiSyllable("ko", "こ"),
+            RapidRomajiSyllable("sa", "さ"),
+            RapidRomajiSyllable("shi", "し"),
+            RapidRomajiSyllable("su", "す"),
+            RapidRomajiSyllable("se", "せ"),
+            RapidRomajiSyllable("so", "そ"),
+            RapidRomajiSyllable("ta", "た"),
+            RapidRomajiSyllable("chi", "ち"),
+            RapidRomajiSyllable("tsu", "つ"),
+            RapidRomajiSyllable("te", "て"),
+            RapidRomajiSyllable("to", "と"),
+            RapidRomajiSyllable("na", "な"),
+            RapidRomajiSyllable("ni", "に"),
+            RapidRomajiSyllable("nu", "ぬ"),
+            RapidRomajiSyllable("ne", "ね"),
+            RapidRomajiSyllable("no", "の"),
+            RapidRomajiSyllable("ha", "は"),
+            RapidRomajiSyllable("hi", "ひ"),
+            RapidRomajiSyllable("fu", "ふ"),
+            RapidRomajiSyllable("he", "へ"),
+            RapidRomajiSyllable("ho", "ほ"),
+            RapidRomajiSyllable("ma", "ま"),
+            RapidRomajiSyllable("mi", "み"),
+            RapidRomajiSyllable("mu", "む"),
+            RapidRomajiSyllable("me", "め"),
+            RapidRomajiSyllable("mo", "も"),
+            RapidRomajiSyllable("ya", "や"),
+            RapidRomajiSyllable("yu", "ゆ"),
+            RapidRomajiSyllable("yo", "よ"),
+            RapidRomajiSyllable("ra", "ら"),
+            RapidRomajiSyllable("ri", "り"),
+            RapidRomajiSyllable("ru", "る"),
+            RapidRomajiSyllable("re", "れ"),
+            RapidRomajiSyllable("ro", "ろ"),
+            RapidRomajiSyllable("wa", "わ"),
+            RapidRomajiSyllable("wo", "を"),
+        )
     }
 }

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -1687,6 +1687,16 @@ class FastInputMatrixInstrumentedTest {
                                         session.targetIme,
                                         activeScenario,
                                     )
+                                    // The keyboard is bottom-anchored, so candidate updates do not
+                                    // change key coordinates. Resolve and validate the complete
+                                    // operation set once per stable surface/column/orientation;
+                                    // querying UiAutomation.windows for every trial can starve the
+                                    // emulator's AccessibilityManager during a long matrix run.
+                                    val points = resolveRapidInputPoints(
+                                        surface = surface,
+                                        operations = generatedScenarios
+                                            .flatMap { it.operations } + surface.warmOperation,
+                                    )
 
                                     for (scenarioIndex in generatedScenarios.indices) {
                                         val inputScenario = generatedScenarios[scenarioIndex]
@@ -1731,12 +1741,9 @@ class FastInputMatrixInstrumentedTest {
                                                     scenario = activeScenario,
                                                     surface = surface,
                                                     editorState = dimensions.editorState,
+                                                    points = points,
                                                 )
                                                 expected = prefix + inputScenario.expected
-                                                val points = resolveRapidInputPoints(
-                                                    surface = surface,
-                                                    operations = inputScenario.operations,
-                                                )
                                                 val injected = when (dimensions.releaseOrder) {
                                                     RapidReleaseOrder.ROLLING_OLDER_FIRST ->
                                                         injectRollingTwoFingerSequence(
@@ -2593,11 +2600,11 @@ class FastInputMatrixInstrumentedTest {
         scenario: ActivityScenario<FastInputHostActivity>,
         surface: RapidInputSurface,
         editorState: RapidEditorState,
+        points: Map<String, RapidTouchPoints>,
     ): String {
         if (editorState == RapidEditorState.COLD) return ""
         val operation = surface.warmOperation
-        val points = resolveRapidInputPoints(surface, listOf(operation)).getValue(operation.token)
-        check(injectRapidSingleGesture(operation, points)) {
+        check(injectRapidSingleGesture(operation, points.getValue(operation.token))) {
             "Unable to prime warm editor state for $surface"
         }
         val actual = awaitTextSettled(scenario)
@@ -2619,22 +2626,26 @@ class FastInputMatrixInstrumentedTest {
             try {
                 val root = findVisibleNodeById(surface.rootViewId)
                     ?: throw SetupException("${surface.rootViewId} is not visible")
-                return requiredTokens.associateWith { token ->
-                    val operation = operations.first { it.token == token }
-                    val bounds = findRequiredKey(
-                        keyboardRoot = root,
-                        locator = surface.locatorFor(operation),
-                    ).screenRect()
-                    RapidTouchPoints(
-                        start = bounds.center,
-                        ends = RapidDirection.entries.associateWith { direction ->
-                            direction.endPoint(
-                                bounds = bounds,
-                                minimumDistancePx = RAPID_MIN_FLICK_DISTANCE_DP *
-                                    instrumentation.targetContext.resources.displayMetrics.density,
-                            )
-                        },
-                    )
+                return try {
+                    requiredTokens.associateWith { token ->
+                        val operation = operations.first { it.token == token }
+                        val bounds = findRequiredKeyBounds(
+                            keyboardRoot = root,
+                            locator = surface.locatorFor(operation),
+                        )
+                        RapidTouchPoints(
+                            start = bounds.center,
+                            ends = RapidDirection.entries.associateWith { direction ->
+                                direction.endPoint(
+                                    bounds = bounds,
+                                    minimumDistancePx = RAPID_MIN_FLICK_DISTANCE_DP *
+                                        instrumentation.targetContext.resources.displayMetrics.density,
+                                )
+                            },
+                        )
+                    }
+                } finally {
+                    root.recycle()
                 }
             } catch (error: SetupException) {
                 lastError = error.message.orEmpty()
@@ -2656,7 +2667,7 @@ class FastInputMatrixInstrumentedTest {
         var currentDownAt = streamDownTime
         var currentOperation = operations.first()
         var currentPoint = points.getValue(currentOperation.token).start
-        var allInjected = injectPointerEvent(
+        var allInjected = injectRapidPointerEvent(
             downTime = streamDownTime,
             eventTime = streamDownTime,
             actionMasked = MotionEvent.ACTION_DOWN,
@@ -2675,7 +2686,7 @@ class FastInputMatrixInstrumentedTest {
             sleepUntil(currentDownAt + downIntervalMs)
             val nextDownAt = SystemClock.uptimeMillis()
             val nextStart = points.getValue(nextOperation.token).start
-            allInjected = injectPointerEvent(
+            allInjected = injectRapidPointerEvent(
                 downTime = streamDownTime,
                 eventTime = nextDownAt,
                 actionMasked = MotionEvent.ACTION_POINTER_DOWN,
@@ -2684,7 +2695,7 @@ class FastInputMatrixInstrumentedTest {
                 PointerSpec(availablePointerId, nextStart),
             ) && allInjected
             rapidEventDelay(downIntervalMs)
-            allInjected = injectPointerEvent(
+            allInjected = injectRapidPointerEvent(
                 downTime = streamDownTime,
                 eventTime = SystemClock.uptimeMillis(),
                 actionMasked = MotionEvent.ACTION_POINTER_UP,
@@ -2708,7 +2719,7 @@ class FastInputMatrixInstrumentedTest {
         }
 
         SystemClock.sleep(RAPID_FINAL_HOLD_MS)
-        allInjected = injectPointerEvent(
+        allInjected = injectRapidPointerEvent(
             downTime = streamDownTime,
             eventTime = SystemClock.uptimeMillis(),
             actionMasked = MotionEvent.ACTION_UP,
@@ -2741,7 +2752,7 @@ class FastInputMatrixInstrumentedTest {
             var firstPoint = firstTouchPoints.start
             var secondPoint = secondTouchPoints.start
 
-            allInjected = injectPointerEvent(
+            allInjected = injectRapidPointerEvent(
                 downTime = downTime,
                 eventTime = downTime,
                 actionMasked = MotionEvent.ACTION_DOWN,
@@ -2757,7 +2768,7 @@ class FastInputMatrixInstrumentedTest {
             ).also { allInjected = it.injected && allInjected }.point
 
             sleepUntil(downTime + downIntervalMs)
-            allInjected = injectPointerEvent(
+            allInjected = injectRapidPointerEvent(
                 downTime = downTime,
                 eventTime = SystemClock.uptimeMillis(),
                 actionMasked = MotionEvent.ACTION_POINTER_DOWN,
@@ -2770,7 +2781,7 @@ class FastInputMatrixInstrumentedTest {
             if (secondEnd != secondPoint) {
                 rapidEventDelay(downIntervalMs)
                 secondPoint = secondEnd
-                allInjected = injectPointerEvent(
+                allInjected = injectRapidPointerEvent(
                     downTime = downTime,
                     eventTime = SystemClock.uptimeMillis(),
                     actionMasked = MotionEvent.ACTION_MOVE,
@@ -2780,7 +2791,7 @@ class FastInputMatrixInstrumentedTest {
                 ) && allInjected
             }
             SystemClock.sleep(RAPID_FINAL_HOLD_MS)
-            allInjected = injectPointerEvent(
+            allInjected = injectRapidPointerEvent(
                 downTime = downTime,
                 eventTime = SystemClock.uptimeMillis(),
                 actionMasked = MotionEvent.ACTION_POINTER_UP,
@@ -2788,7 +2799,7 @@ class FastInputMatrixInstrumentedTest {
                 PointerSpec(RAPID_POINTER_IDS[0], firstPoint),
                 PointerSpec(RAPID_POINTER_IDS[1], secondPoint),
             ) && allInjected
-            allInjected = injectPointerEvent(
+            allInjected = injectRapidPointerEvent(
                 downTime = downTime,
                 eventTime = SystemClock.uptimeMillis(),
                 actionMasked = MotionEvent.ACTION_UP,
@@ -2806,7 +2817,7 @@ class FastInputMatrixInstrumentedTest {
     ): Boolean {
         val start = touchPoints.start
         val end = operation.directionOrTap.endPoint(touchPoints)
-        return if (start == end) injectTap(start) else injectFlick(start, end)
+        return if (start == end) injectRapidTap(start) else injectRapidFlick(start, end)
     }
 
     private fun moveRapidPointerIfNeeded(
@@ -2819,7 +2830,7 @@ class FastInputMatrixInstrumentedTest {
         val end = operation.directionOrTap.endPoint(points.getValue(operation.token))
         if (end == pointer.point) return RapidMoveResult(pointer.point, true)
         rapidEventDelay(intervalMs)
-        val injected = injectPointerEvent(
+        val injected = injectRapidPointerEvent(
             downTime = downTime,
             eventTime = SystemClock.uptimeMillis(),
             actionMasked = MotionEvent.ACTION_MOVE,
@@ -3451,10 +3462,14 @@ class FastInputMatrixInstrumentedTest {
             try {
                 val root = findVisibleNodeById(surface.rootViewId)
                     ?: throw SetupException("${surface.rootViewId} is not visible")
-                val current = findRequiredKey(
-                    keyboardRoot = root,
-                    locator = surface.locatorFor(operation),
-                ).screenRect()
+                val current = try {
+                    findRequiredKeyBounds(
+                        keyboardRoot = root,
+                        locator = surface.locatorFor(operation),
+                    )
+                } finally {
+                    root.recycle()
+                }
                 if (current.isValid && current == previous) {
                     stableSamples += 1
                     if (stableSamples >= GEOMETRY_STABLE_SAMPLES) return
@@ -3649,23 +3664,27 @@ class FastInputMatrixInstrumentedTest {
     ): GeometrySnapshot {
         val root = findVisibleNodeById(keyboard.rootViewId)
             ?: throw SetupException("${keyboard.rootViewId} is not visible")
-        val rootBounds = root.screenRect()
-        val first = findRequiredKey(root, keyboard.firstKey)
-        val second = if (keyboard.firstKey == keyboard.secondKey) {
-            first
-        } else {
-            findRequiredKey(root, keyboard.secondKey)
+        return try {
+            val rootBounds = root.screenRect()
+            val first = findRequiredKeyBounds(root, keyboard.firstKey)
+            val second = if (keyboard.firstKey == keyboard.secondKey) {
+                first
+            } else {
+                findRequiredKeyBounds(root, keyboard.secondKey)
+            }
+            val prime = findRequiredKeyBounds(root, keyboard.primeKey)
+            val neighbor = keyboard.neighborKey?.let { findRequiredKeyBounds(root, it) }
+            GeometrySnapshot(
+                root = rootBounds,
+                first = first,
+                second = second,
+                prime = prime,
+                neighbor = neighbor,
+                candidate = candidateBounds
+            )
+        } finally {
+            root.recycle()
         }
-        val prime = findRequiredKey(root, keyboard.primeKey)
-        val neighbor = keyboard.neighborKey?.let { findRequiredKey(root, it) }
-        return GeometrySnapshot(
-            root = rootBounds,
-            first = first.screenRect(),
-            second = second.screenRect(),
-            prime = prime.screenRect(),
-            neighbor = neighbor?.screenRect(),
-            candidate = candidateBounds
-        )
     }
 
     private fun findRequiredKey(
@@ -3688,18 +3707,38 @@ class FastInputMatrixInstrumentedTest {
         } ?: throw SetupException("Key ${locator.render()} is not visible")
     }
 
+    private fun findRequiredKeyBounds(
+        keyboardRoot: AccessibilityNodeInfo,
+        locator: NodeLocator,
+    ): ScreenRect {
+        val node = findRequiredKey(keyboardRoot, locator)
+        return try {
+            node.screenRect()
+        } finally {
+            node.recycle()
+        }
+    }
+
     private fun findCursorLeftBounds(keyboard: TestKeyboard): ScreenRect {
         return when (keyboard) {
             TestKeyboard.TENKEY -> awaitVisibleNodeBounds("key_soft_left")
             TestKeyboard.SUMIRE -> {
                 val root = findVisibleNodeById(keyboard.rootViewId)
                     ?: throw SetupException("${keyboard.rootViewId} is not visible")
-                val labels = setOf("CursorMoveLeft", "Move Cursor Left", "カーソル左")
-                val node = findDescendant(root) { candidate ->
-                    candidate.text?.toString() in labels ||
-                        candidate.contentDescription?.toString() in labels
-                } ?: throw SetupException("Sumire cursor-left key is not visible")
-                node.screenRect()
+                try {
+                    val labels = setOf("CursorMoveLeft", "Move Cursor Left", "カーソル左")
+                    val node = findDescendant(root) { candidate ->
+                        candidate.text?.toString() in labels ||
+                            candidate.contentDescription?.toString() in labels
+                    } ?: throw SetupException("Sumire cursor-left key is not visible")
+                    try {
+                        node.screenRect()
+                    } finally {
+                        node.recycle()
+                    }
+                } finally {
+                    root.recycle()
+                }
             }
 
             TestKeyboard.QWERTY -> throw SetupException(
@@ -3711,27 +3750,39 @@ class FastInputMatrixInstrumentedTest {
     private fun findCandidateState(): CandidateState {
         val recycler = findVisibleNodeById("suggestion_recycler_view")
             ?: return CandidateState(bounds = null, texts = emptyList())
-        val texts = mutableListOf<String>()
-        forEachDescendant(recycler) { node ->
-            node.text?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
-                if (it !in texts && texts.size < MAX_CANDIDATE_TEXTS) texts += it
+        return try {
+            val texts = mutableListOf<String>()
+            forEachDescendant(recycler) { node ->
+                node.text?.toString()?.trim()?.takeIf { it.isNotEmpty() }?.let {
+                    if (it !in texts && texts.size < MAX_CANDIDATE_TEXTS) texts += it
+                }
             }
+            CandidateState(
+                bounds = recycler.screenRect(),
+                texts = texts
+            )
+        } finally {
+            recycler.recycle()
         }
-        return CandidateState(
-            bounds = recycler.screenRect(),
-            texts = texts
-        )
     }
 
     private fun findVisibleNodeById(idName: String): AccessibilityNodeInfo? {
         for (window in uiAutomation.windows) {
-            val root = window.root ?: continue
-            val found = findDescendant(root) { node ->
-                node.isVisibleToUser &&
-                    node.viewIdResourceName?.endsWith(":id/$idName") == true &&
-                    node.screenRect().isValid
+            try {
+                val root = window.root ?: continue
+                try {
+                    val found = findDescendant(root) { node ->
+                        node.isVisibleToUser &&
+                            node.viewIdResourceName?.endsWith(":id/$idName") == true &&
+                            node.screenRect().isValid
+                    }
+                    if (found != null) return found
+                } finally {
+                    root.recycle()
+                }
+            } finally {
+                window.recycle()
             }
-            if (found != null) return found
         }
         return null
     }
@@ -3836,12 +3887,22 @@ class FastInputMatrixInstrumentedTest {
     ): AccessibilityNodeInfo? {
         val queue = ArrayDeque<AccessibilityNodeInfo>()
         queue.add(root)
-        while (queue.isNotEmpty()) {
-            val node = queue.removeFirst()
-            if (predicate(node)) return node
-            for (index in 0 until node.childCount) {
-                node.getChild(index)?.let(queue::addLast)
+        try {
+            while (queue.isNotEmpty()) {
+                val node = queue.removeFirst()
+                val isRoot = node === root
+                try {
+                    if (predicate(node)) return AccessibilityNodeInfo.obtain(node)
+                    for (index in 0 until node.childCount) {
+                        node.getChild(index)?.let(queue::addLast)
+                    }
+                } finally {
+                    if (!isRoot) node.recycle()
+                }
             }
+        } finally {
+            queue.forEach { it.recycle() }
+            queue.clear()
         }
         return null
     }
@@ -3852,12 +3913,22 @@ class FastInputMatrixInstrumentedTest {
     ) {
         val queue = ArrayDeque<AccessibilityNodeInfo>()
         queue.add(root)
-        while (queue.isNotEmpty()) {
-            val node = queue.removeFirst()
-            action(node)
-            for (index in 0 until node.childCount) {
-                node.getChild(index)?.let(queue::addLast)
+        try {
+            while (queue.isNotEmpty()) {
+                val node = queue.removeFirst()
+                val isRoot = node === root
+                try {
+                    action(node)
+                    for (index in 0 until node.childCount) {
+                        node.getChild(index)?.let(queue::addLast)
+                    }
+                } finally {
+                    if (!isRoot) node.recycle()
+                }
             }
+        } finally {
+            queue.forEach { it.recycle() }
+            queue.clear()
         }
     }
 
@@ -3953,6 +4024,57 @@ class FastInputMatrixInstrumentedTest {
         return allInjected
     }
 
+    private fun injectRapidTap(point: PointF): Boolean {
+        val downTime = SystemClock.uptimeMillis()
+        var injected = injectRapidSinglePointerEvent(
+            downTime = downTime,
+            action = MotionEvent.ACTION_DOWN,
+            point = point,
+        )
+        SystemClock.sleep(TAP_HOLD_MS)
+        injected = injectRapidSinglePointerEvent(
+            downTime = downTime,
+            action = MotionEvent.ACTION_UP,
+            point = point,
+        ) && injected
+        SystemClock.sleep(TAP_GAP_MS)
+        return injected
+    }
+
+    private fun injectRapidFlick(start: PointF, end: PointF): Boolean {
+        if (start == end) return injectRapidTap(start)
+
+        val downTime = SystemClock.uptimeMillis()
+        var allInjected = injectRapidSinglePointerEvent(
+            downTime = downTime,
+            action = MotionEvent.ACTION_DOWN,
+            point = start,
+        )
+        SystemClock.sleep(FLICK_STEP_MS)
+
+        repeat(FLICK_MOVE_STEPS) { index ->
+            val fraction = (index + 1f) / FLICK_MOVE_STEPS
+            val point = PointF(
+                start.x + (end.x - start.x) * fraction,
+                start.y + (end.y - start.y) * fraction,
+            )
+            allInjected = injectRapidSinglePointerEvent(
+                downTime = downTime,
+                action = MotionEvent.ACTION_MOVE,
+                point = point,
+            ) && allInjected
+            SystemClock.sleep(FLICK_STEP_MS)
+        }
+
+        allInjected = injectRapidSinglePointerEvent(
+            downTime = downTime,
+            action = MotionEvent.ACTION_UP,
+            point = end,
+        ) && allInjected
+        SystemClock.sleep(TAP_GAP_MS)
+        return allInjected
+    }
+
     private fun injectSinglePointerEvent(
         downTime: Long,
         action: Int,
@@ -3965,6 +4087,24 @@ class FastInputMatrixInstrumentedTest {
             point = point
         )
         return uiAutomation.injectInputEvent(event, true).also {
+            event.recycle()
+        }
+    }
+
+    private fun injectRapidSinglePointerEvent(
+        downTime: Long,
+        action: Int,
+        point: PointF,
+    ): Boolean {
+        val event = singlePointerEvent(
+            downTime = downTime,
+            eventTime = SystemClock.uptimeMillis(),
+            action = action,
+            point = point,
+        )
+        return try {
+            uiAutomation.injectInputEvent(event, false)
+        } finally {
             event.recycle()
         }
     }
@@ -4202,6 +4342,37 @@ class FastInputMatrixInstrumentedTest {
         actionMasked: Int,
         actionIndex: Int,
         vararg pointers: PointerSpec
+    ): Boolean = injectPointerEventWithMode(
+        downTime = downTime,
+        eventTime = eventTime,
+        actionMasked = actionMasked,
+        actionIndex = actionIndex,
+        synchronous = true,
+        pointers = pointers,
+    )
+
+    private fun injectRapidPointerEvent(
+        downTime: Long,
+        eventTime: Long,
+        actionMasked: Int,
+        actionIndex: Int,
+        vararg pointers: PointerSpec,
+    ): Boolean = injectPointerEventWithMode(
+        downTime = downTime,
+        eventTime = eventTime,
+        actionMasked = actionMasked,
+        actionIndex = actionIndex,
+        synchronous = false,
+        pointers = pointers,
+    )
+
+    private fun injectPointerEventWithMode(
+        downTime: Long,
+        eventTime: Long,
+        actionMasked: Int,
+        actionIndex: Int,
+        synchronous: Boolean,
+        pointers: Array<out PointerSpec>,
     ): Boolean {
         val properties = Array(pointers.size) { index ->
             MotionEvent.PointerProperties().apply {
@@ -4236,7 +4407,7 @@ class FastInputMatrixInstrumentedTest {
             0
         )
         return try {
-            uiAutomation.injectInputEvent(event, true)
+            uiAutomation.injectInputEvent(event, synchronous)
         } finally {
             event.recycle()
         }

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -5,8 +5,10 @@ import android.app.Instrumentation
 import android.app.KeyguardManager
 import android.app.UiAutomation
 import android.content.ComponentName
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.SharedPreferences
 import android.graphics.Bitmap
 import android.graphics.PointF
@@ -30,6 +32,7 @@ import android.view.accessibility.AccessibilityNodeInfo
 import android.view.inputmethod.InputMethodManager
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
+import androidx.core.content.ContextCompat
 import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
@@ -43,6 +46,9 @@ import com.kazumaproject.markdownhelperkeyboard.ime_service.di.KanaKanjiEngineEn
 import dagger.hilt.android.EntryPointAccessors
 import java.io.File
 import java.io.FileOutputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -1617,7 +1623,7 @@ class FastInputMatrixInstrumentedTest {
                             val generatedScenarios = buildRapidInputScenarios(surface, round)
                             for (orientation in TestOrientation.entries) {
                                 rotateAndVerify(orientation)
-                                prepareEmptyEditor(scenario)
+                                prepareEmptyEditor(scenario, surface)
                                 SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
                                 assertDeviceReady(
                                     session.context,
@@ -1635,7 +1641,21 @@ class FastInputMatrixInstrumentedTest {
                                         )
                                         if (dimensions.orientation != orientation) continue
 
-                                        prepareEmptyEditor(scenario)
+                                        val trial = buildString {
+                                            append("surface=${surface.name} ")
+                                            append("columns=$columns ")
+                                            append("round=$round ")
+                                            append("scenario=${inputScenario.name} ")
+                                            append("seed=${inputScenario.seed} ")
+                                            append("orientation=${dimensions.orientation.name} ")
+                                            append("editor=${dimensions.editorState.name} ")
+                                            append("release=${dimensions.releaseOrder.name} ")
+                                            append("intervalMs=$intervalMs")
+                                        }
+                                        Log.i(TAG, "MULTITOUCH_TRIAL\t$trial")
+                                        sendProgress("FAST_INPUT_MULTITOUCH_TRIAL $trial\n")
+
+                                        prepareEmptyEditor(scenario, surface)
                                         val prefix = prepareRapidEditorState(
                                             scenario = scenario,
                                             surface = surface,
@@ -3060,8 +3080,40 @@ class FastInputMatrixInstrumentedTest {
 
     private fun restartInput(scenario: ActivityScenario<FastInputHostActivity>) {
         awaitHostWindowFocus(scenario)
-        scenario.onActivity { activity ->
-            activity.restartEditorInput(clearText = true)
+        val context = instrumentation.targetContext
+        val readinessToken =
+            "${SystemClock.uptimeMillis()}-${IME_RESTART_TOKEN_SEQUENCE.incrementAndGet()}"
+        val readySignal = CountDownLatch(1)
+        val receiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context?, intent: Intent?) {
+                if (
+                    intent?.getStringExtra(FastInputTestProtocol.EXTRA_TOKEN) == readinessToken
+                ) {
+                    readySignal.countDown()
+                }
+            }
+        }
+        ContextCompat.registerReceiver(
+            context,
+            receiver,
+            IntentFilter(FastInputTestProtocol.ACTION_IME_READY),
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
+        try {
+            scenario.onActivity { activity ->
+                activity.restartEditorInput(
+                    clearText = true,
+                    readinessToken = readinessToken,
+                )
+            }
+            if (!readySignal.await(IME_RESTART_READY_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                throw SetupException(
+                    "IME did not report keyboard readiness after restarting the host editor " +
+                        "(token=$readinessToken)"
+                )
+            }
+        } finally {
+            context.unregisterReceiver(receiver)
         }
 
         val deadline = SystemClock.uptimeMillis() + EDITOR_CONNECTION_TIMEOUT_MS
@@ -3113,7 +3165,10 @@ class FastInputMatrixInstrumentedTest {
         )
     }
 
-    private fun prepareEmptyEditor(scenario: ActivityScenario<FastInputHostActivity>) {
+    private fun prepareEmptyEditor(
+        scenario: ActivityScenario<FastInputHostActivity>,
+        rapidSurface: RapidInputSurface? = null,
+    ) {
         restartInput(scenario)
         val deadline = SystemClock.uptimeMillis() + SETUP_TIMEOUT_MS
         while (SystemClock.uptimeMillis() < deadline) {
@@ -3123,10 +3178,46 @@ class FastInputMatrixInstrumentedTest {
                     activity.editText.isShown &&
                     activity.editText.text.isNullOrEmpty()
             }
-            if (ready) return
+            if (ready) {
+                rapidSurface?.let(::awaitRapidInputSurfaceReady)
+                return
+            }
             SystemClock.sleep(POLL_MS)
         }
         throw SetupException("Host editor did not become focused and empty")
+    }
+
+    private fun awaitRapidInputSurfaceReady(surface: RapidInputSurface) {
+        val operation = surface.warmOperation
+        val deadline = SystemClock.uptimeMillis() + SETUP_TIMEOUT_MS
+        var previous: ScreenRect? = null
+        var stableSamples = 0
+        var lastError = "${surface.rootViewId} is not visible"
+        while (SystemClock.uptimeMillis() < deadline) {
+            try {
+                val root = findVisibleNodeById(surface.rootViewId)
+                    ?: throw SetupException("${surface.rootViewId} is not visible")
+                val current = findRequiredKey(
+                    keyboardRoot = root,
+                    locator = surface.locatorFor(operation),
+                ).screenRect()
+                if (current.isValid && current == previous) {
+                    stableSamples += 1
+                    if (stableSamples >= GEOMETRY_STABLE_SAMPLES) return
+                } else {
+                    stableSamples = if (current.isValid) 1 else 0
+                }
+                previous = current
+            } catch (error: SetupException) {
+                lastError = error.message.orEmpty()
+                previous = null
+                stableSamples = 0
+            }
+            SystemClock.sleep(GEOMETRY_SAMPLE_MS)
+        }
+        throw SetupException(
+            "Rapid-input surface ${surface.name} was not stable after editor restart: $lastError"
+        )
     }
 
     private fun readText(scenario: ActivityScenario<FastInputHostActivity>): String {
@@ -5017,12 +5108,14 @@ class FastInputMatrixInstrumentedTest {
         private const val IME_LAYOUT_SETTLE_MS = 350L
         private const val EDITOR_CONNECTION_TIMEOUT_MS = 10_000L
         private const val EDITOR_CONNECTION_STABLE_SAMPLES = 3
+        private const val IME_RESTART_READY_TIMEOUT_MS = 10_000L
         private const val IME_STATE_POLL_MS = 250L
         private const val IME_REGISTRATION_TIMEOUT_MS = 30_000L
         private const val IME_ENABLE_TIMEOUT_MS = 15_000L
         private const val IME_SWITCH_TIMEOUT_MS = 15_000L
         private const val IME_SWITCH_RETRY_MS = 1_000L
         private const val IME_SWITCH_STABILITY_MS = 750L
+        private val IME_RESTART_TOKEN_SEQUENCE = AtomicLong(0L)
         private const val TOTAL_CASES = 3 * 3 * 2 * 2 * 2 * 2
         private const val CASES_PER_ORIENTATION = TOTAL_CASES / 2
         private const val RATE_CONFIGURATIONS = 2 * 2 * 2 * 2

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
@@ -80,13 +80,17 @@ class FastInputHostActivity : Activity() {
         requestImeForEditor()
     }
 
-    fun resetEditorForFastInputTest(token: String, receiver: ResultReceiver) {
+    fun resetEditorForFastInputTest(
+        token: String,
+        receiver: ResultReceiver,
+        traceId: String? = null,
+    ) {
         editText.editableText.clear()
         editText.setSelection(0)
         getSystemService(InputMethodManager::class.java).sendAppPrivateCommand(
             editText,
             FastInputTestProtocol.ACTION_RESET_FOR_TEST,
-            FastInputTestProtocol.resetCommand(token, receiver),
+            FastInputTestProtocol.resetCommand(token, receiver, traceId),
         )
     }
 

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
@@ -69,10 +69,11 @@ class FastInputHostActivity : Activity() {
      * matrix test only needs InputMethodService.onStartInput() to reload its preferences, so a
      * restart on the existing connection is both sufficient and deterministic.
      */
-    fun restartEditorInput(clearText: Boolean) {
+    fun restartEditorInput(clearText: Boolean, readinessToken: String? = null) {
         if (clearText) {
             editText.setText("")
         }
+        editText.privateImeOptions = readinessToken?.let(FastInputTestProtocol::privateImeOptions)
         editText.requestFocus()
         editText.setSelection(editText.text.length)
         getSystemService(InputMethodManager::class.java).restartInput(editText)

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/FastInputHostActivity.kt
@@ -2,6 +2,7 @@ package com.kazumaproject.markdownhelperkeyboard
 
 import android.app.Activity
 import android.os.Bundle
+import android.os.ResultReceiver
 import android.view.WindowManager
 import android.view.inputmethod.InputMethodManager
 import android.widget.EditText
@@ -57,7 +58,6 @@ class FastInputHostActivity : Activity() {
         super.onWindowFocusChanged(hasFocus)
         if (hasFocus) {
             editText.requestFocus()
-            getSystemService(InputMethodManager::class.java).restartInput(editText)
             requestImeForEditor()
         }
     }
@@ -71,13 +71,23 @@ class FastInputHostActivity : Activity() {
      */
     fun restartEditorInput(clearText: Boolean, readinessToken: String? = null) {
         if (clearText) {
-            editText.setText("")
+            editText.editableText.clear()
         }
         editText.privateImeOptions = readinessToken?.let(FastInputTestProtocol::privateImeOptions)
         editText.requestFocus()
         editText.setSelection(editText.text.length)
         getSystemService(InputMethodManager::class.java).restartInput(editText)
         requestImeForEditor()
+    }
+
+    fun resetEditorForFastInputTest(token: String, receiver: ResultReceiver) {
+        editText.editableText.clear()
+        editText.setSelection(0)
+        getSystemService(InputMethodManager::class.java).sendAppPrivateCommand(
+            editText,
+            FastInputTestProtocol.ACTION_RESET_FOR_TEST,
+            FastInputTestProtocol.resetCommand(token, receiver),
+        )
     }
 
     fun requestImeForEditor() {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocol.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocol.kt
@@ -13,6 +13,7 @@ internal object FastInputTestProtocol {
     const val ACTION_RESET_FOR_TEST =
         "com.kazumaproject.markdownhelperkeyboard.action.FAST_INPUT_RESET"
     const val EXTRA_RESET_TOKEN = "fast_input_reset_token"
+    const val EXTRA_TRACE_ID = "fast_input_trace_id"
     const val EXTRA_RESET_RESULT_RECEIVER = "fast_input_reset_result_receiver"
     const val EXTRA_RESET_ERROR = "fast_input_reset_error"
     const val RESET_ACK = 1
@@ -29,8 +30,15 @@ internal object FastInputTestProtocol {
         .setPackage(packageName)
         .putExtra(EXTRA_TOKEN, token)
 
-    fun resetCommand(token: String, receiver: ResultReceiver): Bundle = Bundle().apply {
+    fun resetCommand(
+        token: String,
+        receiver: ResultReceiver,
+        traceId: String? = null,
+    ): Bundle = Bundle().apply {
         putString(EXTRA_RESET_TOKEN, token)
+        traceId?.takeIf(String::isNotBlank)?.let {
+            putString(EXTRA_TRACE_ID, it)
+        }
         putParcelable(EXTRA_RESET_RESULT_RECEIVER, receiver)
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocol.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocol.kt
@@ -1,6 +1,8 @@
 package com.kazumaproject.markdownhelperkeyboard
 
 import android.content.Intent
+import android.os.Bundle
+import android.os.ResultReceiver
 
 /** Debug-only synchronization contract between the fast-input host and the IME. */
 internal object FastInputTestProtocol {
@@ -8,6 +10,13 @@ internal object FastInputTestProtocol {
     const val ACTION_IME_READY =
         "com.kazumaproject.markdownhelperkeyboard.action.FAST_INPUT_IME_READY"
     const val EXTRA_TOKEN = "fast_input_ready_token"
+    const val ACTION_RESET_FOR_TEST =
+        "com.kazumaproject.markdownhelperkeyboard.action.FAST_INPUT_RESET"
+    const val EXTRA_RESET_TOKEN = "fast_input_reset_token"
+    const val EXTRA_RESET_RESULT_RECEIVER = "fast_input_reset_result_receiver"
+    const val EXTRA_RESET_ERROR = "fast_input_reset_error"
+    const val RESET_ACK = 1
+    const val RESET_ERROR = -1
 
     fun privateImeOptions(token: String): String = PRIVATE_IME_OPTION_PREFIX + token
 
@@ -19,4 +28,9 @@ internal object FastInputTestProtocol {
     fun readyIntent(packageName: String, token: String): Intent = Intent(ACTION_IME_READY)
         .setPackage(packageName)
         .putExtra(EXTRA_TOKEN, token)
+
+    fun resetCommand(token: String, receiver: ResultReceiver): Bundle = Bundle().apply {
+        putString(EXTRA_RESET_TOKEN, token)
+        putParcelable(EXTRA_RESET_RESULT_RECEIVER, receiver)
+    }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocol.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocol.kt
@@ -1,0 +1,22 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import android.content.Intent
+
+/** Debug-only synchronization contract between the fast-input host and the IME. */
+internal object FastInputTestProtocol {
+    const val PRIVATE_IME_OPTION_PREFIX = "fast-input-ready:"
+    const val ACTION_IME_READY =
+        "com.kazumaproject.markdownhelperkeyboard.action.FAST_INPUT_IME_READY"
+    const val EXTRA_TOKEN = "fast_input_ready_token"
+
+    fun privateImeOptions(token: String): String = PRIVATE_IME_OPTION_PREFIX + token
+
+    fun tokenFrom(privateImeOptions: String?): String? = privateImeOptions
+        ?.takeIf { it.startsWith(PRIVATE_IME_OPTION_PREFIX) }
+        ?.removePrefix(PRIVATE_IME_OPTION_PREFIX)
+        ?.takeIf { it.isNotBlank() }
+
+    fun readyIntent(packageName: String, token: String): Intent = Intent(ACTION_IME_READY)
+        .setPackage(packageName)
+        .putExtra(EXTRA_TOKEN, token)
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTextSettlePolicy.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/FastInputTextSettlePolicy.kt
@@ -1,0 +1,32 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+/**
+ * State machine for deciding when an editor value is safe to use as the result of an asynchronous
+ * input trace.
+ *
+ * With an expected value, a stable partial value is deliberately never terminal. This is
+ * important for rapid multi-touch input because InputConnection callbacks can arrive in chunks.
+ */
+internal class FastInputTextSettlePolicy(
+    private val expectedText: String? = null,
+    private val stableSamplesRequired: Int = 1,
+) {
+    private var previousText: String? = null
+    private var stableSamples = 0
+
+    init {
+        require(stableSamplesRequired > 0) { "stableSamplesRequired must be positive" }
+    }
+
+    fun observe(text: String): Boolean {
+        if (text == previousText) {
+            stableSamples += 1
+        } else {
+            previousText = text
+            stableSamples = 1
+        }
+
+        return stableSamples >= stableSamplesRequired &&
+            (expectedText == null || text == expectedText)
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -176,6 +176,7 @@ import com.kazumaproject.listeners.ReturnToTenKeyButtonClickListener
 import com.kazumaproject.listeners.SymbolRecyclerViewItemClickListener
 import com.kazumaproject.listeners.SymbolRecyclerViewItemLongClickListener
 import com.kazumaproject.markdownhelperkeyboard.BuildConfig
+import com.kazumaproject.markdownhelperkeyboard.FastInputTestProtocol
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ClipboardHistoryItem
 import com.kazumaproject.markdownhelperkeyboard.clipboard_history.database.ItemType
@@ -5016,6 +5017,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
         refreshBaselineInputBehaviorForCurrentKeyboard("start input keyboard layout settled")
         consumePendingGemmaPickedImage()
+        if (BuildConfig.DEBUG) {
+            FastInputTestProtocol.tokenFrom(editorInfo?.privateImeOptions)?.let { token ->
+                sendBroadcast(FastInputTestProtocol.readyIntent(packageName, token))
+            }
+        }
     }
 
     override fun onWindowShown() {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -151,6 +151,7 @@ import com.kazumaproject.core.domain.state.TenKeyQWERTYMode
 import com.kazumaproject.core.domain.state.TwoStateNumberReturnTarget
 import com.kazumaproject.core.domain.state.toInputMode
 import com.kazumaproject.core.domain.state.toTwoStateNumberReturnTargetOrNull
+import com.kazumaproject.core.domain.touch.PointerGestureTrace
 import com.kazumaproject.core.domain.window.getScreenHeight
 import com.kazumaproject.custom_keyboard.data.FlickDirection
 import com.kazumaproject.custom_keyboard.data.KeyAction
@@ -1520,6 +1521,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private val _dakutenPressed = MutableStateFlow(false)
     private val candidateRefreshCoordinator = CandidateRefreshCoordinator()
     private val candidateRefreshRequests = candidateRefreshCoordinator.requests
+    private val fastInputResetCoordinator = ImeTransientStateResetCoordinator()
     private var defaultInputFinalizeJob: Job? = null
     private val _suggestionViewStatus = MutableStateFlow(true)
     private val suggestionViewStatus = _suggestionViewStatus.asStateFlow()
@@ -2627,6 +2629,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         val token = data?.getString(FastInputTestProtocol.EXTRA_RESET_TOKEN).orEmpty()
         if (receiver == null || token.isBlank()) return
 
+        PointerGestureTrace.end()
+        data?.getString(FastInputTestProtocol.EXTRA_TRACE_ID)?.let(PointerGestureTrace::begin)
         runCatching { resetFastInputTestState() }
             .onSuccess {
                 receiver.send(
@@ -2635,8 +2639,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                         putString(FastInputTestProtocol.EXTRA_RESET_TOKEN, token)
                     },
                 )
+                PointerGestureTrace.log("reset", "ack")
             }
             .onFailure { error ->
+                PointerGestureTrace.log(
+                    "reset",
+                    "error=" + (error.message ?: error::class.java.simpleName),
+                )
                 Timber.e(error, "Fast-input test reset failed")
                 receiver.send(
                     FastInputTestProtocol.RESET_ERROR,
@@ -2659,6 +2668,23 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
      * this path is only the between-trial barrier.
      */
     private fun resetFastInputTestState() {
+        val inputConnection = currentInputConnection
+            ?: error("InputConnection is unavailable during fast-input test reset")
+        val generation = fastInputResetCoordinator.reset(
+            ImeTransientStateResetCoordinator.Actions(
+                cancelAsyncWork = ::cancelFastInputAsyncWork,
+                resetGestureState = ::resetFastInputGestureState,
+                clearTransientState = ::clearFastInputTransientState,
+                clearViewsAndEffects = ::clearFastInputViewsAndEffects,
+                clearInputConnection = {
+                    clearFastInputInputConnection(inputConnection)
+                },
+            )
+        )
+        PointerGestureTrace.log("reset", "generation=" + generation + " complete")
+    }
+
+    private fun cancelFastInputAsyncWork() {
         flickInputPreviewCoordinator.cancel(restore = false)
         flickInputPreviewCoordinator.resetForEditorSession()
         qwertyGlideInputCoordinator?.cancelPending()
@@ -2668,23 +2694,36 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         defaultInputFinalizeJob = null
         cancelActiveCandidateTranslation()
         cancelActiveSelectionAction()
-
-        clearZeroQueryAllState(refresh = false)
         customKeyboardRenderJob?.cancel()
         customKeyboardRenderJob = null
         numberKeyboardRenderJob?.cancel()
         numberKeyboardRenderJob = null
+        conversionLearningSession.cancel()
+        stopDeleteLongPress()
+        stopAllOngoingKeyLongPresses()
+    }
+
+    private fun resetFastInputGestureState() {
+        mainLayoutBinding?.apply {
+            keyboardView.resetTouchStateForFastInputTest()
+            gojuonView.resetTouchStateForFastInputTest()
+            qwertyView.resetTouchStateForFastInputTest()
+            customLayoutDefault.resetTouchStateForFastInputTest()
+            (root as? InkTouchDispatchFrameLayout)?.resetTouchStateForFastInputTest()
+        }
+        floatingKeyboardBinding?.apply {
+            keyboardViewFloating.resetTouchStateForFastInputTest()
+            gojuonViewFloating.resetTouchStateForFastInputTest()
+            qwertyViewFloating.resetTouchStateForFastInputTest()
+            customLayoutFloating.resetTouchStateForFastInputTest()
+            (root as? InkTouchDispatchFrameLayout)?.resetTouchStateForFastInputTest()
+        }
+    }
+
+    private fun clearFastInputTransientState() {
+        clearZeroQueryAllState(refresh = false)
         clearFunctionKeyConversionSource()
         _inputString.update { "" }
-        clearZenzLiveSlot("fast-input-test-reset")
-        setSuggestionAdapterSuggestionsOnMain(emptyList())
-        setSuggestionAdaptersOnMain(emptyList())
-        updateSuggestionsForFloatingCandidate(emptyList())
-        suggestionAdapter?.updateHighlightPosition(RecyclerView.NO_POSITION)
-        suggestionAdapterFull?.updateHighlightPosition(RecyclerView.NO_POSITION)
-        listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
-        suggestionClickNum = 0
-        filteredCandidateList = emptyList()
         stringInTail.set("")
         isHenkan.set(false)
         henkanPressedWithBunsetsuDetect = false
@@ -2701,9 +2740,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         isFirstClickHasStringTail = false
         lastCandidate = ""
         currentHighlightIndex = RecyclerView.NO_POSITION
-        _keyboardSymbolViewState.update { SymbolKeyboardState() }
-        conversionLearningSession.cancel()
-        stopDeleteLongPress()
         clearDeletedBuffer()
         _selectMode.update { false }
         hasConvertedKatakana = false
@@ -2722,27 +2758,24 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         bunsetsuPositionList = emptyList()
         bunsetsuSplitPatterns = emptyList()
         clearBunsetsuConversionSession()
-        stopAllOngoingKeyLongPresses()
+    }
+
+    private fun clearFastInputViewsAndEffects() {
+        clearZenzLiveSlot("fast-input-test-reset")
+        setSuggestionAdapterSuggestionsOnMain(emptyList())
+        setSuggestionAdaptersOnMain(emptyList())
+        updateSuggestionsForFloatingCandidate(emptyList())
+        suggestionAdapter?.updateHighlightPosition(RecyclerView.NO_POSITION)
+        suggestionAdapterFull?.updateHighlightPosition(RecyclerView.NO_POSITION)
+        listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
+        suggestionClickNum = 0
+        filteredCandidateList = emptyList()
+        _keyboardSymbolViewState.update { SymbolKeyboardState() }
         refreshEditHistoryUi()
-
-        mainLayoutBinding?.apply {
-            keyboardView.resetTouchStateForFastInputTest()
-            gojuonView.resetTouchStateForFastInputTest()
-            qwertyView.resetTouchStateForFastInputTest()
-            customLayoutDefault.resetTouchStateForFastInputTest()
-            (root as? InkTouchDispatchFrameLayout)?.resetTouchStateForFastInputTest()
-        }
-        floatingKeyboardBinding?.apply {
-            keyboardViewFloating.resetTouchStateForFastInputTest()
-            gojuonViewFloating.resetTouchStateForFastInputTest()
-            qwertyViewFloating.resetTouchStateForFastInputTest()
-            customLayoutFloating.resetTouchStateForFastInputTest()
-            (root as? InkTouchDispatchFrameLayout)?.resetTouchStateForFastInputTest()
-        }
         clearAndPauseKeyboardTouchEffects()
+    }
 
-        val inputConnection = currentInputConnection
-            ?: error("InputConnection is unavailable during fast-input test reset")
+    private fun clearFastInputInputConnection(inputConnection: InputConnection) {
         inputConnection.beginBatchEdit()
         try {
             inputConnection.finishComposingText()
@@ -5176,6 +5209,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun onFinishInput() {
+        PointerGestureTrace.end()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             inlineAutofillController?.clear()
         }
@@ -5230,6 +5264,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun onDestroy() {
+        PointerGestureTrace.end()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             inlineAutofillController?.destroy()
             inlineAutofillController = null
@@ -17570,11 +17605,15 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private fun scheduleDefaultInputFinalize(string: String) {
         val timeToDelay = delayTime?.toLong() ?: DEFAULT_DELAY_MS
+        val resetGeneration = fastInputResetCoordinator.currentGeneration()
         defaultInputFinalizeJob = scope.launch {
             measureDebugStage("IMEService.input.finalizeDelay") {
                 delay(timeToDelay)
             }
 
+            if (!fastInputResetCoordinator.isCurrent(resetGeneration)) {
+                return@launch
+            }
             if (inputString.value != string || isLiveConversionEnable == true) {
                 return@launch
             }
@@ -26866,6 +26905,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         cancelCandidateTranslationIfPreEditMutates()
         val committed = currentInputConnection.commitText(p0, p1)
         if (committed) composingTextArbiter.markCanonicalFinished()
+        PointerGestureTrace.log(
+            "input-connection",
+            "commitText text=" +
+                p0?.toString()?.replace("\n", "\\n") +
+                " cursorPosition=" + p1 +
+                " accepted=" + committed,
+        )
         return committed
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -2609,6 +2609,152 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         refreshCandidateStripContent()
     }
 
+    override fun onAppPrivateCommand(action: String?, data: Bundle?) {
+        super.onAppPrivateCommand(action, data)
+        if (!BuildConfig.DEBUG || action != FastInputTestProtocol.ACTION_RESET_FOR_TEST) {
+            return
+        }
+
+        @Suppress("DEPRECATION")
+        val receiver = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            data?.getParcelable(
+                FastInputTestProtocol.EXTRA_RESET_RESULT_RECEIVER,
+                ResultReceiver::class.java,
+            )
+        } else {
+            data?.getParcelable(FastInputTestProtocol.EXTRA_RESET_RESULT_RECEIVER)
+        }
+        val token = data?.getString(FastInputTestProtocol.EXTRA_RESET_TOKEN).orEmpty()
+        if (receiver == null || token.isBlank()) return
+
+        runCatching { resetFastInputTestState() }
+            .onSuccess {
+                receiver.send(
+                    FastInputTestProtocol.RESET_ACK,
+                    Bundle().apply {
+                        putString(FastInputTestProtocol.EXTRA_RESET_TOKEN, token)
+                    },
+                )
+            }
+            .onFailure { error ->
+                Timber.e(error, "Fast-input test reset failed")
+                receiver.send(
+                    FastInputTestProtocol.RESET_ERROR,
+                    Bundle().apply {
+                        putString(FastInputTestProtocol.EXTRA_RESET_TOKEN, token)
+                        putString(
+                            FastInputTestProtocol.EXTRA_RESET_ERROR,
+                            error.message ?: error::class.java.simpleName,
+                        )
+                    },
+                )
+            }
+    }
+
+    /**
+     * Clears only transient input state for the debug fast-input matrix.
+     *
+     * The selected keyboard surface and its candidate-column preference are deliberately not
+     * changed here. Surface, column, and orientation changes still use onStartInput/restartInput;
+     * this path is only the between-trial barrier.
+     */
+    private fun resetFastInputTestState() {
+        flickInputPreviewCoordinator.cancel(restore = false)
+        flickInputPreviewCoordinator.resetForEditorSession()
+        qwertyGlideInputCoordinator?.cancelPending()
+        candidateRequestTracker.invalidate()
+        candidateRefreshCoordinator.invalidate()
+        defaultInputFinalizeJob?.cancel()
+        defaultInputFinalizeJob = null
+        cancelActiveCandidateTranslation()
+        cancelActiveSelectionAction()
+
+        clearZeroQueryAllState(refresh = false)
+        customKeyboardRenderJob?.cancel()
+        customKeyboardRenderJob = null
+        numberKeyboardRenderJob?.cancel()
+        numberKeyboardRenderJob = null
+        clearFunctionKeyConversionSource()
+        _inputString.update { "" }
+        clearZenzLiveSlot("fast-input-test-reset")
+        setSuggestionAdapterSuggestionsOnMain(emptyList())
+        setSuggestionAdaptersOnMain(emptyList())
+        updateSuggestionsForFloatingCandidate(emptyList())
+        suggestionAdapter?.updateHighlightPosition(RecyclerView.NO_POSITION)
+        suggestionAdapterFull?.updateHighlightPosition(RecyclerView.NO_POSITION)
+        listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
+        suggestionClickNum = 0
+        filteredCandidateList = emptyList()
+        stringInTail.set("")
+        isHenkan.set(false)
+        henkanPressedWithBunsetsuDetect = false
+        bunsetusMultipleDetect = false
+        isContinuousTapInputEnabled.set(false)
+        leftCursorKeyLongKeyPressed.set(false)
+        rightCursorKeyLongKeyPressed.set(false)
+        _dakutenPressed.value = false
+        englishSpaceKeyPressed.set(false)
+        lastFlickConvertedNextHiragana.set(false)
+        onDeleteLongPressUp.set(false)
+        isSpaceKeyLongPressed = false
+        onKeyboardSwitchLongPressUp = false
+        isFirstClickHasStringTail = false
+        lastCandidate = ""
+        currentHighlightIndex = RecyclerView.NO_POSITION
+        _keyboardSymbolViewState.update { SymbolKeyboardState() }
+        conversionLearningSession.cancel()
+        stopDeleteLongPress()
+        clearDeletedBuffer()
+        _selectMode.update { false }
+        hasConvertedKatakana = false
+        romajiConverter?.clear()
+        hardKeyboardShiftPressd = false
+        resetSumireKeyboardDakutenMode()
+        initialCursorDetectInFloatingCandidateView = false
+        initialCursorXPosition = 0
+        countToggleKatakana = 0
+        currentEnterKeyIndex = 0
+        currentSpaceKeyIndex = 0
+        currentKatakanaKeyIndex = 0
+        currentDakutenKeyIndex = 0
+        clearPendingReconversionEntry()
+        clearBunsetsuReconversionDraft()
+        bunsetsuPositionList = emptyList()
+        bunsetsuSplitPatterns = emptyList()
+        clearBunsetsuConversionSession()
+        stopAllOngoingKeyLongPresses()
+        refreshEditHistoryUi()
+
+        mainLayoutBinding?.apply {
+            keyboardView.resetTouchStateForFastInputTest()
+            gojuonView.resetTouchStateForFastInputTest()
+            qwertyView.resetTouchStateForFastInputTest()
+            customLayoutDefault.resetTouchStateForFastInputTest()
+            (root as? InkTouchDispatchFrameLayout)?.resetTouchStateForFastInputTest()
+        }
+        floatingKeyboardBinding?.apply {
+            keyboardViewFloating.resetTouchStateForFastInputTest()
+            gojuonViewFloating.resetTouchStateForFastInputTest()
+            qwertyViewFloating.resetTouchStateForFastInputTest()
+            customLayoutFloating.resetTouchStateForFastInputTest()
+            (root as? InkTouchDispatchFrameLayout)?.resetTouchStateForFastInputTest()
+        }
+        clearAndPauseKeyboardTouchEffects()
+
+        val inputConnection = currentInputConnection
+            ?: error("InputConnection is unavailable during fast-input test reset")
+        inputConnection.beginBatchEdit()
+        try {
+            inputConnection.finishComposingText()
+            check(inputConnection.setComposingText("", 1)) {
+                "InputConnection rejected empty composing text"
+            }
+            inputConnection.finishComposingText()
+        } finally {
+            inputConnection.endBatchEdit()
+        }
+    }
+
     private fun startKanaKanjiConversionSession(backend: ConversionBackend) {
         conversionBackend = backend
         kanaKanjiConversionSession = KanaKanjiConversionSession(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImeTransientStateResetCoordinator.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImeTransientStateResetCoordinator.kt
@@ -1,0 +1,37 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Orders the destructive parts of a fast-input reset and invalidates work from the previous
+ * trial before any new transient state is exposed.
+ *
+ * The coordinator owns only reset generations. The service supplies the state-specific actions,
+ * which keeps this class independent from the large IME state graph.
+ */
+internal class ImeTransientStateResetCoordinator {
+    data class Actions(
+        val cancelAsyncWork: () -> Unit,
+        val resetGestureState: () -> Unit,
+        val clearTransientState: () -> Unit,
+        val clearViewsAndEffects: () -> Unit,
+        val clearInputConnection: () -> Unit,
+    )
+
+    private val generation = AtomicLong(0L)
+
+    fun reset(actions: Actions): Long {
+        val currentGeneration = generation.incrementAndGet()
+        actions.cancelAsyncWork()
+        actions.resetGestureState()
+        actions.clearTransientState()
+        actions.clearViewsAndEffects()
+        actions.clearInputConnection()
+        return currentGeneration
+    }
+
+    fun isCurrent(candidateGeneration: Long): Boolean =
+        generation.get() == candidateGeneration
+
+    fun currentGeneration(): Long = generation.get()
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/image_effect/InkTouchDispatchFrameLayout.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/image_effect/InkTouchDispatchFrameLayout.kt
@@ -51,6 +51,15 @@ class InkTouchDispatchFrameLayout @JvmOverloads constructor(
 
     var suppressTouchEffectMotionEvents: Boolean = false
 
+    fun resetTouchStateForFastInputTest() {
+        clearFallbackTarget()
+        lastStableTarget = null
+        lastStableTargetScreenX = 0
+        lastStableTargetScreenY = 0
+        lastStableTargetWidth = 0
+        lastStableTargetHeight = 0
+    }
+
     override fun dispatchTouchEvent(ev: MotionEvent): Boolean {
         if (!suppressTouchEffectMotionEvents) {
             runCatching {

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocolTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/FastInputTestProtocolTest.kt
@@ -1,0 +1,26 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FastInputTestProtocolTest {
+    @Test
+    fun readinessTokenRoundTripsThroughPrivateImeOptions() {
+        val token = "12345-9"
+
+        assertEquals(
+            token,
+            FastInputTestProtocol.tokenFrom(FastInputTestProtocol.privateImeOptions(token)),
+        )
+    }
+
+    @Test
+    fun unrelatedOrEmptyPrivateImeOptionsAreIgnored() {
+        assertNull(FastInputTestProtocol.tokenFrom(null))
+        assertNull(FastInputTestProtocol.tokenFrom("com.example.option"))
+        assertNull(
+            FastInputTestProtocol.tokenFrom(FastInputTestProtocol.PRIVATE_IME_OPTION_PREFIX),
+        )
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/FastInputTextSettlePolicyTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/FastInputTextSettlePolicyTest.kt
@@ -1,0 +1,40 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class FastInputTextSettlePolicyTest {
+    @Test
+    fun stablePartialTextDoesNotCompleteExpectedTrace() {
+        val policy = FastInputTextSettlePolicy(expectedText = "あい", stableSamplesRequired = 2)
+
+        assertFalse(policy.observe("あ"))
+        assertFalse(policy.observe("あ"))
+        assertFalse(policy.observe("あ"))
+        assertFalse(policy.observe("あ"))
+    }
+
+    @Test
+    fun expectedTextCompletesOnlyAfterRequiredStableSamples() {
+        val policy = FastInputTextSettlePolicy(expectedText = "あい", stableSamplesRequired = 3)
+
+        assertFalse(policy.observe("あ"))
+        assertFalse(policy.observe("あい"))
+        assertFalse(policy.observe("あい"))
+        assertTrue(policy.observe("あい"))
+    }
+
+    @Test
+    fun lateExtraTextInvalidatesTheCurrentStableWindow() {
+        val policy = FastInputTextSettlePolicy(expectedText = "あい", stableSamplesRequired = 3)
+
+        assertFalse(policy.observe("あい"))
+        assertFalse(policy.observe("あい"))
+        assertFalse(policy.observe("あいう"))
+        assertFalse(policy.observe("あいう"))
+        assertFalse(policy.observe("あい"))
+        assertFalse(policy.observe("あい"))
+        assertTrue(policy.observe("あい"))
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ImeTransientStateResetCoordinatorTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ImeTransientStateResetCoordinatorTest.kt
@@ -1,0 +1,57 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import com.kazumaproject.markdownhelperkeyboard.ime_service.ImeTransientStateResetCoordinator
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ImeTransientStateResetCoordinatorTest {
+    @Test
+    fun resetRunsInTheContractedOrderAndReturnsCurrentGeneration() {
+        val coordinator = ImeTransientStateResetCoordinator()
+        val calls = mutableListOf<String>()
+
+        val generation = coordinator.reset(
+            ImeTransientStateResetCoordinator.Actions(
+                cancelAsyncWork = { calls += "cancel-async" },
+                resetGestureState = { calls += "reset-gesture" },
+                clearTransientState = { calls += "clear-transient" },
+                clearViewsAndEffects = { calls += "clear-views" },
+                clearInputConnection = { calls += "clear-input-connection" },
+            ),
+        )
+
+        assertEquals(1L, generation)
+        assertEquals(
+            listOf(
+                "cancel-async",
+                "reset-gesture",
+                "clear-transient",
+                "clear-views",
+                "clear-input-connection",
+            ),
+            calls,
+        )
+        assertTrue(coordinator.isCurrent(generation))
+    }
+
+    @Test
+    fun aNewResetInvalidatesThePreviousGeneration() {
+        val coordinator = ImeTransientStateResetCoordinator()
+        val firstGeneration = coordinator.reset(noOpActions())
+        val secondGeneration = coordinator.reset(noOpActions())
+
+        assertEquals(2L, secondGeneration)
+        assertFalse(coordinator.isCurrent(firstGeneration))
+        assertTrue(coordinator.isCurrent(secondGeneration))
+    }
+
+    private fun noOpActions() = ImeTransientStateResetCoordinator.Actions(
+        cancelAsyncWork = {},
+        resetGestureState = {},
+        clearTransientState = {},
+        clearViewsAndEffects = {},
+        clearInputConnection = {},
+    )
+}

--- a/core/src/main/java/com/kazumaproject/core/domain/state/PressedKey.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/state/PressedKey.kt
@@ -4,7 +4,8 @@ import com.kazumaproject.core.domain.key.Key
 
 data class PressedKey(
     var key: Key,
-    var pointer: Int,
+    /** Stable MotionEvent pointer id. This is not a pointer index. */
+    var pointerId: Int,
     var initialX: Float,
     var initialY: Float,
 )

--- a/core/src/main/java/com/kazumaproject/core/domain/touch/PointerEventResolver.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/touch/PointerEventResolver.kt
@@ -1,0 +1,83 @@
+package com.kazumaproject.core.domain.touch
+
+import android.os.Build
+import android.view.MotionEvent
+
+/**
+ * Stable information about one pointer in a MotionEvent.
+ *
+ * [pointerId] is stable for the lifetime of a touch stream. [pointerIndex] is only the index
+ * used to read this particular MotionEvent and must never be persisted as pointer identity.
+ */
+data class PointerSample(
+    val pointerId: Int,
+    val pointerIndex: Int,
+    val screenX: Float,
+    val screenY: Float,
+)
+
+/**
+ * Centralizes the Android pointer-id/index and display-coordinate rules used by keyboard views.
+ */
+object PointerEventResolver {
+    fun at(event: MotionEvent, pointerIndex: Int): PointerSample? {
+        if (pointerIndex !in 0 until event.pointerCount) return null
+        return PointerSample(
+            pointerId = event.getPointerId(pointerIndex),
+            pointerIndex = pointerIndex,
+            screenX = screenX(event, pointerIndex),
+            screenY = screenY(event, pointerIndex),
+        )
+    }
+
+    fun forId(event: MotionEvent, pointerId: Int): PointerSample? {
+        val pointerIndex = event.findPointerIndex(pointerId)
+        return at(event, pointerIndex)
+    }
+
+    fun actionPointer(event: MotionEvent): PointerSample? =
+        at(event, event.actionIndex)
+
+    /** Compact DEBUG/test representation that keeps IDs, indices, and screen coordinates together. */
+    fun describe(event: MotionEvent): String =
+        (0 until event.pointerCount).joinToString("|") { pointerIndex ->
+            val pointer = at(event, pointerIndex)
+            if (pointer == null) {
+                "index=$pointerIndex:unavailable"
+            } else {
+                "${pointer.pointerId}@${pointer.screenX},${pointer.screenY}"
+            }
+        }
+
+    fun screenX(event: MotionEvent, pointerIndex: Int): Float {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            event.getRawX(pointerIndex)
+        } else {
+            event.getX(pointerIndex) + event.rawX - event.x
+        }
+    }
+
+    fun screenY(event: MotionEvent, pointerIndex: Int): Float {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            event.getRawY(pointerIndex)
+        } else {
+            event.getY(pointerIndex) + event.rawY - event.y
+        }
+    }
+
+    fun historicalScreenX(
+        event: MotionEvent,
+        pointerIndex: Int,
+        historyIndex: Int,
+    ): Float {
+        return event.getHistoricalX(pointerIndex, historyIndex) + event.rawX - event.x
+    }
+
+    fun historicalScreenY(
+        event: MotionEvent,
+        pointerIndex: Int,
+        historyIndex: Int,
+    ): Float {
+        return event.getHistoricalY(pointerIndex, historyIndex) + event.rawY - event.y
+    }
+}

--- a/core/src/main/java/com/kazumaproject/core/domain/touch/PointerGestureRouter.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/touch/PointerGestureRouter.kt
@@ -1,0 +1,181 @@
+package com.kazumaproject.core.domain.touch
+
+import android.view.MotionEvent
+
+/**
+ * Semantic touch events used by keyboard surfaces.
+ *
+ * A semantic event always carries the stable pointer ID and display coordinates. The raw
+ * MotionEvent index is deliberately not part of the event, because an index can change after a
+ * different pointer is lifted.
+ */
+sealed interface PointerGestureEvent {
+    val pointerId: Int
+    val eventTime: Long
+    val screenX: Float
+    val screenY: Float
+
+    data class Down(
+        override val pointerId: Int,
+        override val eventTime: Long,
+        override val screenX: Float,
+        override val screenY: Float,
+    ) : PointerGestureEvent
+
+    data class Move(
+        override val pointerId: Int,
+        override val eventTime: Long,
+        override val screenX: Float,
+        override val screenY: Float,
+    ) : PointerGestureEvent
+
+    data class Up(
+        override val pointerId: Int,
+        override val eventTime: Long,
+        override val screenX: Float,
+        override val screenY: Float,
+    ) : PointerGestureEvent
+
+    data class Cancel(
+        override val pointerId: Int,
+        override val eventTime: Long,
+        override val screenX: Float,
+        override val screenY: Float,
+    ) : PointerGestureEvent
+}
+
+/**
+ * Converts a raw MotionEvent stream into pointer-ID based semantic events.
+ *
+ * The router owns only stream identity. A keyboard surface still decides whether a second
+ * pointer commits an older gesture, suppresses a special key, or is allowed to remain active.
+ * That policy belongs above this class and is therefore testable without duplicating Android's
+ * pointer-index rules in every view.
+ */
+class PointerGestureRouter {
+    private val activePointers = LinkedHashMap<Int, PointerSample>()
+    private var streamActive = false
+
+    fun route(
+        event: MotionEvent,
+        emit: (PointerGestureEvent) -> Unit,
+    ) {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_DOWN -> {
+                activePointers.clear()
+                streamActive = true
+                PointerEventResolver.actionPointer(event)?.let { sample ->
+                    activePointers[sample.pointerId] = sample
+                    emit(sample.toDown(event.eventTime))
+                }
+            }
+
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                // The POINTER_DOWN frame contains the latest coordinate for every existing
+                // pointer. Publish those samples before registering the new pointer so a view can
+                // finalize an older gesture without reading a stale frame.
+                activePointers.keys.toList().forEach { pointerId ->
+                    val sample = PointerEventResolver.forId(event, pointerId)
+                    if (sample == null) {
+                        val last = activePointers.remove(pointerId)
+                        last?.let { emit(it.toCancel(event.eventTime)) }
+                    } else {
+                        activePointers[pointerId] = sample
+                        emit(sample.toMove(event.eventTime))
+                    }
+                }
+
+                PointerEventResolver.actionPointer(event)?.let { sample ->
+                    // A duplicate pointer ID is malformed input. Close the old ownership before
+                    // accepting the new down so one ID can never own two gestures.
+                    activePointers.remove(sample.pointerId)?.let {
+                        emit(it.toCancel(event.eventTime))
+                    }
+                    activePointers[sample.pointerId] = sample
+                    emit(sample.toDown(event.eventTime))
+                }
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                activePointers.keys.toList().forEach { pointerId ->
+                    val sample = PointerEventResolver.forId(event, pointerId)
+                    if (sample == null) {
+                        val last = activePointers.remove(pointerId)
+                        last?.let { emit(it.toCancel(event.eventTime)) }
+                    } else {
+                        activePointers[pointerId] = sample
+                        emit(sample.toMove(event.eventTime))
+                    }
+                }
+            }
+
+            MotionEvent.ACTION_POINTER_UP -> {
+                PointerEventResolver.actionPointer(event)?.let { sample ->
+                    if (activePointers.remove(sample.pointerId) != null) {
+                        emit(sample.toUp(event.eventTime))
+                    }
+                }
+            }
+
+            MotionEvent.ACTION_UP -> {
+                if (!streamActive) return
+                // ACTION_UP is the stream terminator. Emit exactly one terminal event for every
+                // pointer that is still owned, even if a malformed producer omitted an earlier
+                // POINTER_UP.
+                val remaining = activePointers.keys.toList()
+                if (remaining.isEmpty()) {
+                    streamActive = false
+                } else {
+                    remaining.forEach { pointerId ->
+                        val sample = PointerEventResolver.forId(event, pointerId)
+                            ?: activePointers[pointerId]
+                        activePointers.remove(pointerId)
+                        sample?.let { emit(it.toUp(event.eventTime)) }
+                    }
+                }
+                streamActive = false
+            }
+
+            MotionEvent.ACTION_CANCEL -> {
+                activePointers.values.toList().forEach { sample ->
+                    emit(sample.toCancel(event.eventTime))
+                }
+                activePointers.clear()
+                streamActive = false
+            }
+        }
+    }
+
+    fun reset() {
+        activePointers.clear()
+        streamActive = false
+    }
+
+    private fun PointerSample.toDown(eventTime: Long) = PointerGestureEvent.Down(
+        pointerId = pointerId,
+        eventTime = eventTime,
+        screenX = screenX,
+        screenY = screenY,
+    )
+
+    private fun PointerSample.toMove(eventTime: Long) = PointerGestureEvent.Move(
+        pointerId = pointerId,
+        eventTime = eventTime,
+        screenX = screenX,
+        screenY = screenY,
+    )
+
+    private fun PointerSample.toUp(eventTime: Long) = PointerGestureEvent.Up(
+        pointerId = pointerId,
+        eventTime = eventTime,
+        screenX = screenX,
+        screenY = screenY,
+    )
+
+    private fun PointerSample.toCancel(eventTime: Long) = PointerGestureEvent.Cancel(
+        pointerId = pointerId,
+        eventTime = eventTime,
+        screenX = screenX,
+        screenY = screenY,
+    )
+}

--- a/core/src/main/java/com/kazumaproject/core/domain/touch/PointerGestureTrace.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/touch/PointerGestureTrace.kt
@@ -1,0 +1,33 @@
+package com.kazumaproject.core.domain.touch
+
+import android.util.Log
+
+/**
+ * Test-only cross-view trace context for a single rapid-input trial.
+ *
+ * The context is inactive by default. The debug IME reset protocol assigns a trace ID before a
+ * trial, so production input does not pay for logging or expose touch details.
+ */
+object PointerGestureTrace {
+    private const val TAG = "FastInputTrace"
+
+    @Volatile
+    private var activeTraceId: String? = null
+
+    fun isActive(): Boolean = activeTraceId != null
+
+    fun begin(traceId: String) {
+        activeTraceId = traceId.takeIf(String::isNotBlank)
+        log("lifecycle", "begin")
+    }
+
+    fun end() {
+        log("lifecycle", "end")
+        activeTraceId = null
+    }
+
+    fun log(stage: String, message: String) {
+        val traceId = activeTraceId ?: return
+        Log.d(TAG, "traceId=$traceId stage=$stage $message")
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CenterGuideFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CenterGuideFlickInputController.kt
@@ -27,7 +27,7 @@ import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 class CenterGuideFlickInputController(
     private val context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -110,15 +110,22 @@ class CenterGuideFlickInputController(
         }
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         listener?.onCanceled()
         activeGestureConfig = null
         isTouchActive = false
         popupHost.dismiss()
+        attachedView?.isPressed = false
+    }
+
+    override fun dispose() {
+        resetGestureState()
         attachedView?.setOnTouchListener(null)
         attachedView = null
         textMap = emptyMap()
     }
+
+    fun cancel() = dispose()
 
     private fun handleTouchEvent(view: View, event: MotionEvent): Boolean {
         when (event.actionMasked) {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CrossFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CrossFlickInputController.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.launch
 class CrossFlickInputController(
     private val context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -100,6 +100,7 @@ class CrossFlickInputController(
 
     private var inputMode: InputMode = InputMode.ACTION
     private var anchorView: View? = null
+    private var attachedView: View? = null
     private var initialTouchPoint = PointF(0f, 0f)
     private var currentDirection = FlickDirection.TAP
     private var activeGestureConfig: GestureSessionConfig? = null
@@ -177,19 +178,38 @@ class CrossFlickInputController(
         invalidateDirectionalPopupCache()
     }
 
-    // コントローラを破棄する。ビューのデタッチやキーボードビューの再構築時に FlickKeyboardView から呼ばれる。
-    fun cancel() {
+    override fun resetGestureState() {
         listener?.onCanceled()
         activeGestureConfig = null
         longPressJob?.cancel()
-        controllerScope.cancel()
+        longPressJob = null
+        isLongPressMode = false
+        isLongPressTriggered = false
         restoreOriginalButtonText()
+        dismissAllPopups(clearDirectionalCache = false)
+        attachedView?.isPressed = false
+        anchorView = null
+    }
+
+    override fun dispose() {
+        resetGestureState()
+        attachedView?.setOnTouchListener(null)
+        attachedView = null
+        flickActionMap = emptyMap()
+        textMap = emptyMap()
+        longPressTextMap = emptyMap()
+        controllerScope.cancel()
         dismissAllPopups(clearDirectionalCache = true)
     }
+
+    // コントローラを破棄する。ビューのデタッチやキーボードビューの再構築時に呼ばれる。
+    fun cancel() = dispose()
 
     // ACTION モードでビューにアタッチする。CROSS_FLICK キー（アイコン付き特殊キー）向け。
     @SuppressLint("ClickableViewAccessibility")
     fun attach(view: View, map: Map<FlickDirection, FlickAction>) {
+        attachedView?.takeUnless { it === view }?.setOnTouchListener(null)
+        attachedView = view
         inputMode = InputMode.ACTION
         flickActionMap = map.mapValues { (_, action) -> action.withDisplayMetadata() }
         textMap = emptyMap()
@@ -206,6 +226,8 @@ class CrossFlickInputController(
         map: Map<FlickDirection, String>,
         longPressMap: Map<FlickDirection, String> = emptyMap()
     ) {
+        attachedView?.takeUnless { it === view }?.setOnTouchListener(null)
+        attachedView = view
         inputMode = InputMode.TEXT
         textMap = map
         longPressTextMap = longPressMap

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CustomAngleFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/CustomAngleFlickController.kt
@@ -30,7 +30,7 @@ import kotlin.math.atan2
 class CustomAngleFlickController(
     context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -73,6 +73,7 @@ class CustomAngleFlickController(
     }
 
     private var anchorView: View? = null
+    private var attachedView: View? = null
     private var initialTouchX = 0f
     private var initialTouchY = 0f
 
@@ -149,12 +150,29 @@ class CustomAngleFlickController(
         enabledSlots = effectiveRanges.keys.toSet()
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         listener?.onCanceled()
+        longPressJob?.cancel()
+        longPressJob = null
         activeGestureConfig = null
+        attachedView?.isPressed = false
+        anchorView = null
+        isLongPressModeActive = false
+        previousDirection = CircularFlickDirection.TAP
         hidePopup()
+    }
+
+    override fun dispose() {
+        resetGestureState()
+        attachedView?.setOnTouchListener(null)
+        attachedView = null
+        keyMaps = emptyList()
+        mapSwitchLabels = emptyList()
         controllerScope.cancel()
     }
+
+    /** Backward-compatible teardown entry point for existing callers. */
+    fun cancel() = dispose()
 
     @SuppressLint("ClickableViewAccessibility")
     fun attach(
@@ -163,6 +181,8 @@ class CustomAngleFlickController(
         switchLabels: List<String?>
     ) {
         if (maps.isEmpty()) return
+        attachedView?.takeUnless { it === button }?.setOnTouchListener(null)
+        attachedView = button
         this.keyMaps = maps
         this.mapSwitchLabels = switchLabels
         currentMapIndex = 0

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/FlickLongPressInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/FlickLongPressInputController.kt
@@ -22,7 +22,7 @@ import kotlin.math.atan2
 class FlickLongPressInputController(
     private val context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -112,20 +112,28 @@ class FlickLongPressInputController(
         normalMap: Map<TfbiFlickDirection, String>,
         longPressMap: Map<TfbiFlickDirection, String>
     ) {
+        attachedView?.takeUnless { it === view }?.setOnTouchListener(null)
         attachedView = view
         this.normalMap = normalMap
         this.longPressMap = longPressMap
         view.setOnTouchListener { _, event -> handleTouchEvent(event) }
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         clearLongPressCallback()
         resetState()
+        attachedView?.isPressed = false
+    }
+
+    override fun dispose() {
+        resetGestureState()
         attachedView?.setOnTouchListener(null)
         attachedView = null
         normalMap = emptyMap()
         longPressMap = emptyMap()
     }
+
+    fun cancel() = dispose()
 
     private fun handleTouchEvent(event: MotionEvent): Boolean {
         val view = attachedView ?: return false

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/GestureStateResettable.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/GestureStateResettable.kt
@@ -1,0 +1,12 @@
+package com.kazumaproject.custom_keyboard.controller
+
+/**
+ * Lifecycle used by input controllers that are reused while the keyboard layout stays alive.
+ *
+ * Resetting a touch stream must not detach the controller or cancel resources that are needed by
+ * the next stream. [dispose] is reserved for the actual view/layout teardown path.
+ */
+interface GestureStateResettable {
+    fun resetGestureState()
+    fun dispose()
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/StandardFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/StandardFlickInputController.kt
@@ -71,6 +71,9 @@ class StandardFlickInputController(
             false
         ).apply {
             setBackgroundDrawable(Color.TRANSPARENT.toDrawable())
+            isTouchable = false
+            isFocusable = false
+            isOutsideTouchable = false
             isClippingEnabled = false
             elevation = 8f
             animationStyle = 0

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/StandardFlickInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/StandardFlickInputController.kt
@@ -23,7 +23,7 @@ import com.kazumaproject.custom_keyboard.view.StandardFlickPopupView
 class StandardFlickInputController(
     context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(context: Context) : this(
         context = context,
@@ -48,6 +48,7 @@ class StandardFlickInputController(
     var listener: StandardFlickListener? = null
     private var popupWindowAnchorProvider: (() -> View?)? = null
     private var characterMap: Map<FlickDirection, String> = emptyMap()
+    private var attachedView: View? = null
     private var anchorView: View? = null
     private var segmentedDrawable: SegmentedBackgroundDrawable? = null
 
@@ -112,6 +113,8 @@ class StandardFlickInputController(
         map: Map<FlickDirection, String>,
         drawable: SegmentedBackgroundDrawable
     ) {
+        attachedView?.takeUnless { it === button }?.setOnTouchListener(null)
+        attachedView = button
         val completeMap = mutableMapOf<FlickDirection, String>()
         completeMap[FlickDirection.TAP] = map[FlickDirection.TAP] ?: ""
         completeMap[FlickDirection.UP] = map[FlickDirection.UP] ?: ""
@@ -253,11 +256,24 @@ class StandardFlickInputController(
         }
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         listener?.onCanceled()
         activeGestureConfig = null
         dismissPopup()
+        segmentedDrawable?.highlightDirection = null
+        anchorView?.isPressed = false
     }
+
+    override fun dispose() {
+        resetGestureState()
+        attachedView?.setOnTouchListener(null)
+        attachedView = null
+        anchorView = null
+        characterMap = emptyMap()
+        segmentedDrawable = null
+    }
+
+    fun cancel() = dispose()
 
     private fun isAnchorReady(keyAnchor: View, windowAnchor: View?): Boolean {
         if (!keyAnchor.isAttachedToWindow) return false

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TapLongPressInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TapLongPressInputController.kt
@@ -66,6 +66,22 @@ class TapLongPressInputController(
         clearGesture()
     }
 
+    /**
+     * Clears a pending gesture without detaching the listeners installed by [attach].
+     *
+     * The generated fast-input test resets the state between trials while reusing the keyboard
+     * views. Calling [cancel] here would make the next normal key permanently inert.
+     */
+    fun resetGestureStateForFastInputTest() {
+        val view = attachedView
+        view?.removeCallbacks(longPressRunnable)
+        if (isLongPressTriggered) {
+            listener?.onLongPressCanceled()
+        }
+        view?.isPressed = false
+        clearGesture()
+    }
+
     private fun handleTouchEvent(event: MotionEvent): Boolean {
         val view = attachedView ?: return false
         when (event.actionMasked) {

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TapLongPressInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TapLongPressInputController.kt
@@ -16,7 +16,7 @@ import com.kazumaproject.core.domain.flick.GestureSessionConfigSource
  */
 class TapLongPressInputController(
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     interface Listener {
         fun onPress()
@@ -52,19 +52,26 @@ class TapLongPressInputController(
         view.setOnTouchListener { _, event -> handleTouchEvent(event) }
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         val view = attachedView
         view?.removeCallbacks(longPressRunnable)
         if (isLongPressTriggered) {
             listener?.onLongPressCanceled()
         }
         view?.isPressed = false
+        clearGesture()
+    }
+
+    override fun dispose() {
+        resetGestureState()
+        val view = attachedView
         view?.setOnTouchListener(null)
         view?.setOnClickListener(null)
         attachedView = null
         listener = null
-        clearGesture()
     }
+
+    fun cancel() = dispose()
 
     /**
      * Clears a pending gesture without detaching the listeners installed by [attach].
@@ -72,15 +79,8 @@ class TapLongPressInputController(
      * The generated fast-input test resets the state between trials while reusing the keyboard
      * views. Calling [cancel] here would make the next normal key permanently inert.
      */
-    fun resetGestureStateForFastInputTest() {
-        val view = attachedView
-        view?.removeCallbacks(longPressRunnable)
-        if (isLongPressTriggered) {
-            listener?.onLongPressCanceled()
-        }
-        view?.isPressed = false
-        clearGesture()
-    }
+    @Deprecated("Use resetGestureState() for reusable controller instances")
+    fun resetGestureStateForFastInputTest() = resetGestureState()
 
     private fun handleTouchEvent(event: MotionEvent): Boolean {
         val view = attachedView ?: return false

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiHierarchicalFlickController.kt
@@ -36,7 +36,7 @@ import kotlin.math.atan2
 class TfbiHierarchicalFlickController(
     private val context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -193,6 +193,7 @@ class TfbiHierarchicalFlickController(
         view: View,
         node: TfbiFlickNode.StatefulKey
     ) {
+        attachedView?.takeUnless { it === view }?.setOnTouchListener(null)
         this.attachedView = view
         this.rootNode = node
 
@@ -216,12 +217,19 @@ class TfbiHierarchicalFlickController(
     /**
      * コントローラーを View からデタッチし、リソースを解放します。
      */
-    fun cancel() {
+    override fun resetGestureState() {
         listener?.onCanceled()
         resetState()
+        attachedView?.isPressed = false
+    }
+
+    override fun dispose() {
+        resetGestureState()
         attachedView?.setOnTouchListener(null)
         attachedView = null
     }
+
+    fun cancel() = dispose()
 
     // --- タッチイベント処理 ---
 

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiInputController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiInputController.kt
@@ -16,6 +16,7 @@ import com.kazumaproject.core.domain.flick.FlickGestureMath
 import com.kazumaproject.core.domain.flick.GestureSessionConfig
 import com.kazumaproject.core.domain.flick.GestureSessionConfigSource
 import com.kazumaproject.custom_keyboard.controller.TfbiGuidePopupHost
+import com.kazumaproject.custom_keyboard.controller.GestureStateResettable
 import com.kazumaproject.custom_keyboard.controller.getLocationRelativeToWindowAnchor
 import com.kazumaproject.custom_keyboard.controller.isTfbiGuideTapCell
 import com.kazumaproject.custom_keyboard.controller.resolveTfbiGuideFingerPosition
@@ -36,7 +37,7 @@ enum class TfbiFlickDirection {
 class TfbiInputController(
     private val context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -171,6 +172,7 @@ class TfbiInputController(
         provider: (TfbiFlickDirection, TfbiFlickDirection) -> String,
         longPressProvider: (TfbiFlickDirection, TfbiFlickDirection) -> String = { _, _ -> "" }
     ) {
+        attachedView?.takeUnless { it === view }?.setOnTouchListener(null)
         this.attachedView = view
         this.characterMapProvider = provider
         this.longPressCharacterMapProvider = longPressProvider
@@ -178,15 +180,22 @@ class TfbiInputController(
         view.setOnTouchListener { _, event -> handleTouchEvent(event) }
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         listener?.onCanceled()
         activeGestureConfig = null
         clearLongPressCallback(attachedView)
         isTouchActive = false
         resetState()
+        attachedView?.isPressed = false
+    }
+
+    override fun dispose() {
+        resetGestureState()
         attachedView?.setOnTouchListener(null)
         attachedView = null
     }
+
+    fun cancel() = dispose()
 
     private fun handleTouchEvent(event: MotionEvent): Boolean {
         // Log.d("TfbInput", "handleTouchEvent: ${MotionEvent.actionToString(event.action)}")

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiStickyFlickController.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/controller/TfbiStickyFlickController.kt
@@ -26,7 +26,7 @@ import kotlin.math.atan2
 class TfbiStickyFlickController(
     private val context: Context,
     private val gestureConfigSource: GestureSessionConfigSource
-) {
+) : GestureStateResettable {
 
     constructor(
         context: Context,
@@ -101,6 +101,7 @@ class TfbiStickyFlickController(
         view: View,
         provider: (TfbiFlickDirection, TfbiFlickDirection) -> String
     ) {
+        attachedView?.takeUnless { it === view }?.setOnTouchListener(null)
         this.attachedView = view
         this.characterMapProvider = provider
 
@@ -148,11 +149,18 @@ class TfbiStickyFlickController(
         guidePopupHost.applyPopupViewStyle(popupStyle)
     }
 
-    fun cancel() {
+    override fun resetGestureState() {
         resetState()
+        attachedView?.isPressed = false
+    }
+
+    override fun dispose() {
+        resetGestureState()
         attachedView?.setOnTouchListener(null)
         attachedView = null
     }
+
+    fun cancel() = dispose()
 
     private fun handleTouchEvent(event: MotionEvent): Boolean {
         val view = attachedView ?: return false

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -2838,6 +2838,23 @@ class FlickKeyboardView @JvmOverloads constructor(
         pointerDownTime.clear()
     }
 
+    fun resetTouchStateForFastInputTest() {
+        doubleTapActionDispatcher.cancel()
+        cancelTextPreview()
+        cancelTrackedTouchState()
+        listener?.onLongPressActionCanceled(KeyAction.Cancel)
+        flickControllers.forEach { it.cancel() }
+        crossFlickControllers.forEach { it.cancel() }
+        centerGuideFlickControllers.forEach { it.cancel() }
+        standardFlickControllers.forEach { it.cancel() }
+        tfbiControllers.forEach { it.cancel() }
+        flickLongPressControllers.forEach { it.cancel() }
+        stickyTfbiControllers.forEach { it.cancel() }
+        hierarchicalTfbiControllers.forEach { it.cancel() }
+        tapLongPressControllers.forEach { it.resetGestureStateForFastInputTest() }
+        setCursorMode(false)
+    }
+
     private fun findTargetView(displayX: Float, displayY: Float): MotionTarget? {
         val location = IntArray(2)
         for (i in 0 until childCount) {
@@ -3027,7 +3044,17 @@ class FlickKeyboardView @JvmOverloads constructor(
                         val existingPointerIndex = event.findPointerIndex(existingPointerId)
                         if (existingPointerIndex != -1) {
                             // A second finger starts a new key gesture; the first finger should be
-                            // committed at its current position, not canceled.
+                            // committed at its current position, not canceled. The current
+                            // position can be the last movement sample carried by this
+                            // ACTION_POINTER_DOWN event. Deliver it before ACTION_UP so the child
+                            // controller can resolve a fast flick instead of committing TAP.
+                            dispatchPointerEvent(
+                                source = event,
+                                pointerIndex = existingPointerIndex,
+                                target = target,
+                                action = MotionEvent.ACTION_MOVE,
+                                downTime = downTime
+                            )
                             dispatchPointerEvent(
                                 source = event,
                                 pointerIndex = existingPointerIndex,

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -9,7 +9,6 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
-import android.os.Build
 import android.os.SystemClock
 import android.text.Spannable
 import android.text.SpannableString
@@ -46,12 +45,17 @@ import com.kazumaproject.core.domain.flick.GestureSessionConfigSource
 import com.kazumaproject.core.domain.flick.MutableRuntimeGestureSettingsSource
 import com.kazumaproject.core.domain.flick.RuntimeGestureSettings
 import com.kazumaproject.core.domain.flick.RuntimeGestureSettingsSource
+import com.kazumaproject.core.domain.touch.PointerEventResolver
+import com.kazumaproject.core.domain.touch.PointerGestureEvent
+import com.kazumaproject.core.domain.touch.PointerGestureRouter
+import com.kazumaproject.core.domain.touch.PointerGestureTrace
 import com.kazumaproject.custom_keyboard.controller.CenterGuideFlickInputController
 import com.kazumaproject.custom_keyboard.controller.CrossFlickInputController
 import com.kazumaproject.custom_keyboard.controller.CustomAngleFlickController
 import com.kazumaproject.custom_keyboard.controller.CancellableTask
 import com.kazumaproject.custom_keyboard.controller.DoubleTapActionDispatcher
 import com.kazumaproject.custom_keyboard.controller.FlickLongPressInputController
+import com.kazumaproject.custom_keyboard.controller.GestureStateResettable
 import com.kazumaproject.custom_keyboard.controller.StandardFlickInputController
 import com.kazumaproject.custom_keyboard.controller.TapTaskScheduler
 import com.kazumaproject.custom_keyboard.controller.TapLongPressInputController
@@ -603,31 +607,31 @@ class FlickKeyboardView @JvmOverloads constructor(
 
         removeAllViews()
 
-        flickControllers.forEach { it.cancel() }
+        flickControllers.forEach { it.dispose() }
         flickControllers.clear()
 
-        crossFlickControllers.forEach { it.cancel() }
+        crossFlickControllers.forEach { it.dispose() }
         crossFlickControllers.clear()
 
-        centerGuideFlickControllers.forEach { it.cancel() }
+        centerGuideFlickControllers.forEach { it.dispose() }
         centerGuideFlickControllers.clear()
 
-        standardFlickControllers.forEach { it.cancel() }
+        standardFlickControllers.forEach { it.dispose() }
         standardFlickControllers.clear()
 
-        tfbiControllers.forEach { it.cancel() }
+        tfbiControllers.forEach { it.dispose() }
         tfbiControllers.clear()
 
-        flickLongPressControllers.forEach { it.cancel() }
+        flickLongPressControllers.forEach { it.dispose() }
         flickLongPressControllers.clear()
 
-        stickyTfbiControllers.forEach { it.cancel() }
+        stickyTfbiControllers.forEach { it.dispose() }
         stickyTfbiControllers.clear()
 
-        hierarchicalTfbiControllers.forEach { it.cancel() }
+        hierarchicalTfbiControllers.forEach { it.dispose() }
         hierarchicalTfbiControllers.clear()
 
-        tapLongPressControllers.forEach { it.cancel() }
+        tapLongPressControllers.forEach { it.dispose() }
         tapLongPressControllers.clear()
 
         keyInfos.clear()
@@ -2721,47 +2725,47 @@ class FlickKeyboardView @JvmOverloads constructor(
     private fun detachKeyBehavior(controller: Any?) {
         when (controller) {
             is CustomAngleFlickController -> {
-                controller.cancel()
+                controller.dispose()
                 flickControllers.remove(controller)
             }
 
             is CrossFlickInputController -> {
-                controller.cancel()
+                controller.dispose()
                 crossFlickControllers.remove(controller)
             }
 
             is CenterGuideFlickInputController -> {
-                controller.cancel()
+                controller.dispose()
                 centerGuideFlickControllers.remove(controller)
             }
 
             is StandardFlickInputController -> {
-                controller.cancel()
+                controller.dispose()
                 standardFlickControllers.remove(controller)
             }
 
             is TfbiInputController -> {
-                controller.cancel()
+                controller.dispose()
                 tfbiControllers.remove(controller)
             }
 
             is FlickLongPressInputController -> {
-                controller.cancel()
+                controller.dispose()
                 flickLongPressControllers.remove(controller)
             }
 
             is TfbiStickyFlickController -> {
-                controller.cancel()
+                controller.dispose()
                 stickyTfbiControllers.remove(controller)
             }
 
             is TfbiHierarchicalFlickController -> {
-                controller.cancel()
+                controller.dispose()
                 hierarchicalTfbiControllers.remove(controller)
             }
 
             is TapLongPressInputController -> {
-                controller.cancel()
+                controller.dispose()
                 tapLongPressControllers.remove(controller)
             }
         }
@@ -2799,29 +2803,29 @@ class FlickKeyboardView @JvmOverloads constructor(
 
     private val motionTargets = mutableMapOf<Int, MotionTarget>()
     private val pointerDownTime = mutableMapOf<Int, Long>()
+    private val pointerGestureRouter = PointerGestureRouter()
     private val TAG = "FlickKeyboardViewTouch"
 
     private fun cancelTrackedTouchState() {
         cancelTextPreview()
+        pointerGestureRouter.reset()
         if (motionTargets.isEmpty() && pointerDownTime.isEmpty()) return
 
         val eventTime = SystemClock.uptimeMillis()
         motionTargets.toList().forEach { (trackedPointerId, target) ->
-            var cancelEvent: MotionEvent? = null
             try {
-                cancelEvent = MotionEvent.obtain(
-                    pointerDownTime[trackedPointerId] ?: eventTime,
-                    eventTime,
-                    MotionEvent.ACTION_CANCEL,
-                    target.view.width / 2f,
-                    target.view.height / 2f,
-                    0
+                dispatchSemanticPointerEvent(
+                    semanticEvent = PointerGestureEvent.Cancel(
+                        pointerId = trackedPointerId,
+                        eventTime = eventTime,
+                        screenX = target.displayOriginX + target.view.width / 2f,
+                        screenY = target.displayOriginY + target.view.height / 2f,
+                    ),
+                    target = target,
+                    downTime = pointerDownTime[trackedPointerId] ?: eventTime,
                 )
-                target.view.dispatchTouchEvent(cancelEvent)
             } catch (e: Exception) {
                 Log.w(TAG, "Failed to dispatch ACTION_CANCEL while clearing touch state", e)
-            } finally {
-                cancelEvent?.recycle()
             }
 
             try {
@@ -2843,16 +2847,28 @@ class FlickKeyboardView @JvmOverloads constructor(
         cancelTextPreview()
         cancelTrackedTouchState()
         listener?.onLongPressActionCanceled(KeyAction.Cancel)
-        flickControllers.forEach { it.cancel() }
-        crossFlickControllers.forEach { it.cancel() }
-        centerGuideFlickControllers.forEach { it.cancel() }
-        standardFlickControllers.forEach { it.cancel() }
-        tfbiControllers.forEach { it.cancel() }
-        flickLongPressControllers.forEach { it.cancel() }
-        stickyTfbiControllers.forEach { it.cancel() }
-        hierarchicalTfbiControllers.forEach { it.cancel() }
-        tapLongPressControllers.forEach { it.resetGestureStateForFastInputTest() }
+        resetGestureControllers()
         setCursorMode(false)
+    }
+
+    private inline fun forEachGestureController(action: (GestureStateResettable) -> Unit) {
+        flickControllers.forEach(action)
+        crossFlickControllers.forEach(action)
+        centerGuideFlickControllers.forEach(action)
+        standardFlickControllers.forEach(action)
+        tfbiControllers.forEach(action)
+        flickLongPressControllers.forEach(action)
+        stickyTfbiControllers.forEach(action)
+        hierarchicalTfbiControllers.forEach(action)
+        tapLongPressControllers.forEach(action)
+    }
+
+    private fun resetGestureControllers() {
+        forEachGestureController { it.resetGestureState() }
+    }
+
+    private fun disposeGestureControllers() {
+        forEachGestureController { it.dispose() }
     }
 
     private fun findTargetView(displayX: Float, displayY: Float): MotionTarget? {
@@ -2880,19 +2896,11 @@ class FlickKeyboardView @JvmOverloads constructor(
     }
 
     private fun MotionEvent.displayX(pointerIndex: Int): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            getRawX(pointerIndex)
-        } else {
-            getX(pointerIndex) + rawX - x
-        }
+        return PointerEventResolver.screenX(this, pointerIndex)
     }
 
     private fun MotionEvent.displayY(pointerIndex: Int): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            getRawY(pointerIndex)
-        } else {
-            getY(pointerIndex) + rawY - y
-        }
+        return PointerEventResolver.screenY(this, pointerIndex)
     }
 
     private fun dispatchPointerEvent(
@@ -2903,15 +2911,71 @@ class FlickKeyboardView @JvmOverloads constructor(
         downTime: Long,
         eventTime: Long = source.eventTime
     ) {
-        val displayX = source.displayX(pointerIndex)
-        val displayY = source.displayY(pointerIndex)
+        val sample = PointerEventResolver.at(source, pointerIndex) ?: return
+        val semanticEvent = when (action and MotionEvent.ACTION_MASK) {
+            MotionEvent.ACTION_DOWN -> PointerGestureEvent.Down(
+                pointerId = sample.pointerId,
+                eventTime = eventTime,
+                screenX = sample.screenX,
+                screenY = sample.screenY,
+            )
+
+            MotionEvent.ACTION_MOVE -> PointerGestureEvent.Move(
+                pointerId = sample.pointerId,
+                eventTime = eventTime,
+                screenX = sample.screenX,
+                screenY = sample.screenY,
+            )
+
+            MotionEvent.ACTION_UP -> PointerGestureEvent.Up(
+                pointerId = sample.pointerId,
+                eventTime = eventTime,
+                screenX = sample.screenX,
+                screenY = sample.screenY,
+            )
+
+            MotionEvent.ACTION_CANCEL -> PointerGestureEvent.Cancel(
+                pointerId = sample.pointerId,
+                eventTime = eventTime,
+                screenX = sample.screenX,
+                screenY = sample.screenY,
+            )
+
+            else -> return
+        }
+        dispatchSemanticPointerEvent(
+            semanticEvent = semanticEvent,
+            target = target,
+            downTime = downTime,
+            metaState = source.metaState,
+        )
+    }
+
+    private fun dispatchSemanticPointerEvent(
+        semanticEvent: PointerGestureEvent,
+        target: MotionTarget,
+        downTime: Long,
+        metaState: Int = 0,
+    ) {
+        val action = when (semanticEvent) {
+            is PointerGestureEvent.Down -> MotionEvent.ACTION_DOWN
+            is PointerGestureEvent.Move -> MotionEvent.ACTION_MOVE
+            is PointerGestureEvent.Up -> MotionEvent.ACTION_UP
+            is PointerGestureEvent.Cancel -> MotionEvent.ACTION_CANCEL
+        }
+        PointerGestureTrace.log(
+            "view-dispatch",
+            "surface=CUSTOM action=" + MotionEvent.actionToString(action) +
+                " pointerId=" + semanticEvent.pointerId +
+                " targetViewId=" + target.view.id,
+        )
         val childEvent = MotionEvent.obtain(
             downTime,
-            eventTime,
+            semanticEvent.eventTime,
             action,
-            displayX,
-            displayY,
-            source.metaState
+            semanticEvent.screenX,
+            semanticEvent.screenY,
+            metaState,
         )
         childEvent.offsetLocation(
             -target.displayOriginX,
@@ -2941,8 +3005,31 @@ class FlickKeyboardView @JvmOverloads constructor(
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
         val action = event.actionMasked
-        val pointerIndex = event.actionIndex
-        val pointerId = event.getPointerId(pointerIndex)
+        val actionPointer = PointerEventResolver.actionPointer(event)
+        val pointerIndex = actionPointer?.pointerIndex ?: 0
+        val pointerId = actionPointer?.pointerId ?: -1
+        PointerGestureTrace.log(
+            "view",
+            "surface=CUSTOM action=" + MotionEvent.actionToString(action) +
+                " actionIndex=" + event.actionIndex +
+                " pointers=" + PointerEventResolver.describe(event),
+        )
+        pointerGestureRouter.route(event) { semanticEvent ->
+            if (!PointerGestureTrace.isActive()) return@route
+            val semanticType = when (semanticEvent) {
+                is PointerGestureEvent.Down -> "DOWN"
+                is PointerGestureEvent.Move -> "MOVE"
+                is PointerGestureEvent.Up -> "UP"
+                is PointerGestureEvent.Cancel -> "CANCEL"
+            }
+            PointerGestureTrace.log(
+                "router",
+                "surface=CUSTOM type=" + semanticType +
+                    " pointerId=" + semanticEvent.pointerId +
+                    " screenX=" + semanticEvent.screenX +
+                    " screenY=" + semanticEvent.screenY,
+            )
+        }
 
         if (isCursorMode) {
             when (event.actionMasked) {
@@ -3041,8 +3128,8 @@ class FlickKeyboardView @JvmOverloads constructor(
                     )
 
                     if (target != null && downTime != null) {
-                        val existingPointerIndex = event.findPointerIndex(existingPointerId)
-                        if (existingPointerIndex != -1) {
+                        val existingPointer = PointerEventResolver.forId(event, existingPointerId)
+                        if (existingPointer != null) {
                             // A second finger starts a new key gesture; the first finger should be
                             // committed at its current position, not canceled. The current
                             // position can be the last movement sample carried by this
@@ -3050,14 +3137,14 @@ class FlickKeyboardView @JvmOverloads constructor(
                             // controller can resolve a fast flick instead of committing TAP.
                             dispatchPointerEvent(
                                 source = event,
-                                pointerIndex = existingPointerIndex,
+                                pointerIndex = existingPointer.pointerIndex,
                                 target = target,
                                 action = MotionEvent.ACTION_MOVE,
                                 downTime = downTime
                             )
                             dispatchPointerEvent(
                                 source = event,
-                                pointerIndex = existingPointerIndex,
+                                pointerIndex = existingPointer.pointerIndex,
                                 target = target,
                                 action = MotionEvent.ACTION_UP,
                                 downTime = downTime
@@ -3089,19 +3176,20 @@ class FlickKeyboardView @JvmOverloads constructor(
                 motionTargets.clear()
                 pointerDownTime.clear()
 
-                val newPointerId = event.getPointerId(pointerIndex)
+                val newPointer = actionPointer ?: return true
+                val newPointerId = newPointer.pointerId
 
                 pointerDownTime[newPointerId] = event.eventTime
                 val targetView = findTargetView(
-                    displayX = event.displayX(pointerIndex),
-                    displayY = event.displayY(pointerIndex)
+                    displayX = newPointer.screenX,
+                    displayY = newPointer.screenY
                 )
 
                 targetView?.let { target ->
                     motionTargets[newPointerId] = target
                     dispatchPointerEvent(
                         source = event,
-                        pointerIndex = pointerIndex,
+                        pointerIndex = newPointer.pointerIndex,
                         target = target,
                         action = MotionEvent.ACTION_DOWN,
                         downTime = event.eventTime
@@ -3134,19 +3222,21 @@ class FlickKeyboardView @JvmOverloads constructor(
                     return false
                 }
 
+                val liftedPointer = actionPointer ?: return true
                 Log.d(
                     "FlickKeyboardView",
-                    "ACTION_POINTER_UP: pointerId=$pointerId, index=$pointerIndex"
+                    "ACTION_POINTER_UP: pointerId=${liftedPointer.pointerId}, " +
+                        "index=${liftedPointer.pointerIndex}"
                 )
 
-                motionTargets[pointerId]?.let { target ->
-                    val downTime = pointerDownTime[pointerId]!!
+                motionTargets[liftedPointer.pointerId]?.let { target ->
+                    val downTime = pointerDownTime[liftedPointer.pointerId] ?: return@let
 
                     Log.d("FlickKeyboardView", "ACTION_POINTER_UP: Found target! $target")
 
                     dispatchPointerEvent(
                         source = event,
-                        pointerIndex = pointerIndex,
+                        pointerIndex = liftedPointer.pointerIndex,
                         target = target,
                         action = MotionEvent.ACTION_UP,
                         downTime = downTime
@@ -3154,12 +3244,13 @@ class FlickKeyboardView @JvmOverloads constructor(
                 } ?: run {
                     Log.e(
                         "FlickKeyboardView",
-                        "ACTION_POINTER_UP: No target found for pointerId=$pointerId"
+                        "ACTION_POINTER_UP: No target found for " +
+                            "pointerId=${liftedPointer.pointerId}"
                     )
                 }
 
-                motionTargets.remove(pointerId)
-                pointerDownTime.remove(pointerId)
+                motionTargets.remove(liftedPointer.pointerId)
+                pointerDownTime.remove(liftedPointer.pointerId)
                 return true
             }
 
@@ -3167,15 +3258,21 @@ class FlickKeyboardView @JvmOverloads constructor(
                 val actionToDispatch =
                     if (action == MotionEvent.ACTION_UP) MotionEvent.ACTION_UP else MotionEvent.ACTION_CANCEL
 
-                motionTargets[pointerId]?.let { target ->
-                    val downTime = pointerDownTime[pointerId]!!
-                    dispatchPointerEvent(
-                        source = event,
-                        pointerIndex = pointerIndex,
-                        target = target,
-                        action = actionToDispatch,
-                        downTime = downTime
-                    )
+                if (action == MotionEvent.ACTION_CANCEL) {
+                    dispatchEndEventToTrackedTargets(event, actionToDispatch)
+                } else {
+                    val liftedPointer = actionPointer ?: return true
+                    motionTargets[liftedPointer.pointerId]?.let { target ->
+                        val downTime =
+                            pointerDownTime[liftedPointer.pointerId] ?: return@let
+                        dispatchPointerEvent(
+                            source = event,
+                            pointerIndex = liftedPointer.pointerIndex,
+                            target = target,
+                            action = actionToDispatch,
+                            downTime = downTime
+                        )
+                    }
                 }
 
                 if (action == MotionEvent.ACTION_CANCEL) {
@@ -3216,15 +3313,7 @@ class FlickKeyboardView @JvmOverloads constructor(
         cancelTrackedTouchState()
         super.onDetachedFromWindow()
         listener?.onLongPressActionCanceled(KeyAction.Cancel)
-        flickControllers.forEach { it.cancel() }
-        crossFlickControllers.forEach { it.cancel() }
-        centerGuideFlickControllers.forEach { it.cancel() }
-        standardFlickControllers.forEach { it.cancel() }
-        tfbiControllers.forEach { it.cancel() }
-        flickLongPressControllers.forEach { it.cancel() }
-        stickyTfbiControllers.forEach { it.cancel() }
-        hierarchicalTfbiControllers.forEach { it.cancel() }
-        tapLongPressControllers.forEach { it.cancel() }
+        disposeGestureControllers()
     }
 
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
@@ -3266,6 +3355,20 @@ class FlickKeyboardView @JvmOverloads constructor(
         motionTargets.forEach { (trackedPointerId, target) ->
             val trackedPointerIndex = sourceEvent.findPointerIndex(trackedPointerId)
             if (trackedPointerIndex == -1) {
+                if (actionToDispatch == MotionEvent.ACTION_CANCEL) {
+                    val eventTime = sourceEvent.eventTime
+                    dispatchSemanticPointerEvent(
+                        semanticEvent = PointerGestureEvent.Cancel(
+                            pointerId = trackedPointerId,
+                            eventTime = eventTime,
+                            screenX = target.displayOriginX + target.view.width / 2f,
+                            screenY = target.displayOriginY + target.view.height / 2f,
+                        ),
+                        target = target,
+                        downTime = pointerDownTime[trackedPointerId] ?: eventTime,
+                        metaState = sourceEvent.metaState,
+                    )
+                }
                 target.view.isPressed = false
                 target.view.isSelected = false
                 target.view.refreshDrawableState()

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardViewTouchDispatchTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardViewTouchDispatchTest.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.graphics.Rect
 import android.os.Looper
 import android.view.ContextThemeWrapper
+import android.view.InputDevice
 import android.view.MotionEvent
 import android.view.View
 import androidx.test.core.app.ApplicationProvider
@@ -134,6 +135,53 @@ class FlickKeyboardViewTouchDispatchTest {
         )
     }
 
+    @Test
+    fun secondPointerDown_commitsFirstPointerAtItsLatestPosition() {
+        val listener = RecordingKeyboardActionListener()
+        val keyboardView = keyboardView(listener)
+        keyboardView.setKeyboard(petalFlickCharacterLayout())
+        layoutKeyboard(keyboardView)
+
+        val characterKey = keyboardView.getChildAt(0)
+        val centerX = characterKey.centerX()
+        val centerY = characterKey.centerY()
+        val finalX = centerX + 160f
+
+        keyboardView.dispatchTouch(
+            action = MotionEvent.ACTION_DOWN,
+            pointers = listOf(Pointer(0, centerX, centerY)),
+            downTime = 700L,
+            eventTime = 700L
+        )
+        keyboardView.dispatchTouch(
+            action = MotionEvent.ACTION_MOVE,
+            pointers = listOf(Pointer(0, centerX + 20f, centerY)),
+            downTime = 700L,
+            eventTime = 701L
+        )
+
+        // The final movement sample is carried by ACTION_POINTER_DOWN. The router must forward
+        // it before committing the first pointer, otherwise this RIGHT flick is committed as TAP.
+        keyboardView.dispatchTouch(
+            action = MotionEvent.ACTION_POINTER_DOWN,
+            actionIndex = 1,
+            pointers = listOf(
+                Pointer(0, finalX, centerY),
+                Pointer(1, -100f, -100f)
+            ),
+            downTime = 700L,
+            eventTime = 702L
+        )
+        keyboardView.dispatchTouch(
+            action = MotionEvent.ACTION_UP,
+            pointers = listOf(Pointer(1, -100f, -100f)),
+            downTime = 700L,
+            eventTime = 703L
+        )
+
+        assertTrue(listener.actions == listOf(KeyAction.Text("え")))
+    }
+
     private fun keyboardView(
         listener: FlickKeyboardView.OnKeyboardActionListener
     ): FlickKeyboardView {
@@ -215,6 +263,31 @@ class FlickKeyboardViewTouchDispatchTest {
         )
     }
 
+    private fun petalFlickCharacterLayout(): KeyboardLayout {
+        val characterKey = KeyData(
+            label = "あ",
+            row = 0,
+            column = 0,
+            isFlickable = true,
+            action = KeyAction.Text("あ"),
+            keyId = "a",
+            keyType = KeyType.PETAL_FLICK
+        )
+        return KeyboardLayout(
+            keys = listOf(characterKey),
+            flickKeyMaps = mapOf(
+                "a" to listOf(
+                    mapOf(
+                        FlickDirection.TAP to FlickAction.Input("あ"),
+                        FlickDirection.UP_RIGHT_FAR to FlickAction.Input("え")
+                    )
+                )
+            ),
+            columnCount = 1,
+            rowCount = 1
+        )
+    }
+
     private fun layoutKeyboard(keyboardView: FlickKeyboardView) {
         val widthSpec = View.MeasureSpec.makeMeasureSpec(240, View.MeasureSpec.EXACTLY)
         val heightSpec = View.MeasureSpec.makeMeasureSpec(120, View.MeasureSpec.EXACTLY)
@@ -229,10 +302,58 @@ class FlickKeyboardViewTouchDispatchTest {
         downTime: Long,
         eventTime: Long
     ) {
-        val event = MotionEvent.obtain(downTime, eventTime, action, x, y, 0)
+        dispatchTouch(
+            action = action,
+            pointers = listOf(Pointer(0, x, y)),
+            downTime = downTime,
+            eventTime = eventTime
+        )
+    }
+
+    private fun FlickKeyboardView.dispatchTouch(
+        action: Int,
+        actionIndex: Int = 0,
+        pointers: List<Pointer>,
+        downTime: Long,
+        eventTime: Long
+    ) {
+        val pointerProperties = Array(pointers.size) {
+            MotionEvent.PointerProperties().apply {
+                id = pointers[it].id
+                toolType = MotionEvent.TOOL_TYPE_FINGER
+            }
+        }
+        val pointerCoords = Array(pointers.size) {
+            MotionEvent.PointerCoords().apply {
+                x = pointers[it].x
+                y = pointers[it].y
+                pressure = 1f
+                size = 1f
+            }
+        }
+        val encodedAction = action or
+            (actionIndex shl MotionEvent.ACTION_POINTER_INDEX_SHIFT)
+        val event = MotionEvent.obtain(
+            downTime,
+            eventTime,
+            encodedAction,
+            pointers.size,
+            pointerProperties,
+            pointerCoords,
+            0,
+            0,
+            1f,
+            1f,
+            0,
+            0,
+            InputDevice.SOURCE_TOUCHSCREEN,
+            0
+        )
         onTouchEvent(event)
         event.recycle()
     }
+
+    private data class Pointer(val id: Int, val x: Float, val y: Float)
 
     private fun View.centerX(): Float = left + width / 2f
 

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/PointerGestureRouterTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/PointerGestureRouterTest.kt
@@ -1,0 +1,219 @@
+package com.kazumaproject.custom_keyboard.view
+
+import android.view.InputDevice
+import android.view.MotionEvent
+import com.kazumaproject.core.domain.touch.PointerGestureEvent
+import com.kazumaproject.core.domain.touch.PointerGestureRouter
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class PointerGestureRouterTest {
+    @Test
+    fun actionIndexSelectsLiftedIdAndExistingPointerMovesBeforeNewDown() {
+        val router = PointerGestureRouter()
+        val events = mutableListOf<String>()
+
+        route(
+            router,
+            action = MotionEvent.ACTION_DOWN,
+            pointers = listOf(Pointer(7, 10f, 20f)),
+            eventTime = 100L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_POINTER_DOWN,
+            actionIndex = 1,
+            pointers = listOf(
+                Pointer(7, 30f, 40f),
+                Pointer(19, 50f, 60f),
+            ),
+            eventTime = 110L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_POINTER_UP,
+            actionIndex = 0,
+            pointers = listOf(
+                Pointer(7, 35f, 45f),
+                Pointer(19, 50f, 60f),
+            ),
+            eventTime = 120L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_UP,
+            pointers = listOf(Pointer(19, 55f, 65f)),
+            eventTime = 130L,
+            events = events,
+        )
+
+        assertEquals(
+            listOf("DOWN:7", "MOVE:7", "DOWN:19", "UP:7", "UP:19"),
+            events,
+        )
+    }
+
+    @Test
+    fun newerPointerCanLiftBeforeOlderPointerWithoutSwappingOwnership() {
+        val router = PointerGestureRouter()
+        val events = mutableListOf<String>()
+
+        route(
+            router,
+            action = MotionEvent.ACTION_DOWN,
+            pointers = listOf(Pointer(7, 10f, 20f)),
+            eventTime = 300L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_POINTER_DOWN,
+            actionIndex = 1,
+            pointers = listOf(
+                Pointer(7, 30f, 40f),
+                Pointer(19, 50f, 60f),
+            ),
+            eventTime = 310L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_POINTER_UP,
+            actionIndex = 1,
+            pointers = listOf(
+                Pointer(7, 35f, 45f),
+                Pointer(19, 55f, 65f),
+            ),
+            eventTime = 320L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_UP,
+            pointers = listOf(Pointer(7, 40f, 50f)),
+            eventTime = 330L,
+            events = events,
+        )
+
+        assertEquals(
+            listOf("DOWN:7", "MOVE:7", "DOWN:19", "UP:19", "UP:7"),
+            events,
+        )
+    }
+
+    @Test
+    fun actionCancelClosesEveryStillOwnedPointerExactlyOnce() {
+        val router = PointerGestureRouter()
+        val events = mutableListOf<String>()
+
+        route(
+            router,
+            action = MotionEvent.ACTION_DOWN,
+            pointers = listOf(Pointer(7, 10f, 20f)),
+            eventTime = 200L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_POINTER_DOWN,
+            actionIndex = 1,
+            pointers = listOf(
+                Pointer(7, 30f, 40f),
+                Pointer(19, 50f, 60f),
+            ),
+            eventTime = 210L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_CANCEL,
+            pointers = listOf(
+                Pointer(7, 30f, 40f),
+                Pointer(19, 50f, 60f),
+            ),
+            eventTime = 220L,
+            events = events,
+        )
+        route(
+            router,
+            action = MotionEvent.ACTION_UP,
+            pointers = listOf(Pointer(19, 55f, 65f)),
+            eventTime = 230L,
+            events = events,
+        )
+
+        assertEquals(
+            listOf("DOWN:7", "MOVE:7", "DOWN:19", "CANCEL:7", "CANCEL:19"),
+            events,
+        )
+    }
+
+    private fun route(
+        router: PointerGestureRouter,
+        action: Int,
+        actionIndex: Int = 0,
+        pointers: List<Pointer>,
+        eventTime: Long,
+        events: MutableList<String>,
+    ) {
+        val properties = Array(pointers.size) {
+            MotionEvent.PointerProperties().apply {
+                id = pointers[it].id
+                toolType = MotionEvent.TOOL_TYPE_FINGER
+            }
+        }
+        val coordinates = Array(pointers.size) {
+            MotionEvent.PointerCoords().apply {
+                x = pointers[it].x
+                y = pointers[it].y
+                pressure = 1f
+                size = 1f
+            }
+        }
+        val encodedAction = action or
+            (actionIndex shl MotionEvent.ACTION_POINTER_INDEX_SHIFT)
+        val event = MotionEvent.obtain(
+            eventTime,
+            eventTime,
+            encodedAction,
+            pointers.size,
+            properties,
+            coordinates,
+            0,
+            0,
+            1f,
+            1f,
+            0,
+            0,
+            InputDevice.SOURCE_TOUCHSCREEN,
+            0,
+        )
+        try {
+            router.route(event) { semanticEvent ->
+                val type = when (semanticEvent) {
+                    is PointerGestureEvent.Down -> "DOWN"
+                    is PointerGestureEvent.Move -> "MOVE"
+                    is PointerGestureEvent.Up -> "UP"
+                    is PointerGestureEvent.Cancel -> "CANCEL"
+                }
+                events += "${type}:${semanticEvent.pointerId}"
+            }
+        } finally {
+            event.recycle()
+        }
+    }
+
+    private data class Pointer(
+        val id: Int,
+        val x: Float,
+        val y: Float,
+    )
+}

--- a/gojuon_keyboard/src/main/java/com/kazumaproject/gojuon_keyboard/GojuonKeyboardView.kt
+++ b/gojuon_keyboard/src/main/java/com/kazumaproject/gojuon_keyboard/GojuonKeyboardView.kt
@@ -1268,6 +1268,11 @@ class GojuonKeyboardView @JvmOverloads constructor(
         uiScope.cancel()
     }
 
+    fun resetTouchStateForFastInputTest() {
+        skipNextTouches = false
+        cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
+    }
+
     override fun onVisibilityChanged(changedView: View, visibility: Int) {
         super.onVisibilityChanged(changedView, visibility)
         if (changedView == this && visibility != View.VISIBLE) {

--- a/gojuon_keyboard/src/main/java/com/kazumaproject/gojuon_keyboard/GojuonKeyboardView.kt
+++ b/gojuon_keyboard/src/main/java/com/kazumaproject/gojuon_keyboard/GojuonKeyboardView.kt
@@ -56,6 +56,8 @@ import com.kazumaproject.core.domain.state.GestureType
 import com.kazumaproject.core.domain.state.InputMode
 import com.kazumaproject.core.domain.state.InputMode.ModeEnglish.next
 import com.kazumaproject.core.domain.state.PressedKey
+import com.kazumaproject.core.domain.touch.PointerEventResolver
+import com.kazumaproject.core.domain.touch.PointerGestureTrace
 import com.kazumaproject.core.ui.effect.Blur
 import com.kazumaproject.core.ui.key_window.KeyWindowLayout
 import com.kazumaproject.gojuon_keyboard.databinding.GojuonLayoutBinding
@@ -823,6 +825,12 @@ class GojuonKeyboardView @JvmOverloads constructor(
 
     override fun onTouch(v: View?, event: MotionEvent?): Boolean {
         if (v != null && event != null) {
+            PointerGestureTrace.log(
+                "view",
+                "surface=GOJUON action=" + MotionEvent.actionToString(event.actionMasked) +
+                    " actionIndex=" + event.actionIndex +
+                    " pointers=" + PointerEventResolver.describe(event),
+            )
             if (this.visibility != View.VISIBLE) {
                 return false
             }
@@ -838,26 +846,18 @@ class GojuonKeyboardView @JvmOverloads constructor(
             when (event.action and MotionEvent.ACTION_MASK) {
                 MotionEvent.ACTION_DOWN -> {
                     val pointerIndex = event.actionIndex
-                    val pointerId = event.getPointerId(pointerIndex)
+                    val pointer = PointerEventResolver.at(event, pointerIndex) ?: return true
+                    val pointerId = pointer.pointerId
                     val key = pressedKeyByMotionEvent(event, pointerIndex)
                     flickListener?.onFlick(
                         gestureType = GestureType.Down, key = key, char = null
                     )
-                    pressedKey = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        PressedKey(
-                            key = key,
-                            pointer = pointerId,
-                            initialX = event.getRawX(pointerIndex),
-                            initialY = event.getRawY(pointerIndex),
-                        )
-                    } else {
-                        PressedKey(
-                            key = key,
-                            pointer = pointerId,
-                            initialX = event.getX(pointerIndex),
-                            initialY = event.getY(pointerIndex),
-                        )
-                    }
+                    pressedKey = PressedKey(
+                        key = key,
+                        pointerId = pointerId,
+                        initialX = pointer.screenX,
+                        initialY = pointer.screenY,
+                    )
                     setKeyPressed()
                     if (currentInputMode.get() == InputMode.ModeEnglish &&
                         key == Key.KeyKuten
@@ -916,8 +916,11 @@ class GojuonKeyboardView @JvmOverloads constructor(
 
                 MotionEvent.ACTION_UP -> {
                     resetLongPressAction()
-                    if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
-                        val gestureType = getGestureType(event, event.actionIndex)
+                    val liftedPointer = PointerEventResolver.actionPointer(event)
+                    if (liftedPointer != null &&
+                        pressedKey.pointerId == liftedPointer.pointerId
+                    ) {
+                        val gestureType = getGestureType(event, liftedPointer.pointerIndex)
                         val keyInfo = currentInputMode.get().next(
                             keyMap = keyMap, key = pressedKey.key, isGojuon = true
                         )
@@ -1060,7 +1063,7 @@ class GojuonKeyboardView @JvmOverloads constructor(
                 }
 
                 MotionEvent.ACTION_MOVE -> {
-                    val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                    val trackedPointerIndex = event.findPointerIndex(pressedKey.pointerId)
                     if (trackedPointerIndex < 0) {
                         cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
                         return true
@@ -1089,9 +1092,11 @@ class GojuonKeyboardView @JvmOverloads constructor(
                     longPressJob?.cancel()
                     if (event.pointerCount == 2) {
                         isLongPressed = false
-                        val newPointerIndex = event.actionIndex
-                        val newPointerId = event.getPointerId(newPointerIndex)
-                        val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                        val newPointer = PointerEventResolver.actionPointer(event)
+                            ?: return true
+                        val newPointerIndex = newPointer.pointerIndex
+                        val newPointerId = newPointer.pointerId
+                        val trackedPointerIndex = event.findPointerIndex(pressedKey.pointerId)
                         if (trackedPointerIndex < 0) {
                             cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
                             return true
@@ -1162,17 +1167,9 @@ class GojuonKeyboardView @JvmOverloads constructor(
                         }
                         pressedKey = pressedKey.copy(
                             key = key,
-                            pointer = newPointerId,
-                            initialX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawX(newPointerIndex)
-                            } else {
-                                event.getX(newPointerIndex)
-                            },
-                            initialY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawY(newPointerIndex)
-                            } else {
-                                event.getY(newPointerIndex)
-                            },
+                            pointerId = newPointerId,
+                            initialX = newPointer.screenX,
+                            initialY = newPointer.screenY,
                         )
                         setKeyPressed()
                         longPressJob = CoroutineScope(Dispatchers.Main).launch {
@@ -1189,9 +1186,12 @@ class GojuonKeyboardView @JvmOverloads constructor(
 
                 MotionEvent.ACTION_POINTER_UP -> {
                     if (event.pointerCount == 2) {
-                        if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
+                        val liftedPointer = PointerEventResolver.actionPointer(event)
+                        if (liftedPointer != null &&
+                            pressedKey.pointerId == liftedPointer.pointerId
+                        ) {
                             resetLongPressAction()
-                            val gestureType = getGestureType(event, event.actionIndex)
+                            val gestureType = getGestureType(event, liftedPointer.pointerIndex)
                             val keyInfo = currentInputMode.get()
                                 .next(keyMap = keyMap, key = pressedKey.key, isGojuon = true)
                             if (keyInfo == KeyInfo.Null) {
@@ -1305,16 +1305,8 @@ class GojuonKeyboardView @JvmOverloads constructor(
     }
 
     private fun getGestureType(event: MotionEvent, pointer: Int = 0): GestureType {
-        val finalX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            event.getRawX(pointer)
-        } else {
-            event.getX(pointer)
-        }
-        val finalY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            event.getRawY(pointer)
-        } else {
-            event.getY(pointer)
-        }
+        val finalX = PointerEventResolver.screenX(event, pointer)
+        val finalY = PointerEventResolver.screenY(event, pointer)
         val distanceX = finalX - pressedKey.initialX
         val distanceY = finalY - pressedKey.initialY
         return when (
@@ -3091,13 +3083,8 @@ class GojuonKeyboardView @JvmOverloads constructor(
 
     // --- Utility to get consistent absolute coordinates ---
     private fun getRawCoordinates(event: MotionEvent, pointer: Int): Pair<Float, Float> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            event.getRawX(pointer) to event.getRawY(pointer)
-        } else {
-            val location = IntArray(2)
-            this.getLocationOnScreen(location)
-            (event.getX(pointer) + location[0]) to (event.getY(pointer) + location[1])
-        }
+        return PointerEventResolver.screenX(event, pointer) to
+            PointerEventResolver.screenY(event, pointer)
     }
 
     private fun resetLongPressAction() {
@@ -3393,6 +3380,13 @@ class GojuonKeyboardView @JvmOverloads constructor(
                     GestureType.Null -> null
                 }
             }
+            PointerGestureTrace.log(
+                "gesture",
+                "surface=GOJUON pointerId=" + pressedKey.pointerId +
+                    " key=" + pressedKey.key +
+                    " gesture=" + gestureType +
+                    " output=" + charToSend,
+            )
             flickListener?.onFlick(
                 gestureType = gestureType,
                 key = pressedKey.key,

--- a/gojuon_keyboard/src/main/java/com/kazumaproject/gojuon_keyboard/GojuonKeyboardView.kt
+++ b/gojuon_keyboard/src/main/java/com/kazumaproject/gojuon_keyboard/GojuonKeyboardView.kt
@@ -766,6 +766,19 @@ class GojuonKeyboardView @JvmOverloads constructor(
         popupWindowBottom = mPopWindowBottom
         popupWindowCenter = mPopWindowCenter
 
+        listOf(
+            popupWindowActive,
+            popupWindowLeft,
+            popupWindowTop,
+            popupWindowRight,
+            popupWindowBottom,
+            popupWindowCenter,
+        ).forEach { popup ->
+            popup.isTouchable = false
+            popup.isFocusable = false
+            popup.isOutsideTouchable = false
+        }
+
         bubbleViewActive = mPopWindowActive.contentView.findViewById(R.id.bubble_layout_active)
         popTextActive = mPopWindowActive.contentView.findViewById(R.id.popup_text_active)
         bubbleViewLeft = mPopWindowLeft.contentView.findViewById(R.id.bubble_layout)
@@ -824,23 +837,25 @@ class GojuonKeyboardView @JvmOverloads constructor(
             }
             when (event.action and MotionEvent.ACTION_MASK) {
                 MotionEvent.ACTION_DOWN -> {
-                    val key = pressedKeyByMotionEvent(event, 0)
+                    val pointerIndex = event.actionIndex
+                    val pointerId = event.getPointerId(pointerIndex)
+                    val key = pressedKeyByMotionEvent(event, pointerIndex)
                     flickListener?.onFlick(
                         gestureType = GestureType.Down, key = key, char = null
                     )
                     pressedKey = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         PressedKey(
                             key = key,
-                            pointer = 0,
-                            initialX = event.getRawX(event.actionIndex),
-                            initialY = event.getRawY(event.actionIndex),
+                            pointer = pointerId,
+                            initialX = event.getRawX(pointerIndex),
+                            initialY = event.getRawY(pointerIndex),
                         )
                     } else {
                         PressedKey(
                             key = key,
-                            pointer = 0,
-                            initialX = event.getX(event.actionIndex),
-                            initialY = event.getY(event.actionIndex),
+                            pointer = pointerId,
+                            initialX = event.getX(pointerIndex),
+                            initialY = event.getY(pointerIndex),
                         )
                     }
                     setKeyPressed()
@@ -902,7 +917,7 @@ class GojuonKeyboardView @JvmOverloads constructor(
                 MotionEvent.ACTION_UP -> {
                     resetLongPressAction()
                     if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
-                        val gestureType = getGestureType(event)
+                        val gestureType = getGestureType(event, event.actionIndex)
                         val keyInfo = currentInputMode.get().next(
                             keyMap = keyMap, key = pressedKey.key, isGojuon = true
                         )
@@ -1045,10 +1060,12 @@ class GojuonKeyboardView @JvmOverloads constructor(
                 }
 
                 MotionEvent.ACTION_MOVE -> {
-                    val gestureType =
-                        if (event.pointerCount == 1) getGestureType(event, 0) else getGestureType(
-                            event, pressedKey.pointer
-                        )
+                    val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                    if (trackedPointerIndex < 0) {
+                        cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
+                        return true
+                    }
+                    val gestureType = getGestureType(event, trackedPointerIndex)
                     when (gestureType) {
                         GestureType.Null -> {}
                         GestureType.Down -> {}
@@ -1072,9 +1089,15 @@ class GojuonKeyboardView @JvmOverloads constructor(
                     longPressJob?.cancel()
                     if (event.pointerCount == 2) {
                         isLongPressed = false
-                        val pointer = event.getPointerId(event.actionIndex)
-                        val key = pressedKeyByMotionEvent(event, pointer)
-                        val gestureType2 = getGestureType(event, if (pointer == 0) 1 else 0)
+                        val newPointerIndex = event.actionIndex
+                        val newPointerId = event.getPointerId(newPointerIndex)
+                        val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                        if (trackedPointerIndex < 0) {
+                            cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
+                            return true
+                        }
+                        val key = pressedKeyByMotionEvent(event, newPointerIndex)
+                        val gestureType2 = getGestureType(event, trackedPointerIndex)
                         val keyInfo = currentInputMode.get()
                             .next(keyMap = keyMap, key = pressedKey.key, isGojuon = true)
                         if (keyInfo == KeyInfo.Null) {
@@ -1133,30 +1156,22 @@ class GojuonKeyboardView @JvmOverloads constructor(
                                 }
 
                                 GestureType.FlickLeft, GestureType.FlickTop, GestureType.FlickRight, GestureType.FlickBottom -> {
-                                    setFlickActionPointerDown(keyInfo, gestureType2)
+                                    dispatchKeyInfoGesture(keyInfo, gestureType2)
                                 }
                             }
                         }
                         pressedKey = pressedKey.copy(
                             key = key,
-                            pointer = pointer,
-                            initialX = if (pointer == 0) if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawX(0)
+                            pointer = newPointerId,
+                            initialX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                event.getRawX(newPointerIndex)
                             } else {
-                                event.getX(0)
-                            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawX(1)
-                            } else {
-                                event.getX(1)
+                                event.getX(newPointerIndex)
                             },
-                            initialY = if (pointer == 0) if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawY(0)
+                            initialY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                event.getRawY(newPointerIndex)
                             } else {
-                                event.getY(0)
-                            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawY(1)
-                            } else {
-                                event.getY(1)
+                                event.getY(newPointerIndex)
                             },
                         )
                         setKeyPressed()
@@ -1176,8 +1191,7 @@ class GojuonKeyboardView @JvmOverloads constructor(
                     if (event.pointerCount == 2) {
                         if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
                             resetLongPressAction()
-                            val gestureType =
-                                getGestureType(event, event.getPointerId(event.actionIndex))
+                            val gestureType = getGestureType(event, event.actionIndex)
                             val keyInfo = currentInputMode.get()
                                 .next(keyMap = keyMap, key = pressedKey.key, isGojuon = true)
                             if (keyInfo == KeyInfo.Null) {
@@ -1188,17 +1202,7 @@ class GojuonKeyboardView @JvmOverloads constructor(
                                     handleClickInputModeSwitch()
                                 }
                             } else if (keyInfo is KeyInfo.KeyTapFlickInfo) {
-                                val capState = gojuonCapsLockState.value
-                                val outputChar = keyInfo.getOutputChar(capState)
-                                when (gestureType) {
-                                    GestureType.Null -> {}
-                                    GestureType.Down -> {}
-                                    GestureType.Tap, GestureType.FlickLeft, GestureType.FlickTop, GestureType.FlickRight, GestureType.FlickBottom -> flickListener?.onFlick(
-                                        gestureType = gestureType,
-                                        key = pressedKey.key,
-                                        char = outputChar,
-                                    )
-                                }
+                                dispatchKeyInfoGesture(keyInfo, gestureType)
                             }
                             val button = getButtonFromKey(pressedKey.key)
                             if (currentInputMode.get() == InputMode.ModeEnglish && gojuonCapsLockState.value.capsLockOn) {
@@ -3368,7 +3372,7 @@ class GojuonKeyboardView @JvmOverloads constructor(
         }
     }
 
-    private fun setFlickActionPointerDown(keyInfo: KeyInfo, gestureType: GestureType) {
+    private fun dispatchKeyInfoGesture(keyInfo: KeyInfo, gestureType: GestureType) {
         if (keyInfo is KeyInfo.KeyTapFlickInfo) {
             val charToSend = if (currentInputMode.get() == InputMode.ModeEnglish) {
                 val capState = gojuonCapsLockState.value

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -13,7 +13,6 @@ import android.graphics.Typeface
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
-import android.os.Build
 import android.os.SystemClock
 import android.text.Spannable
 import android.text.SpannableString
@@ -58,10 +57,12 @@ import com.kazumaproject.core.domain.extensions.setMarginStart
 import com.kazumaproject.core.domain.extensions.toZenkaku
 import com.kazumaproject.core.domain.flick.FlickDirection as CoreFlickDirection
 import com.kazumaproject.core.domain.flick.FlickGestureMath
+import com.kazumaproject.core.domain.touch.PointerEventResolver
 import com.kazumaproject.core.domain.flick.FlickThresholdShape
 import com.kazumaproject.core.domain.listener.QWERTYKeyListener
 import com.kazumaproject.core.domain.listener.KeyTouchCancelReason
 import com.kazumaproject.core.domain.listener.QwertyKeyTouchCancelListener
+import com.kazumaproject.core.domain.touch.PointerGestureTrace
 import com.kazumaproject.core.domain.qwerty.QWERTYKey
 import com.kazumaproject.core.domain.qwerty.QWERTYKeyInfo
 import com.kazumaproject.core.domain.qwerty.QWERTYKeyMap
@@ -135,6 +136,11 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     private val hitRect = Rect()
     private val keyScreenLocation = IntArray(2)
     private val touchStreamKeyBounds = linkedMapOf<View, Rect>()
+    // Glide points are delivered to the decoder and drawn on this view's local canvas. Keep the
+    // screen origin captured with the frozen key geometry so a moving IME window cannot change
+    // the coordinate transform in the middle of a touch stream.
+    private var touchStreamOriginX = 0f
+    private var touchStreamOriginY = 0f
 
     private var qwertyKeyListener: QWERTYKeyListener? = null
     private var qwertyKeyTouchCancelListener: QwertyKeyTouchCancelListener? = null
@@ -240,6 +246,14 @@ class QWERTYKeyboardView @JvmOverloads constructor(
      * 上フリックジェスチャー中として「ロック」されたポインターIDのセット
      */
     private val flickLockedPointers = mutableSetOf<Int>()
+
+    /**
+     * Pointers that left their original key without producing a flick.
+     *
+     * The original key remains the owner of the stream, but a cancelled pointer must not be
+     * converted into a tap when it is released outside that key.
+     */
+    private val cancelledPointerIds = mutableSetOf<Int>()
 
     /** Persisted 1..200 sensitivity setting and its density-scaled runtime threshold. */
     private var flickSensitivity = 100
@@ -1379,10 +1393,21 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                 else -> zRowLetterViews.indexOf(view)
             }
             val ch = view.text?.firstOrNull()?.lowercaseChar() ?: ('a' + index)
+            val displayBounds = displayBoundsForTouchStream(view)
+            val localLeft = if (touchStreamKeyBounds.isNotEmpty() && displayBounds != null) {
+                displayBounds.left - touchStreamOriginX
+            } else {
+                view.left.toFloat()
+            }
+            val localTop = if (touchStreamKeyBounds.isNotEmpty() && displayBounds != null) {
+                displayBounds.top - touchStreamOriginY
+            } else {
+                view.top.toFloat()
+            }
             QwertyKeyProximity(
                 char = ch,
-                centerX = view.left + view.width / 2f,
-                centerY = view.top + view.height / 2f,
+                centerX = localLeft + view.width / 2f,
+                centerY = localTop + view.height / 2f,
                 width = view.width.toFloat(),
                 height = view.height.toFloat(),
                 rowIndex = row,
@@ -1425,6 +1450,12 @@ class QWERTYKeyboardView @JvmOverloads constructor(
 
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
+        PointerGestureTrace.log(
+            "view",
+            "surface=QWERTY action=" + MotionEvent.actionToString(event.actionMasked) +
+                " actionIndex=" + event.actionIndex +
+                " pointers=" + PointerEventResolver.describe(event),
+        )
 
         if (isCursorMode) {
             when (event.actionMasked) {
@@ -1480,8 +1511,9 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             }
 
             MotionEvent.ACTION_POINTER_DOWN -> {
-                val newPointerIndex = event.actionIndex
-                val newPointerId = event.getPointerId(newPointerIndex)
+                val newPointer = PointerEventResolver.actionPointer(event) ?: return true
+                val newPointerIndex = newPointer.pointerIndex
+                val newPointerId = newPointer.pointerId
 
                 if (variationPopup?.isShowing == true) {
                     val variationPointerId = longPressedPointerId
@@ -1556,8 +1588,9 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             }
 
             MotionEvent.ACTION_POINTER_UP -> {
-                val pointerIndex = event.actionIndex
-                val pointerId = event.getPointerId(pointerIndex)
+                val liftedPointer = PointerEventResolver.actionPointer(event) ?: return true
+                val pointerIndex = liftedPointer.pointerIndex
+                val pointerId = liftedPointer.pointerId
 
                 if (variationPopup?.isShowing == true && pointerId == longPressedPointerId) {
                     finishVariationGesture(pointerId = pointerId, commitSelection = true)
@@ -1572,7 +1605,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             }
 
             MotionEvent.ACTION_UP -> {
-                val liftedId = event.getPointerId(event.actionIndex)
+                val liftedPointer = PointerEventResolver.actionPointer(event) ?: return true
+                val liftedId = liftedPointer.pointerId
                 val variationCommitted =
                     variationPopup?.isShowing == true &&
                         liftedId == longPressedPointerId &&
@@ -1583,8 +1617,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                 if (!variationCommitted) {
                     finishTrackedPointer(
                         pointerId = liftedId,
-                        x = event.displayX(event.actionIndex),
-                        y = event.displayY(event.actionIndex)
+                        x = liftedPointer.screenX,
+                        y = liftedPointer.screenY
                     )
                 }
                 clearAllPressed(clearSuppressedPointers = false)
@@ -1602,19 +1636,11 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     }
 
     private fun MotionEvent.displayX(pointerIndex: Int): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            getRawX(pointerIndex)
-        } else {
-            getX(pointerIndex) + rawX - x
-        }
+        return PointerEventResolver.screenX(this, pointerIndex)
     }
 
     private fun MotionEvent.displayY(pointerIndex: Int): Float {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            getRawY(pointerIndex)
-        } else {
-            getY(pointerIndex) + rawY - y
-        }
+        return PointerEventResolver.screenY(this, pointerIndex)
     }
 
     private fun handleQwertyGlideTouchEvent(event: MotionEvent): Boolean {
@@ -1651,8 +1677,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                     cancelQwertyGlideCandidate(notify = glideStarted)
                     return true
                 }
-                val x = event.getX(pointerIndex)
-                val y = event.getY(pointerIndex)
+                val x = event.displayX(pointerIndex)
+                val y = event.displayY(pointerIndex)
                 val keyHit = classifyQwertyGlideKeyHit(x, y)
                 val moveHandling = QwertyGlideKeyClassifier.decideMoveHandling(
                     glidePointerId = glideCandidatePointerId,
@@ -1753,9 +1779,13 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     }
 
     private fun beginQwertyGlideCandidateIfPossible(event: MotionEvent, pointerIndex: Int) {
-        val pointerId = event.getPointerId(pointerIndex)
-        val x = event.getX(pointerIndex)
-        val y = event.getY(pointerIndex)
+        val pointer = PointerEventResolver.at(event, pointerIndex) ?: return
+        val pointerId = pointer.pointerId
+        if (touchStreamKeyBounds.isEmpty()) {
+            captureTouchStreamKeyBounds()
+        }
+        val x = pointer.screenX
+        val y = pointer.screenY
         if (findExactQwertyGlideLetterViewUnder(x, y) == null) return
         if (SystemClock.uptimeMillis() - lastNonGlideKeyUpTime < glideFastTypingSuppressMillis) return
 
@@ -1764,8 +1794,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         glideDownTime = event.eventTime
         glideRawPoints.clear()
         glideTrailPoints.clear()
-        glideLastSampleX = x
-        glideLastSampleY = y
+        glideLastSampleX = x - touchStreamOriginX
+        glideLastSampleY = y - touchStreamOriginY
         appendQwertyGlidePoint(x, y, event.eventTime, pointerId, force = true)
     }
 
@@ -1792,17 +1822,18 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         y: Float
     ): Boolean {
         val pressedView = pointerButtonMap[pointerId] ?: return false
-        pressedView.getHitRect(glideHitRect)
-        glideHitRect.inset(-pendingGlideLongPressSlop, -pendingGlideLongPressSlop)
-        return glideHitRect.contains(x.toInt(), y.toInt())
+        val bounds = displayBoundsForTouchStream(pressedView)?.let(::Rect) ?: return false
+        bounds.inset(-pendingGlideLongPressSlop, -pendingGlideLongPressSlop)
+        return bounds.contains(x.toInt(), y.toInt())
     }
 
     private fun handleQwertyGlidePointerUp(event: MotionEvent): Boolean {
         val pointerId = glideCandidatePointerId ?: return false
-        val liftedId = event.getPointerId(event.actionIndex)
+        val liftedPointer = PointerEventResolver.actionPointer(event) ?: return false
+        val liftedId = liftedPointer.pointerId
         if (liftedId != pointerId) return false
-        val upX = event.getX(event.actionIndex)
-        val upY = event.getY(event.actionIndex)
+        val upX = liftedPointer.screenX
+        val upY = liftedPointer.screenY
         if (findExactQwertyGlideLetterViewUnder(upX, upY) != null) {
             appendQwertyGlidePoint(
                 x = upX,
@@ -1847,8 +1878,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         pointerId: Int
     ) {
         for (historyIndex in 0 until event.historySize) {
-            val hx = event.getHistoricalX(pointerIndex, historyIndex)
-            val hy = event.getHistoricalY(pointerIndex, historyIndex)
+            val hx = PointerEventResolver.historicalScreenX(event, pointerIndex, historyIndex)
+            val hy = PointerEventResolver.historicalScreenY(event, pointerIndex, historyIndex)
             if (findExactQwertyGlideLetterViewUnder(hx, hy) == null) {
                 continue
             }
@@ -1868,21 +1899,25 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         pointerId: Int,
         force: Boolean = false
     ) {
-        if (!force && hypot(x - glideLastSampleX, y - glideLastSampleY) < glideSamplingMinDistance) {
+        val localX = x - touchStreamOriginX
+        val localY = y - touchStreamOriginY
+        if (!force &&
+            hypot(localX - glideLastSampleX, localY - glideLastSampleY) < glideSamplingMinDistance
+        ) {
             return
         }
-        glideLastSampleX = x
-        glideLastSampleY = y
+        glideLastSampleX = localX
+        glideLastSampleY = localY
         val relativeTime = (eventTime - glideDownTime).coerceIn(0L, Int.MAX_VALUE.toLong()).toInt()
         glideRawPoints.add(
             QwertyInputPointerPoint(
-                x = x.toInt(),
-                y = y.toInt(),
+                x = localX.toInt(),
+                y = localY.toInt(),
                 time = relativeTime,
                 pointerId = pointerId
             )
         )
-        glideTrailPoints.add(x to y)
+        glideTrailPoints.add(localX to localY)
         invalidate()
     }
 
@@ -2065,11 +2100,12 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     }
 
     private fun handlePointerDown(event: MotionEvent, pointerIndex: Int) {
-        val pid = event.getPointerId(pointerIndex)
+        val pointer = PointerEventResolver.at(event, pointerIndex) ?: return
+        val pid = pointer.pointerId
         if (suppressedPointerIds.contains(pid)) return
 
-        val displayX = event.displayX(pointerIndex)
-        val displayY = event.displayY(pointerIndex)
+        val displayX = pointer.screenX
+        val displayY = pointer.screenY
 
         // The IME window can grow when the first candidate row appears. Local coordinates then
         // jump even though the finger has not moved, so gesture deltas must stay in display space.
@@ -2085,6 +2121,11 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         val view = findButtonUnderDisplay(displayX, displayY)
         view?.let {
             val qwertyKey = qwertyButtonMap[it]
+            PointerGestureTrace.log(
+                "gesture",
+                "surface=QWERTY down pointerId=" + pid +
+                    " key=" + qwertyKey,
+            )
             qwertyKey?.let { key ->
                 qwertyKeyListener?.onPressedQWERTYKey(key)
             }
@@ -2133,6 +2174,13 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         y: Float,
         classifyFlick: Boolean = true,
     ) {
+        if (cancelledPointerIds.remove(pointerId)) {
+            pointerButtonMap.remove(pointerId)
+            pointerStartCoords.remove(pointerId)
+            flickLockedPointers.remove(pointerId)
+            cancelLongPressForPointer(pointerId)
+            return
+        }
         if (suppressedPointerIds.remove(pointerId)) {
             pointerButtonMap.remove(pointerId)
             pointerStartCoords.remove(pointerId)
@@ -2148,6 +2196,12 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             tryHandleFlickAt(pointerId = pointerId, x = x, y = y)
         }
         val wasFlick = flickLockedPointers.contains(pointerId)
+        PointerGestureTrace.log(
+            "gesture",
+            "surface=QWERTY up pointerId=" + pointerId +
+                " key=" + pointerButtonMap[pointerId]?.let(qwertyButtonMap::get) +
+                " flick=" + wasFlick,
+        )
         pointerStartCoords.remove(pointerId)
 
         if (!wasFlick) {
@@ -2356,35 +2410,17 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             return
         }
 
-        val currentView = findButtonUnderDisplay(displayX, displayY)
-        if (currentView != previousView) {
-            previousView?.let {
-                it.isPressed = false
+        if (previousView != null && findButtonUnderDisplay(displayX, displayY) != previousView) {
+            if (cancelledPointerIds.add(pointerId)) {
+                previousView.isPressed = false
                 dismissKeyPreview()
                 cancelLongPressForPointer(pointerId)
-            }
-            currentView?.let {
-                it.isPressed = true
-                pointerButtonMap.put(pointerId, it)
-                pointerStartCoords.put(pointerId, Pair(displayX, displayY))
-
-                if (it.id != binding.keySpace.id &&
-                    it.id != binding.keyDelete.id &&
-                    it.id != binding.keyShift.id &&
-                    it.id != binding.key123.id &&
-                    it.id != binding.keyReturn.id &&
-                    it.id != binding.keySwitchDefault.id &&
-                    it.id != binding.keyEmoji.id &&
-                    it.id != binding.switchNumberLayout.id &&
-                    it.id != binding.cursorRight.id &&
-                    it.id != binding.cursorLeft.id
-                ) {
-                    showKeyPreview(it)
-                }
-            } ?: run {
+                notifyQwertyTouchCanceledForPointer(
+                    pointerId,
+                    KeyTouchCancelReason.PointerInterrupted,
+                )
                 pointerButtonMap.remove(pointerId)
                 pointerStartCoords.remove(pointerId)
-                cancelLongPressForPointer(pointerId)
             }
         }
     }
@@ -2395,7 +2431,13 @@ class QWERTYKeyboardView @JvmOverloads constructor(
 
         val (startX, startY) = pointerStartCoords[pointerId] ?: return false
         val previousView = pointerButtonMap[pointerId]
-        return when (detectFlickDirection(x, y, startX, startY, flickThreshold)) {
+        val direction = detectFlickDirection(x, y, startX, startY, flickThreshold)
+        PointerGestureTrace.log(
+            "gesture",
+            "surface=QWERTY direction pointerId=" + pointerId +
+                " direction=" + direction,
+        )
+        return when (direction) {
             FlickDirection.UP -> {
                 when {
                     enableDeleteUpFlick &&
@@ -2464,7 +2506,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         pointerButtonMap.clear()
         pointerStartCoords.clear()
         flickLockedPointers.clear()
+        cancelledPointerIds.clear()
         touchStreamKeyBounds.clear()
+        touchStreamOriginX = 0f
+        touchStreamOriginY = 0f
         dismissKeyPreview()
         if (clearSuppressedPointers) {
             suppressedPointerIds.clear()
@@ -2641,6 +2686,9 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     /** Freeze key geometry until every finger in the current touch stream has lifted. */
     private fun captureTouchStreamKeyBounds() {
         touchStreamKeyBounds.clear()
+        getLocationOnScreen(keyScreenLocation)
+        touchStreamOriginX = keyScreenLocation[0].toFloat()
+        touchStreamOriginY = keyScreenLocation[1].toFloat()
         qwertyButtonMap.keys.forEach { child ->
             if (!child.isVisible || child.width <= 0 || child.height <= 0) return@forEach
             child.getLocationOnScreen(keyScreenLocation)
@@ -2665,12 +2713,17 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     }
 
     private fun View.toQwertyGlideKeyRect(): QwertyGlideKeyClassifier.KeyRect {
-        getHitRect(glideHitRect)
+        val bounds = displayBoundsForTouchStream(this) ?: return QwertyGlideKeyClassifier.KeyRect(
+            left = 0,
+            top = 0,
+            right = 0,
+            bottom = 0,
+        )
         return QwertyGlideKeyClassifier.KeyRect(
-            left = glideHitRect.left,
-            top = glideHitRect.top,
-            right = glideHitRect.right,
-            bottom = glideHitRect.bottom
+            left = bounds.left,
+            top = bounds.top,
+            right = bounds.right,
+            bottom = bounds.bottom
         )
     }
 
@@ -2712,9 +2765,20 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         val yi = y.toInt()
         return getVisibleQwertyLetterViews().firstOrNull { key ->
             if (!key.isVisible) return@firstOrNull false
-            key.getHitRect(glideHitRect)
-            glideHitRect.contains(xi, yi)
+            displayBoundsForTouchStream(key)?.contains(xi, yi) == true
         }
+    }
+
+    private fun displayBoundsForTouchStream(view: View): Rect? {
+        touchStreamKeyBounds[view]?.let { return it }
+        if (!view.isVisible || view.width <= 0 || view.height <= 0) return null
+        view.getLocationOnScreen(keyScreenLocation)
+        return Rect(
+            keyScreenLocation[0],
+            keyScreenLocation[1],
+            keyScreenLocation[0] + view.width,
+            keyScreenLocation[1] + view.height,
+        )
     }
 
     override fun dispatchDraw(canvas: Canvas) {

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -133,6 +133,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
 
     private var keyPreviewPopup: PopupWindow? = null
     private val hitRect = Rect()
+    private val keyScreenLocation = IntArray(2)
+    private val touchStreamKeyBounds = linkedMapOf<View, Rect>()
 
     private var qwertyKeyListener: QWERTYKeyListener? = null
     private var qwertyKeyTouchCancelListener: QwertyKeyTouchCancelListener? = null
@@ -1473,6 +1475,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                     clearAllPressed()
                 }
                 suppressedPointerIds.clear()
+                captureTouchStreamKeyBounds()
                 handlePointerDown(event, pointerIndex = 0)
             }
 
@@ -1519,8 +1522,9 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                         if (pointerIndex >= 0) {
                             finishTrackedPointer(
                                 pointerId = pointerId,
-                                x = event.getX(pointerIndex),
-                                y = event.getY(pointerIndex)
+                                x = event.displayX(pointerIndex),
+                                y = event.displayY(pointerIndex),
+                                classifyFlick = false,
                             )
                         }
                     }
@@ -1562,8 +1566,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
 
                 finishTrackedPointer(
                     pointerId = pointerId,
-                    x = event.getX(pointerIndex),
-                    y = event.getY(pointerIndex)
+                    x = event.displayX(pointerIndex),
+                    y = event.displayY(pointerIndex)
                 )
             }
 
@@ -1579,8 +1583,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
                 if (!variationCommitted) {
                     finishTrackedPointer(
                         pointerId = liftedId,
-                        x = event.getX(event.actionIndex),
-                        y = event.getY(event.actionIndex)
+                        x = event.displayX(event.actionIndex),
+                        y = event.displayY(event.actionIndex)
                     )
                 }
                 clearAllPressed(clearSuppressedPointers = false)
@@ -2054,13 +2058,21 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         val pid = event.getPointerId(pointerIndex)
         if (suppressedPointerIds.contains(pid)) return
 
-        val x = event.getX(pointerIndex)
-        val y = event.getY(pointerIndex)
+        val displayX = event.displayX(pointerIndex)
+        val displayY = event.displayY(pointerIndex)
 
-        pointerStartCoords.put(pid, Pair(x, y))
+        // The IME window can grow when the first candidate row appears. Local coordinates then
+        // jump even though the finger has not moved, so gesture deltas must stay in display space.
+        pointerStartCoords.put(
+            pid,
+            Pair(displayX, displayY)
+        )
         flickLockedPointers.remove(pid)
 
-        val view = findButtonUnder(x.toInt(), y.toInt())
+        // Resolve the key in display space as well. When the candidate row first appears the IME
+        // window is resized, and for a short transition its local MotionEvent coordinates can be
+        // based on the previous window origin. That used to turn an A/H/W press into 1/Y/etc.
+        val view = findButtonUnderDisplay(displayX, displayY)
         view?.let {
             val qwertyKey = qwertyButtonMap[it]
             qwertyKey?.let { key ->
@@ -2108,7 +2120,8 @@ class QWERTYKeyboardView @JvmOverloads constructor(
     private fun finishTrackedPointer(
         pointerId: Int,
         x: Float,
-        y: Float
+        y: Float,
+        classifyFlick: Boolean = true,
     ) {
         if (suppressedPointerIds.remove(pointerId)) {
             pointerButtonMap.remove(pointerId)
@@ -2118,7 +2131,10 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             return
         }
 
-        if (!flickLockedPointers.contains(pointerId)) {
+        // ACTION_POINTER_DOWN ends the older key for chorded typing, but it is not a movement or
+        // terminal event for that finger. Its coordinate sample can be translated while the IME
+        // window is resizing, so only MOVE/UP paths are allowed to infer a previously unseen flick.
+        if (classifyFlick && !flickLockedPointers.contains(pointerId)) {
             tryHandleFlickAt(pointerId = pointerId, x = x, y = y)
         }
         val wasFlick = flickLockedPointers.contains(pointerId)
@@ -2322,15 +2338,15 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         if (suppressedPointerIds.contains(pointerId) || pointerId == lockedPointerId) return
         if (flickLockedPointers.contains(pointerId)) return
 
-        val x = event.getX(pointerIndex)
-        val y = event.getY(pointerIndex)
+        val displayX = event.displayX(pointerIndex)
+        val displayY = event.displayY(pointerIndex)
         val previousView = pointerButtonMap[pointerId]
 
-        if (tryHandleFlickAt(pointerId, x, y)) {
+        if (tryHandleFlickAt(pointerId, displayX, displayY)) {
             return
         }
 
-        val currentView = findButtonUnder(x.toInt(), y.toInt())
+        val currentView = findButtonUnderDisplay(displayX, displayY)
         if (currentView != previousView) {
             previousView?.let {
                 it.isPressed = false
@@ -2340,7 +2356,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             currentView?.let {
                 it.isPressed = true
                 pointerButtonMap.put(pointerId, it)
-                pointerStartCoords.put(pointerId, Pair(x, y))
+                pointerStartCoords.put(pointerId, Pair(displayX, displayY))
 
                 if (it.id != binding.keySpace.id &&
                     it.id != binding.keyDelete.id &&
@@ -2438,6 +2454,7 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         pointerButtonMap.clear()
         pointerStartCoords.clear()
         flickLockedPointers.clear()
+        touchStreamKeyBounds.clear()
         dismissKeyPreview()
         if (clearSuppressedPointers) {
             suppressedPointerIds.clear()
@@ -2576,6 +2593,54 @@ class QWERTYKeyboardView @JvmOverloads constructor(
             }
         }
         return nearestView
+    }
+
+    /**
+     * Display-coordinate counterpart of [findButtonUnder].
+     *
+     * InputMethod windows can change their origin while a candidate row is being attached. Key
+     * views already expose their current display bounds at that point, so matching raw pointer
+     * coordinates against those bounds avoids routing a press through a stale window transform.
+     */
+    private fun findButtonUnderDisplay(x: Float, y: Float): View? {
+        val displayX = x.toInt()
+        val displayY = y.toInt()
+        var nearestView: View? = null
+        var minDistSquared = Long.MAX_VALUE
+
+        val bounds = touchStreamKeyBounds.ifEmpty {
+            captureTouchStreamKeyBounds()
+            touchStreamKeyBounds
+        }
+        bounds.forEach { (child, rect) ->
+            if (rect.contains(displayX, displayY)) return child
+
+            val centerX = rect.centerX()
+            val centerY = rect.centerY()
+            val dx = (displayX - centerX).toLong()
+            val dy = (displayY - centerY).toLong()
+            val distSquared = dx * dx + dy * dy
+            if (distSquared < minDistSquared) {
+                minDistSquared = distSquared
+                nearestView = child
+            }
+        }
+        return nearestView
+    }
+
+    /** Freeze key geometry until every finger in the current touch stream has lifted. */
+    private fun captureTouchStreamKeyBounds() {
+        touchStreamKeyBounds.clear()
+        qwertyButtonMap.keys.forEach { child ->
+            if (!child.isVisible || child.width <= 0 || child.height <= 0) return@forEach
+            child.getLocationOnScreen(keyScreenLocation)
+            touchStreamKeyBounds[child] = Rect(
+                keyScreenLocation[0],
+                keyScreenLocation[1],
+                keyScreenLocation[0] + child.width,
+                keyScreenLocation[1] + child.height,
+            )
+        }
     }
 
     private fun getVisibleQwertyLetterViews(): List<QWERTYButton> {

--- a/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
+++ b/qwerty_keyboard/src/main/java/com/kazumaproject/qwerty_keyboard/ui/QWERTYKeyboardView.kt
@@ -1945,6 +1945,16 @@ class QWERTYKeyboardView @JvmOverloads constructor(
         }
     }
 
+    fun resetTouchStateForFastInputTest() {
+        notifyQwertyTouchCanceledForActivePointers(KeyTouchCancelReason.ActionCancel)
+        setCursorMode(false)
+        dismissVariationPopup()
+        cancelQwertyGlideCandidate(notify = false)
+        clearAllPressed()
+        suppressedPointerIds.clear()
+        lastNonGlideKeyUpTime = 0L
+    }
+
     private fun clearPendingQwertyGlideCandidateForLongPress(pointerId: Int) {
         if (glideCandidatePointerId == pointerId && !glideStarted) {
             clearQwertyGlideState(clearTrail = true)

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -1031,6 +1031,22 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                 setMaterialYouTheme(this.isNightMode, true)
             }
         }
+        configurePopupWindowsAsInputTransparent()
+    }
+
+    private fun configurePopupWindowsAsInputTransparent() {
+        listOf(
+            popupWindowActive,
+            popupWindowLeft,
+            popupWindowTop,
+            popupWindowRight,
+            popupWindowBottom,
+            popupWindowCenter,
+        ).forEach { popup ->
+            popup.isTouchable = false
+            popup.isFocusable = false
+            popup.isOutsideTouchable = false
+        }
     }
 
     /**
@@ -1434,22 +1450,24 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
             }
             when (event.action and MotionEvent.ACTION_MASK) {
                 MotionEvent.ACTION_DOWN -> {
-                    val key = pressedKeyByMotionEvent(event, 0)
+                    val pointerIndex = event.actionIndex
+                    val pointerId = event.getPointerId(pointerIndex)
+                    val key = pressedKeyByMotionEvent(event, pointerIndex)
                     flickListener?.onFlick(GestureType.Down, key, null)
 
                     pressedKey = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         PressedKey(
                             key = key,
-                            pointer = 0,
-                            initialX = event.getRawX(event.actionIndex),
-                            initialY = event.getRawY(event.actionIndex),
+                            pointer = pointerId,
+                            initialX = event.getRawX(pointerIndex),
+                            initialY = event.getRawY(pointerIndex),
                         )
                     } else {
                         PressedKey(
                             key = key,
-                            pointer = 0,
-                            initialX = event.getX(event.actionIndex),
-                            initialY = event.getY(event.actionIndex),
+                            pointer = pointerId,
+                            initialX = event.getX(pointerIndex),
+                            initialY = event.getY(pointerIndex),
                         )
                     }
 
@@ -1495,7 +1513,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                     }
 
                     if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
-                        val gestureType = getGestureType(event)
+                        val gestureType = getGestureType(event, event.actionIndex)
                         Log.d("TenKey: ACTION_UP in pointer", "called $pressedKey")
 
                         dispatchResolvedGesture(pressedKey.key, gestureType)
@@ -1517,15 +1535,17 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                 }
 
                 MotionEvent.ACTION_MOVE -> {
+                    val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                    if (trackedPointerIndex < 0) {
+                        cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
+                        return true
+                    }
                     if (isCursorMode) {
                         // sensitivity threshold in pixels
                         val threshold = 16f
 
-                        // 1) get the tracked pointer index
-                        val pointer = pressedKey.pointer
-
                         // 2) read its current raw X–Y
-                        val (currentX, currentY) = getRawCoordinates(event, pointer)
+                        val (currentX, currentY) = getRawCoordinates(event, trackedPointerIndex)
 
                         // 3) compute delta since last origin
                         val dx = currentX - pressedKey.initialX
@@ -1567,11 +1587,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         return true
                     }
 
-                    val gestureType = if (event.pointerCount == 1) {
-                        getGestureType(event, 0)
-                    } else {
-                        getGestureType(event, pressedKey.pointer)
-                    }
+                    val gestureType = getGestureType(event, trackedPointerIndex)
                     flickTextPreviewEmitter.update(
                         resolveTextSelection(pressedKey.key, gestureType)
                     )
@@ -1609,11 +1625,15 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                     }
                     if (event.pointerCount == 2) {
                         isLongPressed = false
-                        val pointer = event.getPointerId(event.actionIndex)
-                        val key = pressedKeyByMotionEvent(event, pointer)
-                        val gestureType2 = getGestureType(
-                            event, if (pointer == 0) 1 else 0
-                        )
+                        val newPointerIndex = event.actionIndex
+                        val newPointerId = event.getPointerId(newPointerIndex)
+                        val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                        if (trackedPointerIndex < 0) {
+                            cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
+                            return true
+                        }
+                        val key = pressedKeyByMotionEvent(event, newPointerIndex)
+                        val gestureType2 = getGestureType(event, trackedPointerIndex)
                         if (pressedKey.key == Key.KeyDakutenSmall && currentInputMode.value == InputMode.ModeNumber) {
                             setNumberSmallKeyPresentation()
                         }
@@ -1622,31 +1642,18 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                             setTextForMode(button, currentInputMode.value)
                         }
                         pressedKey = pressedKey.copy(
-                            key = key, pointer = pointer, initialX = if (pointer == 0) {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                    event.getRawX(0)
-                                } else {
-                                    event.getX(0)
-                                }
+                            key = key,
+                            pointer = newPointerId,
+                            initialX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                event.getRawX(newPointerIndex)
                             } else {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                    event.getRawX(1)
-                                } else {
-                                    event.getX(1)
-                                }
-                            }, initialY = if (pointer == 0) {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                    event.getRawY(0)
-                                } else {
-                                    event.getY(0)
-                                }
+                                event.getX(newPointerIndex)
+                            },
+                            initialY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                event.getRawY(newPointerIndex)
                             } else {
-                                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                    event.getRawY(1)
-                                } else {
-                                    event.getY(1)
-                                }
-                            }
+                                event.getY(newPointerIndex)
+                            },
                         )
                         setKeyPressed()
                         flickTextPreviewEmitter.begin(
@@ -1669,9 +1676,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
                             resetLongPressAction()
                             if (isCursorMode) return true
-                            val gestureType = getGestureType(
-                                event, event.getPointerId(event.actionIndex)
-                            )
+                            val gestureType = getGestureType(event, event.actionIndex)
                             Log.d("TenKey: ACTION_POINTER_UP", "called [${pressedKey.key}]")
                             dispatchResolvedGesture(pressedKey.key, gestureType)
                             val button = getButtonFromKey(pressedKey.key)

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -46,6 +46,8 @@ import com.kazumaproject.core.domain.state.PressedKey
 import com.kazumaproject.core.domain.state.TwoStateNumberReturnTarget
 import com.kazumaproject.core.domain.state.toInputMode
 import com.kazumaproject.core.domain.state.toTwoStateNumberReturnTargetOrNull
+import com.kazumaproject.core.domain.touch.PointerEventResolver
+import com.kazumaproject.core.domain.touch.PointerGestureTrace
 import com.kazumaproject.core.data.popup.PopupViewStyle
 import com.kazumaproject.core.domain.flick.FlickDirection as CoreFlickDirection
 import com.kazumaproject.core.domain.flick.FlickGestureMath
@@ -1449,31 +1451,29 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouch(view: View?, event: MotionEvent?): Boolean {
         if (view != null && event != null) {
+            PointerGestureTrace.log(
+                "view",
+                "surface=TENKEY action=" + MotionEvent.actionToString(event.actionMasked) +
+                    " actionIndex=" + event.actionIndex +
+                    " pointers=" + PointerEventResolver.describe(event),
+            )
             if (view.visibility != View.VISIBLE) {
                 return false
             }
             when (event.action and MotionEvent.ACTION_MASK) {
                 MotionEvent.ACTION_DOWN -> {
                     val pointerIndex = event.actionIndex
-                    val pointerId = event.getPointerId(pointerIndex)
+                    val pointer = PointerEventResolver.at(event, pointerIndex) ?: return true
+                    val pointerId = pointer.pointerId
                     val key = pressedKeyByMotionEvent(event, pointerIndex)
                     flickListener?.onFlick(GestureType.Down, key, null)
 
-                    pressedKey = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        PressedKey(
-                            key = key,
-                            pointer = pointerId,
-                            initialX = event.getRawX(pointerIndex),
-                            initialY = event.getRawY(pointerIndex),
-                        )
-                    } else {
-                        PressedKey(
-                            key = key,
-                            pointer = pointerId,
-                            initialX = event.getX(pointerIndex),
-                            initialY = event.getY(pointerIndex),
-                        )
-                    }
+                    pressedKey = PressedKey(
+                        key = key,
+                        pointerId = pointerId,
+                        initialX = pointer.screenX,
+                        initialY = pointer.screenY,
+                    )
 
                     if (isCursorMode) {
                         flickTextPreviewEmitter.cancel()
@@ -1516,8 +1516,11 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         return false
                     }
 
-                    if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
-                        val gestureType = getGestureType(event, event.actionIndex)
+                    val liftedPointer = PointerEventResolver.actionPointer(event)
+                    if (liftedPointer != null &&
+                        pressedKey.pointerId == liftedPointer.pointerId
+                    ) {
+                        val gestureType = getGestureType(event, liftedPointer.pointerIndex)
                         Log.d("TenKey: ACTION_UP in pointer", "called $pressedKey")
 
                         dispatchResolvedGesture(pressedKey.key, gestureType)
@@ -1539,7 +1542,7 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                 }
 
                 MotionEvent.ACTION_MOVE -> {
-                    val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                    val trackedPointerIndex = event.findPointerIndex(pressedKey.pointerId)
                     if (trackedPointerIndex < 0) {
                         cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
                         return true
@@ -1629,9 +1632,11 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                     }
                     if (event.pointerCount == 2) {
                         isLongPressed = false
-                        val newPointerIndex = event.actionIndex
-                        val newPointerId = event.getPointerId(newPointerIndex)
-                        val trackedPointerIndex = event.findPointerIndex(pressedKey.pointer)
+                        val newPointer = PointerEventResolver.actionPointer(event)
+                            ?: return true
+                        val newPointerIndex = newPointer.pointerIndex
+                        val newPointerId = newPointer.pointerId
+                        val trackedPointerIndex = event.findPointerIndex(pressedKey.pointerId)
                         if (trackedPointerIndex < 0) {
                             cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
                             return true
@@ -1647,17 +1652,9 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
                         }
                         pressedKey = pressedKey.copy(
                             key = key,
-                            pointer = newPointerId,
-                            initialX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawX(newPointerIndex)
-                            } else {
-                                event.getX(newPointerIndex)
-                            },
-                            initialY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                                event.getRawY(newPointerIndex)
-                            } else {
-                                event.getY(newPointerIndex)
-                            },
+                            pointerId = newPointerId,
+                            initialX = newPointer.screenX,
+                            initialY = newPointer.screenY,
                         )
                         setKeyPressed()
                         flickTextPreviewEmitter.begin(
@@ -1677,10 +1674,13 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
 
                 MotionEvent.ACTION_POINTER_UP -> {
                     if (event.pointerCount == 2) {
-                        if (pressedKey.pointer == event.getPointerId(event.actionIndex)) {
+                        val liftedPointer = PointerEventResolver.actionPointer(event)
+                        if (liftedPointer != null &&
+                            pressedKey.pointerId == liftedPointer.pointerId
+                        ) {
                             resetLongPressAction()
                             if (isCursorMode) return true
-                            val gestureType = getGestureType(event, event.actionIndex)
+                            val gestureType = getGestureType(event, liftedPointer.pointerIndex)
                             Log.d("TenKey: ACTION_POINTER_UP", "called [${pressedKey.key}]")
                             dispatchResolvedGesture(pressedKey.key, gestureType)
                             val button = getButtonFromKey(pressedKey.key)
@@ -2041,27 +2041,14 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
 
     /** Get absolute coordinates for the given pointer **/
     private fun getRawCoordinates(event: MotionEvent, pointer: Int): Pair<Float, Float> {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            event.getRawX(pointer) to event.getRawY(pointer)
-        } else {
-            val location = IntArray(2)
-            this.getLocationOnScreen(location)
-            (event.getX(pointer) + location[0]) to (event.getY(pointer) + location[1])
-        }
+        return PointerEventResolver.screenX(event, pointer) to
+            PointerEventResolver.screenY(event, pointer)
     }
 
     /** Determine whether the movement is a tap or a flick in a direction **/
     private fun getGestureType(event: MotionEvent, pointer: Int = 0): GestureType {
-        val finalX = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            event.getRawX(pointer)
-        } else {
-            event.getX(pointer)
-        }
-        val finalY = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            event.getRawY(pointer)
-        } else {
-            event.getY(pointer)
-        }
+        val finalX = PointerEventResolver.screenX(event, pointer)
+        val finalY = PointerEventResolver.screenY(event, pointer)
         val distanceX = finalX - pressedKey.initialX
         val distanceY = finalY - pressedKey.initialY
         return when (
@@ -2114,6 +2101,12 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
     }
 
     private fun dispatchResolvedGesture(key: Key, gestureType: GestureType) {
+        PointerGestureTrace.log(
+            "gesture",
+            "surface=TENKEY pointerId=" + pressedKey.pointerId +
+                " key=" + key +
+                " gesture=" + gestureType,
+        )
         val keyInfo = currentInputMode.value.next(
             keyMap = keyMap,
             key = key,

--- a/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
+++ b/tenkey/src/main/java/com/kazumaproject/tenkey/TenKey.kt
@@ -1420,6 +1420,10 @@ class TenKey(context: Context, attributeSet: AttributeSet) :
         scope.coroutineContext.cancelChildren()
     }
 
+    fun resetTouchStateForFastInputTest() {
+        cancelActiveTouch(KeyTouchCancelReason.ActionCancel)
+    }
+
     override fun onDetachedFromWindow() {
         super.onDetachedFromWindow()
         release()


### PR DESCRIPTION
## 日本語

### 概要

2本指で高速入力した際に、濁点や文字が欠落・誤入力される問題を修正します。TenKey・五十音・Sumire・QWERTY・ローマ字・カスタムレイアウトを対象に、候補欄の列数1・2・3を含む汎用的な高速入力回帰テストをCIへ追加します。

### 主な変更

- TenKey／五十音でpointer IDをpointer indexとして扱っていた箇所を修正
- フリックプレビューのPopupWindowを入力透過にし、マルチタッチストリームの分断を防止
- 五十音のACTION_POINTER_UPでフリック方向を正しく確定
- QWERTY／ローマ字で候補欄出現時のIME高さ変更に影響されない画面座標ベースのキー判定を導入
- 6キーボード × 候補列数1/2/3 × 6入力系列 × 7速度（120/60/30/16/8/4/0ms）の756ケースを追加
- 縦横画面、コールド／ウォーム入力、異なる指離し順、濁点・順逆・交互・反復・固定シード順列を網羅
- Fast Input Regression CIから新規テストと既存補助テストを実行し、実行上限を360分へ拡張

### 検証結果

- 実機 Pixel 6: 756/756ケース成功、失敗0
- 既存フルマトリクス: 144/144構成、288入力フェーズ成功
- Sumire速度スイープ: 800/800試行成功
- QWERTY重複2本指テスト: 成功
- `:app:testFullStandardDebugUnitTest`: 1411件、失敗0（4件スキップ）
- AndroidTest Kotlinコンパイル、Shell/YAML構文、`git diff --check`: 成功

## English

### Summary

Fixes dropped or incorrect characters, including dakuten input, during rapid two-finger typing. It also adds a general-purpose CI regression matrix covering TenKey, Gojuon, Sumire, QWERTY, Romaji, and custom layouts with candidate-column counts 1, 2, and 3.

### Key changes

- Fix pointer-ID versus pointer-index handling in TenKey and Gojuon
- Make flick-preview popup windows input-transparent so they do not interrupt multi-touch streams
- Resolve the actual flick direction on Gojuon ACTION_POINTER_UP
- Use display-space coordinates and frozen key bounds in QWERTY/Romaji while candidate-row changes resize the IME
- Add 756 generated cases: 6 keyboards × 3 candidate-column counts × 6 input sequences × 7 speeds (120/60/30/16/8/4/0ms)
- Cover portrait/landscape, cold/warm editor state, release ordering, dakuten, forward/reverse, alternating, repeated, and seeded permutations
- Run the generated matrix and existing focused regressions from Fast Input Regression CI, with a 360-minute timeout

### Verification

- Physical Pixel 6: 756/756 cases passed, 0 failures
- Existing full matrix: 144/144 configurations and 288 input phases passed
- Sumire rate sweep: 800/800 trials passed
- QWERTY overlapping two-finger test passed
- `:app:testFullStandardDebugUnitTest`: 1,411 tests, 0 failures (4 skipped)
- AndroidTest Kotlin compilation, shell/YAML syntax, and `git diff --check` passed