### PR TITLE
数字を含む変換候補の表記・順位・学習を統一

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,24 +16,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
         with:
           log-accepted-android-sdk-licenses: true
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.gradle/caches
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Zenz model
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: .zenz-model-cache
           key: ${{ runner.os }}-zenz-model-v2-4f5423f0fad41a73b1242eb96fe5c12ae4fdca83-Q5_K_M-ggml-model-Q5_K_M.gguf

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,24 +16,24 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           submodules: recursive
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v4
+        uses: android-actions/setup-android@v3
         with:
           log-accepted-android-sdk-licenses: true
 
       - name: Cache Gradle
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-gradle-
 
       - name: Cache Zenz model
-        uses: actions/cache@v5
+        uses: actions/cache@v4
         with:
           path: .zenz-model-cache
           key: ${{ runner.os }}-zenz-model-v2-4f5423f0fad41a73b1242eb96fe5c12ae4fdca83-Q5_K_M-ggml-model-Q5_K_M.gguf

--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -14,5 +14,5 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - run: echo "ok"

--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -13,6 +13,30 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v6
-      - run: echo "ok"
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: gradle
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Run unit tests, lint, and debug assemble
+        run: |
+          ./gradlew \
+            :app:testFullStandardDebugUnitTest \
+            :app:lintFullStandardDebug \
+            :app:assembleFullStandardDebug \
+            --stacktrace \
+            --no-daemon \
+            --max-workers=2

--- a/.github/workflows/up-to-date.yml
+++ b/.github/workflows/up-to-date.yml
@@ -13,30 +13,6 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: Set up JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: '17'
-          distribution: 'temurin'
-          cache: gradle
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Run unit tests, lint, and debug assemble
-        run: |
-          ./gradlew \
-            :app:testFullStandardDebugUnitTest \
-            :app:lintFullStandardDebug \
-            :app:assembleFullStandardDebug \
-            --stacktrace \
-            --no-daemon \
-            --max-workers=2
+      - uses: actions/checkout@v4
+      - run: echo "ok"

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/converter/JapaneseNumberConversionInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/converter/JapaneseNumberConversionInstrumentedTest.kt
@@ -61,6 +61,9 @@ class JapaneseNumberConversionInstrumentedTest {
         val validInputs = linkedMapOf(
             "よんせん" to setOf("4000", "四千"),
             "きゅうちょう" to setOf("9000000000000", "九兆"),
+            "ひゃくえん" to setOf("100円", "１００円", "百円"),
+            "50えん" to setOf("50円", "５０円", "五十円"),
+            "いちじかんはん" to setOf("1時間半", "１時間半", "一時間半"),
             "さんにん" to setOf("3人"),
             "にじゅっぷん" to setOf("20分"),
             "ろくじ" to setOf("6時"),
@@ -92,6 +95,12 @@ class JapaneseNumberConversionInstrumentedTest {
                 "$input unexpectedly generated ${candidates.map { it.string }}",
                 candidates.none { it.string in forbidden },
             )
+        }
+        validInputs.forEach { (input, required) ->
+            val candidates = engine.convertOriginal(input, repository)
+            standardResults[input] = candidates
+            val values = candidates.mapTo(hashSetOf()) { it.string }
+            assertTrue("$input missing $required from $values", values.containsAll(required))
         }
 
         val benchmarkCorpus = (forbiddenByInput.keys + validInputs.keys).toList()

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/BundledNumericSuffixCatalog.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/BundledNumericSuffixCatalog.kt
@@ -1,0 +1,305 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import java.math.BigInteger
+
+/**
+ * The built-in numeric suffix vocabulary.  This file is intentionally data-only: parsing,
+ * phonology, candidate ranking, and rendering consume this catalog through its public model.
+ */
+internal object BundledNumericSuffixCatalog : NumericSuffixCatalog {
+
+    private const val TIME_RIGHT_ID: Short = 2015
+
+    private val kanaStyles = setOf(
+        SuffixStyle.CANONICAL,
+        SuffixStyle.HIRAGANA,
+        SuffixStyle.KATAKANA,
+    )
+
+    private fun definition(
+        id: String,
+        type: NumericSuffixType,
+        surface: String,
+        readings: List<String>,
+        allowedStyles: Set<SuffixStyle> = kanaStyles,
+        composition: NumericCompositionRule = NumericCompositionRule.none(),
+        rightId: Short? = null,
+    ): NumericSuffixDefinition = NumericSuffixDefinition(
+        id = id,
+        type = type,
+        surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, surface)),
+        allowedStyles = allowedStyles,
+        readingRules = readings.map { NumericReadingRule(it) },
+        composition = composition,
+        rightId = rightId,
+    )
+
+    private fun rule(
+        reading: String,
+        condition: NumericCondition = NumericCondition.Always,
+    ): NumericReadingRule = NumericReadingRule(reading, condition)
+
+    private fun whole(
+        reading: String,
+        value: Long,
+    ): NumericReadingRule = NumericReadingRule(
+        reading = reading,
+        wholeExpressionValue = BigInteger.valueOf(value),
+    )
+
+    private val pSound = NumericCondition.AnyOf(
+        listOf(
+            NumericCondition.LastDigitIn(setOf(1, 6, 8)),
+            NumericCondition.FeatureIn(setOf(NumericPhonologicalFeature.GEMINATE)),
+        ),
+    )
+
+    private val definitionsData = listOf(
+        // Time and date.
+        definition(
+            "time.hour",
+            NumericSuffixType.TIME,
+            "時",
+            listOf("じ", "時"),
+            rightId = TIME_RIGHT_ID,
+        ),
+        definition(
+            "time.duration",
+            NumericSuffixType.TIME,
+            "時間",
+            listOf("じかん", "時間"),
+            rightId = TIME_RIGHT_ID,
+        ),
+        NumericSuffixDefinition(
+            id = "time.minute",
+            type = NumericSuffixType.TIME,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "分")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(
+                rule("ふん"),
+                rule(
+                    "ぷん",
+                    NumericCondition.AnyOf(
+                        listOf(
+                            NumericCondition.LastDigitIn(setOf(1, 3, 6, 8)),
+                            NumericCondition.FeatureIn(setOf(NumericPhonologicalFeature.GEMINATE)),
+                        ),
+                    ),
+                ),
+                rule("分"),
+            ),
+            rightId = TIME_RIGHT_ID,
+        ),
+        definition(
+            "time.second",
+            NumericSuffixType.TIME,
+            "秒",
+            listOf("びょう", "秒"),
+            rightId = TIME_RIGHT_ID,
+        ),
+        definition("date.day", NumericSuffixType.DATE, "日", listOf("にち", "日")),
+        definition("date.week", NumericSuffixType.DATE, "週", listOf("しゅう", "週")),
+        definition("date.week.duration", NumericSuffixType.DATE, "週間", listOf("しゅうかん", "週間")),
+        definition("date.month.duration", NumericSuffixType.DATE, "か月", listOf("かげつ", "か月", "ケ月")),
+        definition("date.month", NumericSuffixType.DATE, "月", listOf("がつ", "月")),
+        definition("date.year", NumericSuffixType.DATE, "年", listOf("ねん", "年")),
+        NumericSuffixDefinition(
+            id = "modifier.half",
+            type = NumericSuffixType.OTHER,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "半")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(rule("はん"), rule("半")),
+            composition = NumericCompositionRule(
+                allowedPreviousTypes = setOf(NumericSuffixType.TIME),
+            ),
+            rightId = TIME_RIGHT_ID,
+        ),
+
+        // Currency and measurement units.
+        definition("currency.yen", NumericSuffixType.CURRENCY, "円", listOf("えん", "円")),
+        definition("currency.dollar", NumericSuffixType.CURRENCY, "ドル", listOf("どる", "ドル")),
+        definition("currency.euro", NumericSuffixType.CURRENCY, "ユーロ", listOf("ゆーろ", "ユーロ")),
+        definition("currency.yuan", NumericSuffixType.CURRENCY, "元", listOf("げん", "元")),
+        definition("currency.pound", NumericSuffixType.CURRENCY, "ポンド", listOf("ぽんど", "ポンド")),
+        definition("currency.cent", NumericSuffixType.CURRENCY, "セント", listOf("せんと", "セント")),
+        definition(
+            "unit.percent",
+            NumericSuffixType.UNIT,
+            "%",
+            listOf("ぱーせんと", "%"),
+            setOf(SuffixStyle.CANONICAL),
+        ),
+        definition(
+            "unit.celsius",
+            NumericSuffixType.UNIT,
+            "℃",
+            listOf("ど", "℃"),
+            setOf(SuffixStyle.CANONICAL),
+        ),
+        definition(
+            "unit.fahrenheit",
+            NumericSuffixType.UNIT,
+            "℉",
+            listOf("かし", "℉"),
+            setOf(SuffixStyle.CANONICAL),
+        ),
+        definition("unit.millimeter", NumericSuffixType.UNIT, "mm", listOf("みり", "みりめーとる", "mm")),
+        definition("unit.centimeter", NumericSuffixType.UNIT, "cm", listOf("せんち", "せんちめーとる", "cm")),
+        definition("unit.meter", NumericSuffixType.UNIT, "m", listOf("めーとる", "えむ", "m")),
+        definition("unit.kilometer", NumericSuffixType.UNIT, "km", listOf("きろ", "きろめーとる", "km")),
+        definition("unit.milligram", NumericSuffixType.UNIT, "mg", listOf("みりぐらむ", "mg")),
+        definition("unit.gram", NumericSuffixType.UNIT, "g", listOf("ぐらむ", "g")),
+        definition("unit.kilogram", NumericSuffixType.UNIT, "kg", listOf("きろぐらむ", "kg")),
+        definition("unit.milliliter", NumericSuffixType.UNIT, "ml", listOf("みりりっとる", "ml")),
+        definition("unit.liter", NumericSuffixType.UNIT, "l", listOf("りっとる", "える", "l")),
+
+        // Common counters.  Each entry is data; the parser does not branch on these IDs.
+        definition("counter.person", NumericSuffixType.COUNTER, "人", listOf("にん", "人")),
+        NumericSuffixDefinition(
+            id = "counter.person.irregular",
+            type = NumericSuffixType.COUNTER,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "人")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(whole("ひとり", 1), whole("ふたり", 2)),
+        ),
+        definition("counter.name", NumericSuffixType.COUNTER, "名", listOf("めい", "名")),
+        definition("counter.item", NumericSuffixType.COUNTER, "個", listOf("こ", "個")),
+        definition("counter.item.alt", NumericSuffixType.COUNTER, "箇", listOf("こ", "箇")),
+        NumericSuffixDefinition(
+            id = "counter.hon",
+            type = NumericSuffixType.COUNTER,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "本")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(
+                rule("ほん"),
+                rule("ぼん", NumericCondition.ModuloIn(10, setOf(3))),
+                rule("ぽん", pSound),
+                rule("本"),
+            ),
+        ),
+        NumericSuffixDefinition(
+            id = "counter.hiki",
+            type = NumericSuffixType.COUNTER,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "匹")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(
+                rule("ひき"),
+                rule("びき", NumericCondition.ModuloIn(10, setOf(3))),
+                rule("ぴき", pSound),
+                rule("匹"),
+            ),
+        ),
+        NumericSuffixDefinition(
+            id = "counter.hane",
+            type = NumericSuffixType.COUNTER,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "羽")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(
+                rule("わ"),
+                rule("ば", NumericCondition.ModuloIn(10, setOf(3))),
+                rule("ぱ", pSound),
+                rule("羽"),
+            ),
+        ),
+        definition("counter.large.animal", NumericSuffixType.COUNTER, "頭", listOf("とう", "頭")),
+        NumericSuffixDefinition(
+            id = "counter.cup",
+            type = NumericSuffixType.COUNTER,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "杯")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(
+                rule("はい"),
+                rule("ばい", NumericCondition.ModuloIn(10, setOf(3))),
+                rule("ぱい", pSound),
+                rule("杯"),
+            ),
+        ),
+        definition("counter.sheet", NumericSuffixType.COUNTER, "枚", listOf("まい", "枚")),
+        definition("counter.book", NumericSuffixType.COUNTER, "冊", listOf("さつ", "冊")),
+        definition("counter.machine", NumericSuffixType.COUNTER, "台", listOf("だい", "台")),
+        definition("counter.generation", NumericSuffixType.COUNTER, "代", listOf("だい", "代")),
+        definition("counter.building.floor", NumericSuffixType.COUNTER, "階", listOf("かい", "階")).copy(
+            readingRules = listOf(
+                rule("かい"),
+                rule("がい", NumericCondition.ModuloIn(10, setOf(3))),
+                rule("階"),
+            ),
+        ),
+        definition("counter.times", NumericSuffixType.COUNTER, "回", listOf("かい", "回")),
+        definition("counter.age", NumericSuffixType.COUNTER, "歳", listOf("さい", "歳")),
+        definition("counter.age.alt", NumericSuffixType.COUNTER, "才", listOf("さい", "才")),
+        definition("counter.case", NumericSuffixType.COUNTER, "件", listOf("けん", "件")),
+        definition("counter.house", NumericSuffixType.COUNTER, "軒", listOf("けん", "軒")).copy(
+            readingRules = listOf(
+                rule("けん"),
+                rule("げん", NumericCondition.ModuloIn(10, setOf(3))),
+                rule("軒"),
+            ),
+        ),
+        definition("counter.building", NumericSuffixType.COUNTER, "棟", listOf("とう", "棟")),
+        definition("counter.household", NumericSuffixType.COUNTER, "戸", listOf("こ", "戸")),
+        definition("counter.point", NumericSuffixType.COUNTER, "点", listOf("てん", "点")),
+        definition("counter.can", NumericSuffixType.COUNTER, "缶", listOf("かん", "缶")),
+        definition("counter.bottle", NumericSuffixType.COUNTER, "瓶", listOf("びん", "ビン", "瓶")),
+        definition("counter.box", NumericSuffixType.COUNTER, "箱", listOf("はこ", "箱")),
+        definition("counter.bag", NumericSuffixType.COUNTER, "袋", listOf("ふくろ", "袋")),
+        definition("counter.grain", NumericSuffixType.COUNTER, "粒", listOf("つぶ", "粒")),
+        definition("counter.bundle", NumericSuffixType.COUNTER, "束", listOf("たば", "束")),
+        definition("counter.cluster", NumericSuffixType.COUNTER, "房", listOf("ふさ", "房")),
+        definition("counter.wear", NumericSuffixType.COUNTER, "着", listOf("ちゃく", "着")),
+        definition("counter.shoe", NumericSuffixType.COUNTER, "足", listOf("そく", "足")),
+        definition("counter.face", NumericSuffixType.COUNTER, "面", listOf("めん", "面")),
+        definition("counter.letter", NumericSuffixType.COUNTER, "通", listOf("つう", "通")),
+        definition("counter.part", NumericSuffixType.COUNTER, "部", listOf("ぶ", "部")),
+        definition("counter.volume", NumericSuffixType.COUNTER, "巻", listOf("かん", "巻")),
+        definition("counter.chapter", NumericSuffixType.COUNTER, "章", listOf("しょう", "章")),
+        definition("counter.mouth", NumericSuffixType.COUNTER, "口", listOf("くち", "口")),
+        definition("counter.seat", NumericSuffixType.COUNTER, "席", listOf("せき", "席")),
+        definition("counter.row", NumericSuffixType.COUNTER, "列", listOf("れつ", "列")),
+        definition("counter.foundation", NumericSuffixType.COUNTER, "基", listOf("き", "基")),
+        definition("counter.stock", NumericSuffixType.COUNTER, "株", listOf("かぶ", "株")),
+        definition("counter.formula", NumericSuffixType.COUNTER, "式", listOf("しき", "式")),
+        definition("counter.block", NumericSuffixType.COUNTER, "丁", listOf("ちょう", "丁")),
+        definition("counter.vessel", NumericSuffixType.COUNTER, "隻", listOf("せき", "隻")),
+        definition("counter.boat", NumericSuffixType.COUNTER, "艘", listOf("そう", "艘")),
+
+        // Ordinal and scalar expressions.
+        definition("ordinal.number", NumericSuffixType.ORDINAL, "番", listOf("ばん", "番")),
+        definition("ordinal.code", NumericSuffixType.ORDINAL, "号", listOf("ごう", "号")),
+        definition("ordinal.numbered", NumericSuffixType.ORDINAL, "番目", listOf("ばんめ", "番目")),
+        definition("ordinal.rank", NumericSuffixType.ORDINAL, "位", listOf("い", "位")),
+        definition("ordinal.group", NumericSuffixType.ORDINAL, "組", listOf("くみ", "組")),
+        definition("ordinal.pair", NumericSuffixType.ORDINAL, "対", listOf("つい", "対")),
+        definition("ordinal.step", NumericSuffixType.ORDINAL, "段", listOf("だん", "段")),
+        definition("scalar.degree", NumericSuffixType.OTHER, "度", listOf("ど", "度")),
+        definition("scalar.multiple", NumericSuffixType.OTHER, "倍", listOf("ばい", "倍")),
+        definition("scalar.ratio", NumericSuffixType.OTHER, "割", listOf("わり", "割")),
+
+        // Irregular calendar readings are data, not parser branches.
+        NumericSuffixDefinition(
+            id = "date.day.irregular",
+            type = NumericSuffixType.DATE,
+            surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "日")),
+            allowedStyles = kanaStyles,
+            readingRules = listOf(
+                whole("ついたち", 1),
+                whole("ふつか", 2),
+                whole("みっか", 3),
+                whole("よっか", 4),
+                whole("いつか", 5),
+                whole("むいか", 6),
+                whole("なのか", 7),
+                whole("ようか", 8),
+                whole("ここのか", 9),
+                whole("とおか", 10),
+                whole("はつか", 20),
+            ),
+        ),
+    )
+
+    override val definitions: List<NumericSuffixDefinition> = definitionsData
+
+    init {
+        check(validate().isEmpty()) { validate().joinToString() }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
@@ -2,7 +2,6 @@ package com.kazumaproject.markdownhelperkeyboard.converter.engine
 
 import android.content.Context
 import android.os.Build
-import androidx.core.text.isDigitsOnly
 import com.kazumaproject.Louds.LOUDS
 import com.kazumaproject.Louds.with_term_id.LOUDSWithTermId
 import com.kazumaproject.convertFullWidthToHalfWidth
@@ -46,12 +45,10 @@ import com.kazumaproject.markdownhelperkeyboard.dictionary_override.DictionaryFi
 import com.kazumaproject.markdownhelperkeyboard.dictionary_override.DictionaryOverrideStore
 import com.kazumaproject.markdownhelperkeyboard.dictionary_override.DictionaryOverrideValidator
 import com.kazumaproject.markdownhelperkeyboard.dictionary_override.DictionarySourceResolver
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.addCommasToNumber
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.containsDigit
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.containsFullWidthNumber
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertFullWidthAlnumToHalfWidth
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertFullWidthNumbersToHalfWidth
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertToKanjiNotation
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.createValueBasedSymbolCandidates
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isAllEnglishLetters
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isAllFullWidthAscii
@@ -60,12 +57,8 @@ import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.replaceJa
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toFullWidth
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toKanji
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toNumber
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toNumberExponent
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toSubscriptDigits
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toSuperscriptDigits
 import com.kazumaproject.markdownhelperkeyboard.repository.LearnRepository
 import com.kazumaproject.markdownhelperkeyboard.repository.UserDictionaryRepository
-import com.kazumaproject.toFullWidthDigitsEfficient
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
@@ -78,11 +71,6 @@ import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
 
-private const val POS_ID_COUNTER_GENERIC: Short = 2011
-private const val POS_ID_COUNTER_TIME: Short = 2015
-private const val POS_ID_NUMBER_ARABIC: Short = 2044
-private const val POS_ID_NUMBER_SEPARATED: Short = 2045
-private const val POS_ID_NUMBER_KANJI: Short = 2046
 private const val ENGLISH_READING_CAPITALIZED_SCORE_OFFSET = 1_500
 private const val ENGLISH_READING_UPPERCASE_SCORE_OFFSET = 3_000
 
@@ -1214,109 +1202,33 @@ class KanaKanjiEngine {
         }
         conversionContext.ensureActive()
 
-        if (input.isDigitsOnly()) {
-            // 1. Generate full-width, time, and date candidates as before.
-            val fullWidth = Candidate(
-                string = input.toFullWidthDigitsEfficient(),
-                type = 22,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+        if (NumericCandidateProvider.isDigitSequence(input)) {
+            val numericCandidates = generateNumberCandidatesForDigitInput(
+                input = input,
+                predictionConfig = predictionConfig,
+                candidateSegmentCollector = candidateSegmentCollector,
             )
-            val halfWidth = Candidate(
-                string = input.convertFullWidthToHalfWidth(),
-                type = 31,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+            return prioritizeNumericCandidate(
+                input = input,
+                candidates = resultNBestFinalDeferred + numericCandidates,
+                numericCandidates = numericCandidates,
             )
-            val timeConversion = createCandidatesForTime(input)
-            val dateConversion = createCandidatesForDateInDigit(input)
-
-            // 2. Correctly generate number-to-Kanji/comma candidates.
-            val numberValue = input.toLongOrNull() // Safely convert the digit string to a number.
-            val numberCandidates = if (numberValue != null) {
-                buildList {
-                    // Full Kanji style (e.g., 百二十三)
-                    add(
-                        Candidate(
-                            string = numberValue.toKanji(),
-                            type = 17, // Using 17 for Kanji
-                            score = 2000,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Comma-separated style (e.g., 1,234)
-                    add(
-                        Candidate(
-                            string = input.addCommasToNumber(),
-                            type = 19,
-                            score = 8001,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Original number string itself (e.g., 123)
-                    add(
-                        Candidate(
-                            string = input,
-                            type = 18,
-                            score = 8002,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Mixed Kanji style (e.g., 12万3456)
-                    add(
-                        Candidate(
-                            string = numberValue.convertToKanjiNotation(),
-                            type = 23, // Using a different type for this style
-                            score = 7900, // Lower score for the mixed style
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                }
-            } else {
-                emptyList()
-            }
-
-            val superscriptCandidate = Candidate(
-                string = input.toSuperscriptDigits(),
-                type = 21,
-                score = 8000,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val subscriptCandidate = Candidate(
-                string = input.toSubscriptDigits(),
-                type = 20,
-                score = 8001,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val valueBasedCandidates = if (predictionConfig.showSymbolCandidates && numberValue != null) {
-                createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
-            } else {
-                emptyList()
-            }
-
-            // 3. Combine and return all generated candidates.
-            return resultNBestFinalDeferred + timeConversion + dateConversion + fullWidth + halfWidth + numberCandidates + superscriptCandidate + subscriptCandidate + valueBasedCandidates
         }
 
         if (input.containsDigit() && input.containsFullWidthNumber()) {
+            val numericCandidates = generateNumberCandidates(
+                input = input,
+                showSymbolCandidates = predictionConfig.showSymbolCandidates,
+                numericNotationPreference = predictionConfig.numericNotationPreference,
+                candidateSegmentCollector = candidateSegmentCollector,
+            )
+            if (numericCandidates.isNotEmpty()) {
+                return prioritizeNumericCandidate(
+                    input = input,
+                    candidates = resultNBestFinalDeferred + numericCandidates,
+                    numericCandidates = numericCandidates,
+                )
+            }
             val resultWithHankaku = addHalfWidthCandidates(resultNBestFinalDeferred)
             val finalList = resultWithHankaku.sortedBy { it.score }
             // 3. Combine and return all generated candidates.
@@ -1608,6 +1520,8 @@ class KanaKanjiEngine {
         val numbersDeferred = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
 
         val mozcUTPersonNames =
@@ -1624,8 +1538,11 @@ class KanaKanjiEngine {
         val resultList =
             resultNBestFinalDeferred + readingCorrectionListDeferred + predictiveSearchResult + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
-        val resultListFinal =
-            resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string })
+        val resultListFinal = prioritizeNumericCandidate(
+            input = input,
+            candidates = resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string }),
+            numericCandidates = numbersDeferred,
+        )
 
         val englishReadingDeferred = deferredEnglishReadingCandidates(input, resultList)
         return resultListFinal + englishReadingDeferred + kotowazaListDeferred + symbolHalfWidthListDeferred + (englishDeferred + englishZenkaku).sortedBy { it.score } + (emojiListDeferred + emoticonListDeferred).sortedBy { it.score } + symbolListDeferred + hirakanaAndKana + yomiPartListDeferred + singleKanjiListDeferred
@@ -1729,114 +1646,43 @@ class KanaKanjiEngine {
         }
         conversionContext.ensureActive()
 
-        if (input.isDigitsOnly()) {
-            // 1. Generate full-width, time, and date candidates as before.
-            val fullWidth = Candidate(
-                string = input.toFullWidthDigitsEfficient(),
-                type = 22,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+        if (NumericCandidateProvider.isDigitSequence(input)) {
+            val numericCandidates = generateNumberCandidatesForDigitInput(
+                input = input,
+                predictionConfig = predictionConfig,
+                candidateSegmentCollector = candidateSegmentCollector,
             )
-            val halfWidth = Candidate(
-                string = input.convertFullWidthToHalfWidth(),
-                type = 31,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+            val finalList = prioritizeNumericCandidate(
+                input = input,
+                candidates = resultNBestFinalDeferred.candidates + numericCandidates,
+                numericCandidates = numericCandidates,
             )
-            val timeConversion = createCandidatesForTime(input)
-            val dateConversion = createCandidatesForDateInDigit(input)
-
-            // 2. Correctly generate number-to-Kanji/comma candidates.
-            val numberValue = input.toLongOrNull() // Safely convert the digit string to a number.
-            val numberCandidates = if (numberValue != null) {
-                buildList {
-                    // Full Kanji style (e.g., 百二十三)
-                    add(
-                        Candidate(
-                            string = numberValue.toKanji(),
-                            type = 17, // Using 17 for Kanji
-                            score = 2000,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Comma-separated style (e.g., 1,234)
-                    add(
-                        Candidate(
-                            string = input.addCommasToNumber(),
-                            type = 19,
-                            score = 8001,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Original number string itself (e.g., 123)
-                    add(
-                        Candidate(
-                            string = input,
-                            type = 18,
-                            score = 8002,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Mixed Kanji style (e.g., 12万3456)
-                    add(
-                        Candidate(
-                            string = numberValue.convertToKanjiNotation(),
-                            type = 23, // Using a different type for this style
-                            score = 7900, // Lower score for the mixed style
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                }
-            } else {
-                emptyList()
-            }
-
-            val superscriptCandidate = Candidate(
-                string = input.toSuperscriptDigits(),
-                type = 21,
-                score = 8000,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val subscriptCandidate = Candidate(
-                string = input.toSubscriptDigits(),
-                type = 20,
-                score = 8001,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val valueBasedCandidates = if (predictionConfig.showSymbolCandidates && numberValue != null) {
-                createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
-            } else {
-                emptyList()
-            }
-
-            val finalList =
-                resultNBestFinalDeferred.candidates + timeConversion + dateConversion + fullWidth + halfWidth + numberCandidates + superscriptCandidate + subscriptCandidate + valueBasedCandidates
             return BunsetsuCandidateResult(
                 candidates = finalList,
                 splitPatterns = resultNBestFinalDeferred.splitPatterns,
-                splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString
+                splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString,
             )
         }
 
         if (input.containsDigit() && input.containsFullWidthNumber()) {
+            val numericCandidates = generateNumberCandidates(
+                input = input,
+                showSymbolCandidates = predictionConfig.showSymbolCandidates,
+                numericNotationPreference = predictionConfig.numericNotationPreference,
+                candidateSegmentCollector = candidateSegmentCollector,
+            )
+            if (numericCandidates.isNotEmpty()) {
+                val finalList = prioritizeNumericCandidate(
+                    input = input,
+                    candidates = resultNBestFinalDeferred.candidates + numericCandidates,
+                    numericCandidates = numericCandidates,
+                )
+                return BunsetsuCandidateResult(
+                    candidates = finalList,
+                    splitPatterns = resultNBestFinalDeferred.splitPatterns,
+                    splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString,
+                )
+            }
             val resultWithHankaku = addHalfWidthCandidates(resultNBestFinalDeferred)
 
             val finalList = resultWithHankaku.candidates.sortedBy { it.score }
@@ -2142,6 +1988,8 @@ class KanaKanjiEngine {
         val numbersDeferred = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
 
         val mozcUTPersonNames =
@@ -2160,10 +2008,14 @@ class KanaKanjiEngine {
 
         val systemNgramMatchedCandidates = resultNBestFinalDeferred.systemNgramMatchedCandidates
         val resultListFinal =
-            resultList.sortedWith(
-                compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
-                    .thenBy { it.score }
-                    .thenBy { it.string },
+            prioritizeNumericCandidate(
+                input = input,
+                candidates = resultList.sortedWith(
+                    compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
+                        .thenBy { it.score }
+                        .thenBy { it.string },
+                ),
+                numericCandidates = numbersDeferred,
             ) + deferredEnglishReadingCandidates(input, resultList) + kotowazaListDeferred + symbolHalfWidthListDeferred + (englishDeferred + englishZenkaku).sortedBy { it.score } + (emojiListDeferred + emoticonListDeferred).sortedBy { it.score } + symbolListDeferred + hirakanaAndKana + yomiPartListDeferred + singleKanjiListDeferred
 
         return BunsetsuCandidateResult(
@@ -2272,116 +2124,43 @@ class KanaKanjiEngine {
         }
         conversionContext.ensureActive()
 
-        if (input.isDigitsOnly()) {
-            // 1. Generate full-width, time, and date candidates as before.
-            val fullWidth = Candidate(
-                string = input.toFullWidthDigitsEfficient(),
-                type = 22,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+        if (NumericCandidateProvider.isDigitSequence(input)) {
+            val numericCandidates = generateNumberCandidatesForDigitInput(
+                input = input,
+                predictionConfig = predictionConfig,
+                candidateSegmentCollector = candidateSegmentCollector,
             )
-            val halfWidth = Candidate(
-                string = input.convertFullWidthToHalfWidth(),
-                type = 31,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+            val finalList = prioritizeNumericCandidate(
+                input = input,
+                candidates = resultNBestFinalDeferred.candidates + numericCandidates,
+                numericCandidates = numericCandidates,
             )
-            val timeConversion = createCandidatesForTime(input)
-            val dateConversion = createCandidatesForDateInDigit(input)
-
-            // 2. Correctly generate number-to-Kanji/comma candidates.
-            val numberValue = input.toLongOrNull() // Safely convert the digit string to a number.
-            val numberCandidates = if (numberValue != null) {
-                buildList {
-                    // Full Kanji style (e.g., 百二十三)
-                    add(
-                        Candidate(
-                            string = numberValue.toKanji(),
-                            type = 17, // Using 17 for Kanji
-                            score = 2000,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Comma-separated style (e.g., 1,234)
-                    add(
-                        Candidate(
-                            string = input.addCommasToNumber(),
-                            type = 19,
-                            score = 8001,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Original number string itself (e.g., 123)
-                    add(
-                        Candidate(
-                            string = input,
-                            type = 18,
-                            score = 8002,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Mixed Kanji style (e.g., 12万3456)
-                    add(
-                        Candidate(
-                            string = numberValue.convertToKanjiNotation(),
-                            type = 23, // Using a different type for this style
-                            score = 7900, // Lower score for the mixed style
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                }
-            } else {
-                emptyList()
-            }
-
-            val superscriptCandidate = Candidate(
-                string = input.toSuperscriptDigits(),
-                type = 21,
-                score = 8000,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val subscriptCandidate = Candidate(
-                string = input.toSubscriptDigits(),
-                type = 20,
-                score = 8001,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val valueBasedCandidates = if (predictionConfig.showSymbolCandidates && numberValue != null) {
-                createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
-            } else {
-                emptyList()
-            }
-
-            val finalList =
-                resultNBestFinalDeferred.candidates + timeConversion + dateConversion + fullWidth + halfWidth + numberCandidates + superscriptCandidate + subscriptCandidate + valueBasedCandidates
-
-            // 3. Combine and return all generated candidates.
             return BunsetsuCandidateResult(
                 candidates = finalList,
                 splitPatterns = resultNBestFinalDeferred.splitPatterns,
-                splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString
+                splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString,
             )
         }
 
         if (input.containsDigit() && input.containsFullWidthNumber()) {
+            val numericCandidates = generateNumberCandidates(
+                input = input,
+                showSymbolCandidates = predictionConfig.showSymbolCandidates,
+                numericNotationPreference = predictionConfig.numericNotationPreference,
+                candidateSegmentCollector = candidateSegmentCollector,
+            )
+            if (numericCandidates.isNotEmpty()) {
+                val finalList = prioritizeNumericCandidate(
+                    input = input,
+                    candidates = resultNBestFinalDeferred.candidates + numericCandidates,
+                    numericCandidates = numericCandidates,
+                )
+                return BunsetsuCandidateResult(
+                    candidates = finalList,
+                    splitPatterns = resultNBestFinalDeferred.splitPatterns,
+                    splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString,
+                )
+            }
             val resultWithHankaku = addHalfWidthCandidates(resultNBestFinalDeferred)
             val finalList = resultWithHankaku.candidates.sortedBy { it.score }
 
@@ -2666,6 +2445,8 @@ class KanaKanjiEngine {
         val numbersDeferred = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
 
         val mozcUTPersonNames =
@@ -2683,10 +2464,14 @@ class KanaKanjiEngine {
             resultNBestFinalDeferred.candidates + readingCorrectionListDeferred + predictiveSearchResult + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
         val systemNgramMatchedCandidates = resultNBestFinalDeferred.systemNgramMatchedCandidates
-        val resultListFinal = resultList.sortedWith(
-            compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
-                .thenBy { it.score }
-                .thenBy { it.string },
+        val resultListFinal = prioritizeNumericCandidate(
+            input = input,
+            candidates = resultList.sortedWith(
+                compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
+                    .thenBy { it.score }
+                    .thenBy { it.string },
+            ),
+            numericCandidates = numbersDeferred,
         )
 
         val finalList =
@@ -2796,109 +2581,33 @@ class KanaKanjiEngine {
         }
         conversionContext.ensureActive()
 
-        if (input.isDigitsOnly()) {
-            // 1. Generate full-width, time, and date candidates as before.
-            val fullWidth = Candidate(
-                string = input.toFullWidthDigitsEfficient(),
-                type = 22,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+        if (NumericCandidateProvider.isDigitSequence(input)) {
+            val numericCandidates = generateNumberCandidatesForDigitInput(
+                input = input,
+                predictionConfig = predictionConfig,
+                candidateSegmentCollector = candidateSegmentCollector,
             )
-            val halfWidth = Candidate(
-                string = input.convertFullWidthToHalfWidth(),
-                type = 31,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+            return prioritizeNumericCandidate(
+                input = input,
+                candidates = resultNBestFinalDeferred + numericCandidates,
+                numericCandidates = numericCandidates,
             )
-            val timeConversion = createCandidatesForTime(input)
-            val dateConversion = createCandidatesForDateInDigit(input)
-
-            // 2. Correctly generate number-to-Kanji/comma candidates.
-            val numberValue = input.toLongOrNull() // Safely convert the digit string to a number.
-            val numberCandidates = if (numberValue != null) {
-                buildList {
-                    // Full Kanji style (e.g., 百二十三)
-                    add(
-                        Candidate(
-                            string = numberValue.toKanji(),
-                            type = 17, // Using 17 for Kanji
-                            score = 2000,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Comma-separated style (e.g., 1,234)
-                    add(
-                        Candidate(
-                            string = input.addCommasToNumber(),
-                            type = 19,
-                            score = 8001,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Original number string itself (e.g., 123)
-                    add(
-                        Candidate(
-                            string = input,
-                            type = 18,
-                            score = 8002,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Mixed Kanji style (e.g., 12万3456)
-                    add(
-                        Candidate(
-                            string = numberValue.convertToKanjiNotation(),
-                            type = 23, // Using a different type for this style
-                            score = 7900, // Lower score for the mixed style
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                }
-            } else {
-                emptyList()
-            }
-
-            val superscriptCandidate = Candidate(
-                string = input.toSuperscriptDigits(),
-                type = 21,
-                score = 8000,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val subscriptCandidate = Candidate(
-                string = input.toSubscriptDigits(),
-                type = 20,
-                score = 8001,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val valueBasedCandidates = if (predictionConfig.showSymbolCandidates && numberValue != null) {
-                createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
-            } else {
-                emptyList()
-            }
-
-            // 3. Combine and return all generated candidates.
-            return resultNBestFinalDeferred + timeConversion + dateConversion + fullWidth + halfWidth + numberCandidates + superscriptCandidate + subscriptCandidate + valueBasedCandidates
         }
 
         if (input.containsDigit() && input.containsFullWidthNumber()) {
+            val numericCandidates = generateNumberCandidates(
+                input = input,
+                showSymbolCandidates = predictionConfig.showSymbolCandidates,
+                numericNotationPreference = predictionConfig.numericNotationPreference,
+                candidateSegmentCollector = candidateSegmentCollector,
+            )
+            if (numericCandidates.isNotEmpty()) {
+                return prioritizeNumericCandidate(
+                    input = input,
+                    candidates = resultNBestFinalDeferred + numericCandidates,
+                    numericCandidates = numericCandidates,
+                )
+            }
             val resultWithHankaku = addHalfWidthCandidates(resultNBestFinalDeferred)
 
             val finalList = resultWithHankaku.sortedBy { it.score }
@@ -3188,6 +2897,8 @@ class KanaKanjiEngine {
         val numbersDeferred = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
 
         val mozcUTPersonNames =
@@ -3204,8 +2915,11 @@ class KanaKanjiEngine {
         val resultList =
             resultNBestFinalDeferred + readingCorrectionListDeferred + predictiveSearchResult + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
-        val resultListFinal =
-            resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string })
+        val resultListFinal = prioritizeNumericCandidate(
+            input = input,
+            candidates = resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string }),
+            numericCandidates = numbersDeferred,
+        )
 
         return resultListFinal + deferredEnglishReadingCandidates(input, resultList) + kotowazaListDeferred + (englishDeferred + englishZenkaku).sortedBy { it.score } + (emojiListDeferred + emoticonListDeferred).sortedBy { it.score } + hirakanaAndKana + yomiPartListDeferred + symbolListDeferred + singleKanjiListDeferred
 
@@ -3302,109 +3016,33 @@ class KanaKanjiEngine {
         }
         conversionContext.ensureActive()
 
-        if (input.isDigitsOnly()) {
-            // 1. Generate full-width, time, and date candidates as before.
-            val fullWidth = Candidate(
-                string = input.toFullWidthDigitsEfficient(),
-                type = 22,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+        if (NumericCandidateProvider.isDigitSequence(input)) {
+            val numericCandidates = generateNumberCandidatesForDigitInput(
+                input = input,
+                predictionConfig = predictionConfig,
+                candidateSegmentCollector = candidateSegmentCollector,
             )
-            val halfWidth = Candidate(
-                string = input.convertFullWidthToHalfWidth(),
-                type = 31,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+            return prioritizeNumericCandidate(
+                input = input,
+                candidates = resultNBestFinalDeferred + numericCandidates,
+                numericCandidates = numericCandidates,
             )
-            val timeConversion = createCandidatesForTime(input)
-            val dateConversion = createCandidatesForDateInDigit(input)
-
-            // 2. Correctly generate number-to-Kanji/comma candidates.
-            val numberValue = input.toLongOrNull() // Safely convert the digit string to a number.
-            val numberCandidates = if (numberValue != null) {
-                buildList {
-                    // Full Kanji style (e.g., 百二十三)
-                    add(
-                        Candidate(
-                            string = numberValue.toKanji(),
-                            type = 17, // Using 17 for Kanji
-                            score = 2000,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Comma-separated style (e.g., 1,234)
-                    add(
-                        Candidate(
-                            string = input.addCommasToNumber(),
-                            type = 19,
-                            score = 8001,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Original number string itself (e.g., 123)
-                    add(
-                        Candidate(
-                            string = input,
-                            type = 18,
-                            score = 8002,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Mixed Kanji style (e.g., 12万3456)
-                    add(
-                        Candidate(
-                            string = numberValue.convertToKanjiNotation(),
-                            type = 23, // Using a different type for this style
-                            score = 7900, // Lower score for the mixed style
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                }
-            } else {
-                emptyList()
-            }
-
-            val superscriptCandidate = Candidate(
-                string = input.toSuperscriptDigits(),
-                type = 21,
-                score = 8000,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val subscriptCandidate = Candidate(
-                string = input.toSubscriptDigits(),
-                type = 20,
-                score = 8001,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val valueBasedCandidates = if (predictionConfig.showSymbolCandidates && numberValue != null) {
-                createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
-            } else {
-                emptyList()
-            }
-
-            // 3. Combine and return all generated candidates.
-            return resultNBestFinalDeferred + timeConversion + dateConversion + fullWidth + halfWidth + numberCandidates + superscriptCandidate + subscriptCandidate + valueBasedCandidates
         }
 
         if (input.containsDigit() && input.containsFullWidthNumber()) {
+            val numericCandidates = generateNumberCandidates(
+                input = input,
+                showSymbolCandidates = predictionConfig.showSymbolCandidates,
+                numericNotationPreference = predictionConfig.numericNotationPreference,
+                candidateSegmentCollector = candidateSegmentCollector,
+            )
+            if (numericCandidates.isNotEmpty()) {
+                return prioritizeNumericCandidate(
+                    input = input,
+                    candidates = resultNBestFinalDeferred + numericCandidates,
+                    numericCandidates = numericCandidates,
+                )
+            }
             val resultWithHankaku = addHalfWidthCandidates(resultNBestFinalDeferred)
             val finalList = resultWithHankaku.sortedBy { it.score }
             return finalList
@@ -3688,6 +3326,8 @@ class KanaKanjiEngine {
         val numbersDeferred = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
 
         val mozcUTPersonNames =
@@ -3704,8 +3344,11 @@ class KanaKanjiEngine {
         val resultList =
             resultNBestFinalDeferred + readingCorrectionListDeferred + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
-        val resultListFinal =
-            resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string })
+        val resultListFinal = prioritizeNumericCandidate(
+            input = input,
+            candidates = resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string }),
+            numericCandidates = numbersDeferred,
+        )
 
         return resultListFinal + deferredEnglishReadingCandidates(input, resultList) + (englishDeferred + englishZenkaku).sortedBy { it.score } + symbolHalfWidthListDeferred + (emojiListDeferred + emoticonListDeferred).sortedBy { it.score } + symbolListDeferred + kotowazaListDeferred + hirakanaAndKana + yomiPartListDeferred + singleKanjiListDeferred
 
@@ -3804,114 +3447,43 @@ class KanaKanjiEngine {
         }
         conversionContext.ensureActive()
 
-        if (input.isDigitsOnly()) {
-            // 1. Generate full-width, time, and date candidates as before.
-            val fullWidth = Candidate(
-                string = input.toFullWidthDigitsEfficient(),
-                type = 22,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+        if (NumericCandidateProvider.isDigitSequence(input)) {
+            val numericCandidates = generateNumberCandidatesForDigitInput(
+                input = input,
+                predictionConfig = predictionConfig,
+                candidateSegmentCollector = candidateSegmentCollector,
             )
-            val halfWidth = Candidate(
-                string = input.convertFullWidthToHalfWidth(),
-                type = 31,
-                length = input.length.toUByte(),
-                score = 8000,
-                leftId = 2040,
-                rightId = 2040
+            val finalList = prioritizeNumericCandidate(
+                input = input,
+                candidates = resultNBestFinalDeferred.candidates + numericCandidates,
+                numericCandidates = numericCandidates,
             )
-            val timeConversion = createCandidatesForTime(input)
-            val dateConversion = createCandidatesForDateInDigit(input)
-
-            // 2. Correctly generate number-to-Kanji/comma candidates.
-            val numberValue = input.toLongOrNull() // Safely convert the digit string to a number.
-            val numberCandidates = if (numberValue != null) {
-                buildList {
-                    // Full Kanji style (e.g., 百二十三)
-                    add(
-                        Candidate(
-                            string = numberValue.toKanji(),
-                            type = 17, // Using 17 for Kanji
-                            score = 2000,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Comma-separated style (e.g., 1,234)
-                    add(
-                        Candidate(
-                            string = input.addCommasToNumber(),
-                            type = 19,
-                            score = 8001,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Original number string itself (e.g., 123)
-                    add(
-                        Candidate(
-                            string = input,
-                            type = 18,
-                            score = 8002,
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                    // Mixed Kanji style (e.g., 12万3456)
-                    add(
-                        Candidate(
-                            string = numberValue.convertToKanjiNotation(),
-                            type = 23, // Using a different type for this style
-                            score = 7900, // Lower score for the mixed style
-                            length = input.length.toUByte(),
-                            leftId = 2040,
-                            rightId = 2040
-                        )
-                    )
-                }
-            } else {
-                emptyList()
-            }
-
-            val superscriptCandidate = Candidate(
-                string = input.toSuperscriptDigits(),
-                type = 21,
-                score = 8000,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val subscriptCandidate = Candidate(
-                string = input.toSubscriptDigits(),
-                type = 20,
-                score = 8001,
-                length = input.length.toUByte(),
-                leftId = 2040,
-                rightId = 2040
-            )
-
-            val valueBasedCandidates = if (predictionConfig.showSymbolCandidates && numberValue != null) {
-                createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
-            } else {
-                emptyList()
-            }
-
-            val finalList =
-                resultNBestFinalDeferred.candidates + timeConversion + dateConversion + fullWidth + halfWidth + numberCandidates + superscriptCandidate + subscriptCandidate + valueBasedCandidates
             return BunsetsuCandidateResult(
                 candidates = finalList,
                 splitPatterns = resultNBestFinalDeferred.splitPatterns,
-                splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString
+                splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString,
             )
         }
 
         if (input.containsDigit() && input.containsFullWidthNumber()) {
+            val numericCandidates = generateNumberCandidates(
+                input = input,
+                showSymbolCandidates = predictionConfig.showSymbolCandidates,
+                numericNotationPreference = predictionConfig.numericNotationPreference,
+                candidateSegmentCollector = candidateSegmentCollector,
+            )
+            if (numericCandidates.isNotEmpty()) {
+                val finalList = prioritizeNumericCandidate(
+                    input = input,
+                    candidates = resultNBestFinalDeferred.candidates + numericCandidates,
+                    numericCandidates = numericCandidates,
+                )
+                return BunsetsuCandidateResult(
+                    candidates = finalList,
+                    splitPatterns = resultNBestFinalDeferred.splitPatterns,
+                    splitPatternByCandidateString = resultNBestFinalDeferred.splitPatternByCandidateString,
+                )
+            }
             val resultWithHankaku = addHalfWidthCandidates(resultNBestFinalDeferred)
 
             val finalList = resultWithHankaku.candidates.sortedBy { it.score }
@@ -4210,6 +3782,8 @@ class KanaKanjiEngine {
         val numbersDeferred = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
 
         val mozcUTPersonNames =
@@ -4228,10 +3802,14 @@ class KanaKanjiEngine {
 
         val systemNgramMatchedCandidates = resultNBestFinalDeferred.systemNgramMatchedCandidates
         val resultListFinal =
-            resultList.sortedWith(
-                compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
-                    .thenBy { it.score }
-                    .thenBy { it.string },
+            prioritizeNumericCandidate(
+                input = input,
+                candidates = resultList.sortedWith(
+                    compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
+                        .thenBy { it.score }
+                        .thenBy { it.string },
+                ),
+                numericCandidates = numbersDeferred,
             ) + deferredEnglishReadingCandidates(input, resultList) + (englishDeferred + englishZenkaku).sortedBy { it.score } + symbolHalfWidthListDeferred + (emojiListDeferred + emoticonListDeferred).sortedBy { it.score } + symbolListDeferred + kotowazaListDeferred + hirakanaAndKana + yomiPartListDeferred + singleKanjiListDeferred
 
         return BunsetsuCandidateResult(
@@ -4265,16 +3843,16 @@ class KanaKanjiEngine {
         predictionConfig: PredictionConfig = PredictionConfig(),
     ): List<Candidate> {
         val inputToEnglish = input.replaceJapaneseCharactersForEnglish()
-        val explicitDigitInput = input.takeIf { value ->
-            value.isNotEmpty() && value.all { it in '0'..'9' || it in '０'..'９' }
-        }
-        val directJapaneseNumber = input.toNumber()
-        val numberUnitCandidates = createCandidatesForJapaneseNumberWithUnit(input)
-        val preferredNumberCandidate = when {
-            numberUnitCandidates.isNotEmpty() -> numberUnitCandidates.first().string
-            directJapaneseNumber != null -> directJapaneseNumber.second
-            explicitDigitInput != null -> explicitDigitInput.convertFullWidthNumbersToHalfWidth()
-            else -> null
+        val numericCandidates = generateNumberCandidates(
+            input = input,
+            showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+        )
+        val digitTemporalCandidates = if (NumericCandidateProvider.isDigitSequence(input)) {
+            val normalizedInput = input.convertFullWidthNumbersToHalfWidth()
+            createCandidatesForTime(normalizedInput) + createCandidatesForDateInDigit(normalizedInput)
+        } else {
+            emptyList()
         }
         val listJapaneseCandidates = buildList {
             add(Candidate(
@@ -4310,27 +3888,6 @@ class KanaKanjiEngine {
                 length = input.length.toUByte(),
                 score = 3000
             ))
-            if (preferredNumberCandidate != null && preferredNumberCandidate != input) {
-                add(Candidate(
-                    string = preferredNumberCandidate,
-                    type = (1).toByte(),
-                    length = input.length.toUByte(),
-                    score = 3000
-                ))
-            }
-        }
-
-        val digitCandidates = when {
-            directJapaneseNumber != null -> createDigitCandidates(
-                directJapaneseNumber.second, input.length.toUByte()
-            )
-
-            numberUnitCandidates.isNotEmpty() -> emptyList()
-            explicitDigitInput != null -> createDigitCandidates(
-                explicitDigitInput,
-                input.length.toUByte(),
-            )
-            else -> emptyList()
         }
 
         val englishDeferred = if (input.isAllEnglishLetters()) {
@@ -4367,10 +3924,15 @@ class KanaKanjiEngine {
         }
 
         val numbersConverted =
-            digitCandidates + numberUnitCandidates + (englishDeferred + englishZenkaku).sortedBy { it.score }
+            numericCandidates + digitTemporalCandidates +
+                (englishDeferred + englishZenkaku).sortedBy { it.score }
         val temporalCandidates = createTemporalDictionaryCandidates(input)
 
-        return listJapaneseCandidates + numbersConverted + temporalCandidates
+        return prioritizeNumericCandidate(
+            input = input,
+            candidates = listJapaneseCandidates + numbersConverted + temporalCandidates,
+            numericCandidates = numericCandidates,
+        )
     }
 
     private fun createTemporalDictionaryCandidates(input: String): List<Candidate> = when (input) {
@@ -4448,144 +4010,6 @@ class KanaKanjiEngine {
 
         return baseCandidates
     }
-
-    private fun createDigitCandidates(inputDigits: String, inputLength: UByte): List<Candidate> {
-        val halfWidthDigits = inputDigits.convertFullWidthNumbersToHalfWidth()
-        val fullWidthDigits = halfWidthDigits.toFullWidthDigitsEfficient()
-
-        val fullWidth = Candidate(
-            string = fullWidthDigits,
-            type = 22,
-            length = inputLength,
-            score = 8000,
-            leftId = POS_ID_NUMBER_ARABIC,
-            rightId = POS_ID_NUMBER_ARABIC
-        )
-        val halfWidth = Candidate(
-            string = halfWidthDigits.convertFullWidthToHalfWidth(),
-            type = 31,
-            length = inputLength,
-            score = 8000,
-            leftId = POS_ID_NUMBER_ARABIC,
-            rightId = POS_ID_NUMBER_ARABIC
-        )
-        val timeConversion = createCandidatesForTime(halfWidthDigits)
-        val dateConversion = createCandidatesForDateInDigit(halfWidthDigits)
-
-        val numberValue = halfWidthDigits.toLongOrNull()
-        val numberCandidates = if (numberValue != null) {
-            buildList {
-                add(
-                    Candidate(
-                        string = numberValue.toKanji(),
-                        type = 17,
-                        score = 2000,
-                        length = inputLength,
-                        leftId = POS_ID_NUMBER_KANJI,
-                        rightId = POS_ID_NUMBER_KANJI
-                    )
-                )
-                add(
-                    Candidate(
-                        string = halfWidthDigits.addCommasToNumber(),
-                        type = 19,
-                        score = 8001,
-                        length = inputLength,
-                        leftId = POS_ID_NUMBER_SEPARATED,
-                        rightId = POS_ID_NUMBER_SEPARATED
-                    )
-                )
-                add(
-                    Candidate(
-                        string = halfWidthDigits,
-                        type = 18,
-                        score = 8002,
-                        length = inputLength,
-                        leftId = POS_ID_NUMBER_ARABIC,
-                        rightId = POS_ID_NUMBER_ARABIC
-                    )
-                )
-                add(
-                    Candidate(
-                        string = numberValue.convertToKanjiNotation(),
-                        type = 23,
-                        score = 7900,
-                        length = inputLength,
-                        leftId = POS_ID_NUMBER_KANJI,
-                        rightId = POS_ID_NUMBER_KANJI
-                    )
-                )
-            }
-        } else {
-            emptyList()
-        }
-
-        return listOf(fullWidth, halfWidth) + timeConversion + dateConversion + numberCandidates
-    }
-
-    private fun createCandidatesForJapaneseNumberWithUnit(input: String): List<Candidate> {
-        val unitMappings = listOf(
-            "にん" to "人", "えん" to "円", "ぷん" to "分", "ふん" to "分", "じ" to "時"
-        )
-
-        for ((readingSuffix, unit) in unitMappings) {
-            if (!input.endsWith(readingSuffix) || input.length <= readingSuffix.length) continue
-
-            val numberReading = normalizeJapaneseNumberReadingForCounter(
-                input.removeSuffix(readingSuffix),
-                readingSuffix,
-            ) ?: continue
-            val number = numberReading.toNumber() ?: continue
-            val isTimeLike = unit == "時" || unit == "分"
-            val rightId = if (unit == "時") POS_ID_COUNTER_TIME else POS_ID_COUNTER_GENERIC
-
-            return listOf(
-                Candidate(
-                    string = "${number.second}$unit",
-                    type = if (isTimeLike) CANDIDATE_TYPE_TIME else 18,
-                    length = input.length.toUByte(),
-                    score = 8000,
-                    leftId = POS_ID_NUMBER_ARABIC,
-                    rightId = rightId
-                ), Candidate(
-                    string = "${number.first}$unit",
-                    type = if (isTimeLike) 30 else 22,
-                    length = input.length.toUByte(),
-                    score = 8001,
-                    leftId = POS_ID_NUMBER_ARABIC,
-                    rightId = rightId
-                )
-            )
-        }
-
-        return emptyList()
-    }
-
-    private fun normalizeJapaneseNumberReadingForCounter(
-        numberReading: String,
-        counterReading: String,
-    ): String? {
-        fun isStandaloneOrAfterPlace(alias: String): Boolean {
-            if (numberReading == alias) return true
-            val prefix = numberReading.dropLast(alias.length)
-            return listOf("じゅう", "ひゃく", "せん", "まん", "おく", "ちょう")
-                .any(prefix::endsWith)
-        }
-
-        // 「し」は単独の四としては有効だが、現在扱っている助数詞の
-        // 直前では通常語との衝突が大きい（しじ、しえん、しにん等）。
-        if (numberReading.endsWith("し") && isStandaloneOrAfterPlace("し")) return null
-        if (counterReading != "じ") return numberReading
-
-        return when {
-            numberReading.endsWith("よ") && isStandaloneOrAfterPlace("よ") ->
-                numberReading.dropLast(1) + "よん"
-            numberReading.endsWith("く") && isStandaloneOrAfterPlace("く") ->
-                numberReading.dropLast(1) + "きゅう"
-            else -> numberReading
-        }
-    }
-
 
     fun getSymbolEmojiCandidates(): List<Emoji> = emojiTokenArray.getNodeIds().map { nodeId ->
         emojiTangoTrie.getLetterShortArray(nodeId, emojiSuccinctBitVectorTangoLBS)
@@ -5443,91 +4867,84 @@ class KanaKanjiEngine {
     private fun generateNumberCandidates(
         input: String,
         showSymbolCandidates: Boolean = true,
+        numericNotationPreference: NumericNotationPreference =
+            NumericNotationPreference.HALF_WIDTH_FIRST,
+        candidateSegmentCollector: MutableMap<String, List<CandidateConversionSegment>>? = null,
     ): List<Candidate> {
-        val numPair = input.toNumber()
-        val expoPair = input.toNumberExponent()
+        val candidates = NumericCandidateProvider.generate(
+            input = input,
+            notationPreference = numericNotationPreference,
+            showSymbolCandidates = showSymbolCandidates,
+        )
+        recordNumericCandidateSegments(
+            input = input,
+            candidates = candidates,
+            candidateSegmentCollector = candidateSegmentCollector,
+        )
+        return candidates
+    }
 
-        return if (numPair != null) {
-            val (firstNum, secondNum) = numPair // firstNum: 全角, secondNum: 半角
-            val numberAsLong = secondNum.toLongOrNull()
+    private fun generateNumberCandidatesForDigitInput(
+        input: String,
+        predictionConfig: PredictionConfig,
+        candidateSegmentCollector: MutableMap<String, List<CandidateConversionSegment>>? = null,
+    ): List<Candidate> {
+        val numericCandidates = generateNumberCandidates(
+            input = input,
+            showSymbolCandidates = predictionConfig.showSymbolCandidates,
+            numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
+        )
+        val normalizedInput = input.convertFullWidthNumbersToHalfWidth()
+        val temporalCandidates = createCandidatesForTime(normalizedInput) +
+            createCandidatesForDateInDigit(normalizedInput)
+        recordNumericCandidateSegments(
+            input = input,
+            candidates = temporalCandidates,
+            candidateSegmentCollector = candidateSegmentCollector,
+        )
+        return numericCandidates + temporalCandidates
+    }
 
-            // 候補リストを構築
-            val candidates = mutableListOf<Candidate>()
+    private fun prioritizeNumericCandidate(
+        input: String,
+        candidates: List<Candidate>,
+        numericCandidates: List<Candidate>,
+    ): List<Candidate> {
+        if (!NumericCandidateProvider.shouldPrioritize(input)) {
+            val numericCandidateSet = numericCandidates.toSet()
+            if (numericCandidateSet.isEmpty()) return candidates
+            return candidates.filterNot(numericCandidateSet::contains) +
+                candidates.filter(numericCandidateSet::contains)
+        }
+        val preferredString = numericCandidates.firstOrNull()?.string ?: return candidates
+        val preferredIndex = candidates.indexOfFirst { it.string == preferredString }
+        if (preferredIndex <= 0) return candidates
 
-            // 1. 伝統的な漢数字 (例: 十, 百二十三)
-            if (numberAsLong != null) {
-                candidates.add(
-                    Candidate(
-                        string = numberAsLong.toKanji(), type = 32, // 新しいタイプ
-                        length = input.length.toUByte(), score = 8000, // 優先度を調整
-                        leftId = POS_ID_NUMBER_KANJI, rightId = POS_ID_NUMBER_KANJI
-                    )
-                )
-            }
+        return buildList(candidates.size) {
+            add(candidates[preferredIndex])
+            addAll(candidates.subList(0, preferredIndex))
+            addAll(candidates.subList(preferredIndex + 1, candidates.size))
+        }
+    }
 
-            // 2. 単位付き漢数字 (例: 1億2345万)
-            if (numberAsLong != null) {
-                candidates.add(
-                    Candidate(
-                        string = numberAsLong.convertToKanjiNotation(),
-                        type = 17,
-                        length = input.length.toUByte(),
-                        score = 8000,
-                        leftId = POS_ID_NUMBER_KANJI,
-                        rightId = POS_ID_NUMBER_KANJI
-                    )
-                )
-            }
-
-            // 3. 全角・半角数字 (例: １２３, 123)
-            listOf(firstNum, secondNum).forEach {
-                candidates.add(
-                    Candidate(
-                        string = it,
-                        type = if (it == firstNum) (30).toByte() else (31).toByte(),
-                        length = input.length.toUByte(),
-                        score = 8002,
-                        leftId = POS_ID_NUMBER_ARABIC,
-                        rightId = POS_ID_NUMBER_ARABIC
-                    )
-                )
-            }
-
-            // 4. カンマ区切り数字 (例: 123,456)
-            candidates.add(
-                Candidate(
-                    string = secondNum.addCommasToNumber(),
-                    type = 19,
-                    length = input.length.toUByte(),
-                    score = 8001,
-                    leftId = POS_ID_NUMBER_SEPARATED,
-                    rightId = POS_ID_NUMBER_SEPARATED
-                )
+    private fun recordNumericCandidateSegments(
+        input: String,
+        candidates: List<Candidate>,
+        candidateSegmentCollector: MutableMap<String, List<CandidateConversionSegment>>?,
+    ) {
+        candidateSegmentCollector ?: return
+        candidates.forEach { candidate ->
+            candidateSegmentCollector.putIfAbsent(
+                candidate.string,
+                listOf(
+                    CandidateConversionSegment(
+                        inputStart = 0,
+                        inputEnd = input.length,
+                        output = candidate.string,
+                    ),
+                ),
             )
-
-            // 5. 指数表記 (例: 10⁸)
-            if (expoPair != null) {
-                candidates.add(
-                    Candidate(
-                        string = expoPair.first,
-                        type = 20,
-                        length = input.length.toUByte(),
-                        score = 8003,
-                        leftId = POS_ID_NUMBER_ARABIC,
-                        rightId = POS_ID_NUMBER_ARABIC
-                    )
-                )
-            }
-
-            candidates += createJapaneseNumberValueBasedCandidates(
-                input = input,
-                showSymbolCandidates = showSymbolCandidates,
-            )
-
-            candidates
-
-        } else {
-            emptyList()
         }
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
@@ -1207,7 +1207,7 @@ class KanaKanjiEngine {
                 predictionConfig = predictionConfig,
                 candidateSegmentCollector = candidateSegmentCollector,
             )
-            return prioritizeNumericCandidate(
+            return composeNumericCandidates(
                 input = input,
                 candidates = resultNBestFinalDeferred + numericCandidates,
                 numericCandidates = numericCandidates,
@@ -1222,7 +1222,7 @@ class KanaKanjiEngine {
                 candidateSegmentCollector = candidateSegmentCollector,
             )
             if (numericCandidates.isNotEmpty()) {
-                return prioritizeNumericCandidate(
+                return composeNumericCandidates(
                     input = input,
                     candidates = resultNBestFinalDeferred + numericCandidates,
                     numericCandidates = numericCandidates,
@@ -1537,7 +1537,7 @@ class KanaKanjiEngine {
         val resultList =
             resultNBestFinalDeferred + readingCorrectionListDeferred + predictiveSearchResult + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
-        val resultListFinal = prioritizeNumericCandidate(
+        val resultListFinal = composeNumericCandidates(
             input = input,
             candidates = resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string }),
             numericCandidates = numbersDeferred,
@@ -1651,7 +1651,7 @@ class KanaKanjiEngine {
                 predictionConfig = predictionConfig,
                 candidateSegmentCollector = candidateSegmentCollector,
             )
-            val finalList = prioritizeNumericCandidate(
+            val finalList = composeNumericCandidates(
                 input = input,
                 candidates = resultNBestFinalDeferred.candidates + numericCandidates,
                 numericCandidates = numericCandidates,
@@ -1671,7 +1671,7 @@ class KanaKanjiEngine {
                 candidateSegmentCollector = candidateSegmentCollector,
             )
             if (numericCandidates.isNotEmpty()) {
-                val finalList = prioritizeNumericCandidate(
+                val finalList = composeNumericCandidates(
                     input = input,
                     candidates = resultNBestFinalDeferred.candidates + numericCandidates,
                     numericCandidates = numericCandidates,
@@ -2007,7 +2007,7 @@ class KanaKanjiEngine {
 
         val systemNgramMatchedCandidates = resultNBestFinalDeferred.systemNgramMatchedCandidates
         val resultListFinal =
-            prioritizeNumericCandidate(
+            composeNumericCandidates(
                 input = input,
                 candidates = resultList.sortedWith(
                     compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
@@ -2129,7 +2129,7 @@ class KanaKanjiEngine {
                 predictionConfig = predictionConfig,
                 candidateSegmentCollector = candidateSegmentCollector,
             )
-            val finalList = prioritizeNumericCandidate(
+            val finalList = composeNumericCandidates(
                 input = input,
                 candidates = resultNBestFinalDeferred.candidates + numericCandidates,
                 numericCandidates = numericCandidates,
@@ -2149,7 +2149,7 @@ class KanaKanjiEngine {
                 candidateSegmentCollector = candidateSegmentCollector,
             )
             if (numericCandidates.isNotEmpty()) {
-                val finalList = prioritizeNumericCandidate(
+                val finalList = composeNumericCandidates(
                     input = input,
                     candidates = resultNBestFinalDeferred.candidates + numericCandidates,
                     numericCandidates = numericCandidates,
@@ -2463,7 +2463,7 @@ class KanaKanjiEngine {
             resultNBestFinalDeferred.candidates + readingCorrectionListDeferred + predictiveSearchResult + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
         val systemNgramMatchedCandidates = resultNBestFinalDeferred.systemNgramMatchedCandidates
-        val resultListFinal = prioritizeNumericCandidate(
+        val resultListFinal = composeNumericCandidates(
             input = input,
             candidates = resultList.sortedWith(
                 compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
@@ -2586,7 +2586,7 @@ class KanaKanjiEngine {
                 predictionConfig = predictionConfig,
                 candidateSegmentCollector = candidateSegmentCollector,
             )
-            return prioritizeNumericCandidate(
+            return composeNumericCandidates(
                 input = input,
                 candidates = resultNBestFinalDeferred + numericCandidates,
                 numericCandidates = numericCandidates,
@@ -2601,7 +2601,7 @@ class KanaKanjiEngine {
                 candidateSegmentCollector = candidateSegmentCollector,
             )
             if (numericCandidates.isNotEmpty()) {
-                return prioritizeNumericCandidate(
+                return composeNumericCandidates(
                     input = input,
                     candidates = resultNBestFinalDeferred + numericCandidates,
                     numericCandidates = numericCandidates,
@@ -2914,7 +2914,7 @@ class KanaKanjiEngine {
         val resultList =
             resultNBestFinalDeferred + readingCorrectionListDeferred + predictiveSearchResult + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
-        val resultListFinal = prioritizeNumericCandidate(
+        val resultListFinal = composeNumericCandidates(
             input = input,
             candidates = resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string }),
             numericCandidates = numbersDeferred,
@@ -3021,7 +3021,7 @@ class KanaKanjiEngine {
                 predictionConfig = predictionConfig,
                 candidateSegmentCollector = candidateSegmentCollector,
             )
-            return prioritizeNumericCandidate(
+            return composeNumericCandidates(
                 input = input,
                 candidates = resultNBestFinalDeferred + numericCandidates,
                 numericCandidates = numericCandidates,
@@ -3036,7 +3036,7 @@ class KanaKanjiEngine {
                 candidateSegmentCollector = candidateSegmentCollector,
             )
             if (numericCandidates.isNotEmpty()) {
-                return prioritizeNumericCandidate(
+                return composeNumericCandidates(
                     input = input,
                     candidates = resultNBestFinalDeferred + numericCandidates,
                     numericCandidates = numericCandidates,
@@ -3343,7 +3343,7 @@ class KanaKanjiEngine {
         val resultList =
             resultNBestFinalDeferred + readingCorrectionListDeferred + mozcUTPersonNames + mozcUTPlacesList + mozcUTWikiList + mozcUTNeologdList + mozcUTWebList + listOfDictionaryToday + numbersDeferred + convertYearToEra
 
-        val resultListFinal = prioritizeNumericCandidate(
+        val resultListFinal = composeNumericCandidates(
             input = input,
             candidates = resultList.sortedWith(compareBy<Candidate> { it.score }.thenBy { it.string }),
             numericCandidates = numbersDeferred,
@@ -3452,7 +3452,7 @@ class KanaKanjiEngine {
                 predictionConfig = predictionConfig,
                 candidateSegmentCollector = candidateSegmentCollector,
             )
-            val finalList = prioritizeNumericCandidate(
+            val finalList = composeNumericCandidates(
                 input = input,
                 candidates = resultNBestFinalDeferred.candidates + numericCandidates,
                 numericCandidates = numericCandidates,
@@ -3472,7 +3472,7 @@ class KanaKanjiEngine {
                 candidateSegmentCollector = candidateSegmentCollector,
             )
             if (numericCandidates.isNotEmpty()) {
-                val finalList = prioritizeNumericCandidate(
+                val finalList = composeNumericCandidates(
                     input = input,
                     candidates = resultNBestFinalDeferred.candidates + numericCandidates,
                     numericCandidates = numericCandidates,
@@ -3801,7 +3801,7 @@ class KanaKanjiEngine {
 
         val systemNgramMatchedCandidates = resultNBestFinalDeferred.systemNgramMatchedCandidates
         val resultListFinal =
-            prioritizeNumericCandidate(
+            composeNumericCandidates(
                 input = input,
                 candidates = resultList.sortedWith(
                     compareByDescending<Candidate> { it.string in systemNgramMatchedCandidates }
@@ -3934,7 +3934,7 @@ class KanaKanjiEngine {
                 (englishDeferred + englishZenkaku).sortedBy { it.score }
         val temporalCandidates = createTemporalDictionaryCandidates(input)
 
-        return prioritizeNumericCandidate(
+        return composeNumericCandidates(
             input = input,
             candidates = listJapaneseCandidates + numbersConverted + temporalCandidates,
             numericCandidates = numericCandidates,
@@ -4913,26 +4913,12 @@ class KanaKanjiEngine {
         return numericCandidates + temporalCandidates
     }
 
-    private fun prioritizeNumericCandidate(
+    private fun composeNumericCandidates(
         input: String,
         candidates: List<Candidate>,
         numericCandidates: List<Candidate>,
     ): List<Candidate> {
-        if (!NumericCandidateProvider.shouldPrioritize(input)) {
-            val numericCandidateSet = numericCandidates.toSet()
-            if (numericCandidateSet.isEmpty()) return candidates
-            return candidates.filterNot(numericCandidateSet::contains) +
-                candidates.filter(numericCandidateSet::contains)
-        }
-        val preferredString = numericCandidates.firstOrNull()?.string ?: return candidates
-        val preferredIndex = candidates.indexOfFirst { it.string == preferredString }
-        if (preferredIndex <= 0) return candidates
-
-        return buildList(candidates.size) {
-            add(candidates[preferredIndex])
-            addAll(candidates.subList(0, preferredIndex))
-            addAll(candidates.subList(preferredIndex + 1, candidates.size))
-        }
+        return NumericCandidateComposer.compose(input, candidates, numericCandidates)
     }
 
     private fun recordNumericCandidateSegments(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngine.kt
@@ -55,8 +55,6 @@ import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isAllFull
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.isAllHalfWidthAscii
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.replaceJapaneseCharactersForEnglish
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toFullWidth
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toKanji
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toNumber
 import com.kazumaproject.markdownhelperkeyboard.repository.LearnRepository
 import com.kazumaproject.markdownhelperkeyboard.repository.UserDictionaryRepository
 import kotlinx.coroutines.runBlocking
@@ -89,8 +87,9 @@ internal fun createJapaneseNumberValueBasedCandidates(
     showSymbolCandidates: Boolean = true,
 ): List<Candidate> {
     if (!showSymbolCandidates) return emptyList()
-    val numberValue = input.toNumber()?.second?.toLongOrNull() ?: return emptyList()
-    return createValueBasedSymbolCandidates(numberValue, input.length.toUByte())
+    val numberValue = NumericNumberParser.parse(input)?.value ?: return emptyList()
+    if (numberValue.bitLength() > 63) return emptyList()
+    return createValueBasedSymbolCandidates(numberValue.toLong(), input.length.toUByte())
 }
 
 class KanaKanjiEngine {
@@ -3841,12 +3840,14 @@ class KanaKanjiEngine {
     fun getCandidatesEnglishKana(
         input: String,
         predictionConfig: PredictionConfig = PredictionConfig(),
+        candidateSegmentCollector: MutableMap<String, List<CandidateConversionSegment>>? = null,
     ): List<Candidate> {
         val inputToEnglish = input.replaceJapaneseCharactersForEnglish()
         val numericCandidates = generateNumberCandidates(
             input = input,
             showSymbolCandidates = predictionConfig.showSymbolCandidates,
             numericNotationPreference = predictionConfig.numericNotationPreference,
+            candidateSegmentCollector = candidateSegmentCollector,
         )
         val digitTemporalCandidates = if (NumericCandidateProvider.isDigitSequence(input)) {
             val normalizedInput = input.convertFullWidthNumbersToHalfWidth()
@@ -3854,6 +3855,11 @@ class KanaKanjiEngine {
         } else {
             emptyList()
         }
+        recordNumericCandidateSegments(
+            input = input,
+            candidates = digitTemporalCandidates,
+            candidateSegmentCollector = candidateSegmentCollector,
+        )
         val listJapaneseCandidates = buildList {
             add(Candidate(
                 string = input, type = (1).toByte(), length = input.length.toUByte(), score = 3000
@@ -4871,17 +4877,18 @@ class KanaKanjiEngine {
             NumericNotationPreference.HALF_WIDTH_FIRST,
         candidateSegmentCollector: MutableMap<String, List<CandidateConversionSegment>>? = null,
     ): List<Candidate> {
-        val candidates = NumericCandidateProvider.generate(
+        val renderedCandidates = NumericCandidateProvider.generateRendered(
             input = input,
             notationPreference = numericNotationPreference,
             showSymbolCandidates = showSymbolCandidates,
         )
-        recordNumericCandidateSegments(
-            input = input,
-            candidates = candidates,
-            candidateSegmentCollector = candidateSegmentCollector,
-        )
-        return candidates
+        renderedCandidates.forEach { rendered ->
+            candidateSegmentCollector?.set(
+                rendered.candidate.string,
+                rendered.segments,
+            )
+        }
+        return renderedCandidates.map { it.candidate }
     }
 
     private fun generateNumberCandidatesForDigitInput(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateComposer.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateComposer.kt
@@ -1,0 +1,28 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_LEARNED_DICTIONARY
+import java.util.Collections
+import java.util.IdentityHashMap
+
+/** Keeps lexical and learned candidates intact when adding generated notation alternatives. */
+internal object NumericCandidateComposer {
+    fun compose(
+        input: String,
+        candidates: List<Candidate>,
+        numericCandidates: List<Candidate>,
+    ): List<Candidate> {
+        if (numericCandidates.isEmpty()) return candidates
+        // Equality of values does not imply that a dictionary entry came from the renderer.
+        val generated = Collections.newSetFromMap(IdentityHashMap<Candidate, Boolean>())
+        generated.addAll(numericCandidates)
+        val lexical = candidates.filterNot { generated.contains(it) }
+        if (!NumericCandidateProvider.shouldPrioritize(input)) {
+            return (lexical + numericCandidates).distinctBy { it.string }
+        }
+        val lexicalBySurface = lexical.distinctBy { it.string }.associateBy { it.string }
+        val learned = lexical.filter { it.type == CANDIDATE_TYPE_LEARNED_DICTIONARY }
+        val orderedNumeric = numericCandidates.map { lexicalBySurface[it.string] ?: it }
+        return (learned + orderedNumeric + lexical).distinctBy { it.string }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProvider.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProvider.kt
@@ -1,0 +1,407 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_TIME
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.addCommasToNumber
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertFullWidthNumbersToHalfWidth
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertToKanjiNotation
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.createValueBasedSymbolCandidates
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toKanji
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toNumber
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toSubscriptDigits
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toSuperscriptDigits
+
+private const val NUMERIC_POS_ID_COUNTER_GENERIC: Short = 2011
+private const val NUMERIC_POS_ID_COUNTER_TIME: Short = 2015
+private const val NUMERIC_POS_ID_NUMBER_ARABIC: Short = 2044
+private const val NUMERIC_POS_ID_NUMBER_SEPARATED: Short = 2045
+private const val NUMERIC_POS_ID_NUMBER_KANJI: Short = 2046
+
+private const val NUMERIC_TYPE_KANJI_MIXED: Byte = 17
+private const val NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT: Byte = 20
+private const val NUMERIC_TYPE_SUPERSCRIPT: Byte = 21
+private const val NUMERIC_TYPE_FULL_WIDTH: Byte = 30
+private const val NUMERIC_TYPE_HALF_WIDTH: Byte = 31
+private const val NUMERIC_TYPE_KANJI: Byte = 32
+private const val NUMERIC_TYPE_SEPARATED: Byte = 19
+
+private const val NUMERIC_BASE_SCORE = 700
+
+/**
+ * A lexical definition for a Japanese counter.
+ *
+ * Counter readings belong here instead of in the conversion engine so the parser can apply the
+ * same number + counter grammar to every conversion path.  The list is deliberately explicit:
+ * accepting every arbitrary dictionary suffix would turn ordinary words into numbers.
+ */
+private data class CounterDefinition(
+    val reading: String,
+    val output: String,
+    val timeLike: Boolean = false,
+    val supportsHalf: Boolean = false,
+    val rightId: Short = NUMERIC_POS_ID_COUNTER_GENERIC,
+    val lexicalPriorityExceptions: Set<String> = emptySet(),
+)
+
+private data class ParsedNumber(
+    val halfWidthDigits: String,
+    val value: Long?,
+)
+
+private data class ParsedNumericExpression(
+    val number: ParsedNumber,
+    val counter: CounterDefinition? = null,
+    val hasHalfModifier: Boolean = false,
+)
+
+private enum class NumericForm {
+    HALF_WIDTH,
+    FULL_WIDTH,
+    KANJI,
+    MIXED_KANJI,
+    COMMA,
+    EXPONENT,
+    SUPERSCRIPT,
+    SUBSCRIPT,
+}
+
+/**
+ * Shared parser and formatter for numeric readings.
+ *
+ * The parser recognizes a complete numeric expression, not just a whole-string Japanese number.
+ * This makes inputs such as "50えん" and "いちじかんはん" instances of the same grammar as
+ * "さんにん".  Formatting is performed only after the semantic expression is parsed.
+ */
+internal object NumericCandidateProvider {
+
+    private val counters = listOf(
+        CounterDefinition(
+            reading = "じかん",
+            output = "時間",
+            timeLike = true,
+            supportsHalf = true,
+            rightId = NUMERIC_POS_ID_COUNTER_TIME,
+        ),
+        CounterDefinition("しゅうかん", "週間", supportsHalf = true),
+        CounterDefinition("かげつ", "か月", supportsHalf = true),
+        CounterDefinition("びょう", "秒", timeLike = true, supportsHalf = true),
+        CounterDefinition("ぷん", "分", timeLike = true, supportsHalf = true),
+        CounterDefinition("ふん", "分", timeLike = true, supportsHalf = true),
+        CounterDefinition("にち", "日", supportsHalf = true),
+        CounterDefinition(
+            reading = "ねん",
+            output = "年",
+            supportsHalf = true,
+        ),
+        CounterDefinition("えん", "円"),
+        CounterDefinition("にん", "人"),
+        CounterDefinition(
+            reading = "じ",
+            output = "時",
+            timeLike = true,
+            supportsHalf = true,
+            rightId = NUMERIC_POS_ID_COUNTER_TIME,
+        ),
+        CounterDefinition(
+            reading = "しゅう",
+            output = "週",
+            supportsHalf = true,
+        ),
+        CounterDefinition("がつ", "月"),
+        CounterDefinition("こ", "個"),
+        CounterDefinition("まい", "枚"),
+        CounterDefinition("ぽん", "本"),
+        CounterDefinition("ぼん", "本"),
+        CounterDefinition(
+            reading = "ほん",
+            output = "本",
+            lexicalPriorityExceptions = setOf("にほん"),
+        ),
+        CounterDefinition("さつ", "冊"),
+        CounterDefinition("だい", "台"),
+        CounterDefinition(
+            reading = "かい",
+            output = "回",
+        ),
+        CounterDefinition("さい", "歳"),
+        CounterDefinition("けん", "件"),
+    ).sortedByDescending { it.reading.length }
+
+    fun isDigitSequence(input: String): Boolean =
+        input.isNotEmpty() && input.all { it in '0'..'9' || it in '０'..'９' }
+
+    /**
+     * Returns whether a parsed numeric expression is safe to move ahead of ordinary lexical
+     * candidates.  Some counter readings are unavoidable homophones (for example 「にほん」 can
+     * mean 日本 or 二本); the numeric candidates remain available, but the lexical candidate keeps
+     * the first position when the input is one of those readings.
+     */
+    fun shouldPrioritize(input: String): Boolean {
+        if (isDigitSequence(input)) return true
+        val expression = parse(input) ?: return false
+        return expression.counter?.lexicalPriorityExceptions?.contains(input) != true
+    }
+
+    fun generate(
+        input: String,
+        notationPreference: NumericNotationPreference = NumericNotationPreference.HALF_WIDTH_FIRST,
+        showSymbolCandidates: Boolean = true,
+    ): List<Candidate> {
+        val expression = parse(input) ?: return emptyList()
+        return render(
+            input = input,
+            expression = expression,
+            notationPreference = notationPreference,
+            showSymbolCandidates = showSymbolCandidates,
+        )
+    }
+
+    private fun parse(input: String): ParsedNumericExpression? {
+        if (input.isEmpty()) return null
+
+        if (isDigitSequence(input)) {
+            return ParsedNumericExpression(parseNumber(input))
+        }
+
+        input.toNumber()?.let { return ParsedNumericExpression(parseNumber(it.second)) }
+
+        val (body, hasHalfModifier) = when {
+            input.endsWith("はん") -> input.dropLast(2) to true
+            input.endsWith("半") -> input.dropLast(1) to true
+            else -> input to false
+        }
+
+        for (counter in counters) {
+            if (!body.endsWith(counter.reading)) continue
+            if (hasHalfModifier && !counter.supportsHalf) continue
+
+            val numberReading = body.dropLast(counter.reading.length)
+            val number = parseNumberReadingForCounter(numberReading) ?: continue
+            return ParsedNumericExpression(
+                number = number,
+                counter = counter,
+                hasHalfModifier = hasHalfModifier,
+            )
+        }
+
+        return null
+    }
+
+    private fun parseNumber(raw: String): ParsedNumber {
+        val halfWidthDigits = raw.convertFullWidthNumbersToHalfWidth()
+        return ParsedNumber(
+            halfWidthDigits = halfWidthDigits,
+            value = halfWidthDigits.toLongOrNull(),
+        )
+    }
+
+    private fun parseNumberReadingForCounter(reading: String): ParsedNumber? {
+        if (reading.isEmpty()) return null
+        if (isDigitSequence(reading)) return parseNumber(reading)
+
+        // Bare 「し」 and a final 「し」 after a place value are highly ambiguous before a
+        // counter (しえん, しじ, じゅうしにん).  The canonical alternatives remain usable:
+        // よんえん, よにん, しじゅうにん, etc.
+        if (reading.endsWith("し")) return null
+
+        val number = reading.toNumber() ?: return null
+        return parseNumber(number.second)
+    }
+
+    private fun render(
+        input: String,
+        expression: ParsedNumericExpression,
+        notationPreference: NumericNotationPreference,
+        showSymbolCandidates: Boolean,
+    ): List<Candidate> {
+        val forms = if (expression.counter == null) {
+            renderNumberOnlyForms(expression.number, notationPreference)
+        } else {
+            renderQuantityForms(expression, notationPreference)
+        }
+
+        val candidates = ArrayList<Candidate>(forms.size + 8)
+        val seen = LinkedHashSet<String>()
+        forms.forEachIndexed { index, (form, string) ->
+            if (!seen.add(string)) return@forEachIndexed
+            candidates += createCandidate(
+                input = input,
+                expression = expression,
+                form = form,
+                string = string,
+                rank = index,
+            )
+        }
+
+        if (expression.counter == null && expression.number.value != null) {
+            val value = expression.number.value
+            val halfWidthDigits = expression.number.halfWidthDigits
+            val inputLength = input.length.toUByte()
+            if (halfWidthDigits.isNotEmpty()) {
+                val exponent = value.toNumberExponentOrNull()
+                if (exponent != null && seen.add(exponent)) {
+                    candidates += Candidate(
+                        string = exponent,
+                        type = NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT,
+                        length = inputLength,
+                        score = NUMERIC_BASE_SCORE + candidates.size,
+                        leftId = NUMERIC_POS_ID_NUMBER_ARABIC,
+                        rightId = NUMERIC_POS_ID_NUMBER_ARABIC,
+                    )
+                }
+            }
+
+            listOf(
+                halfWidthDigits.toSuperscriptDigits() to NUMERIC_TYPE_SUPERSCRIPT,
+                halfWidthDigits.toSubscriptDigits() to NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT,
+            ).forEach { (string, type) ->
+                if (seen.add(string)) {
+                    candidates += Candidate(
+                        string = string,
+                        type = type,
+                        length = inputLength,
+                        score = NUMERIC_BASE_SCORE + candidates.size,
+                        leftId = NUMERIC_POS_ID_NUMBER_ARABIC,
+                        rightId = NUMERIC_POS_ID_NUMBER_ARABIC,
+                    )
+                }
+            }
+
+            if (showSymbolCandidates) {
+                createValueBasedSymbolCandidates(value, inputLength).forEach { candidate ->
+                    if (seen.add(candidate.string)) candidates += candidate
+                }
+            }
+        }
+
+        return candidates
+    }
+
+    private fun renderNumberOnlyForms(
+        number: ParsedNumber,
+        notationPreference: NumericNotationPreference,
+    ): List<Pair<NumericForm, String>> {
+        val available = linkedMapOf<NumericForm, String>()
+        addPrimaryForms(available, number, notationPreference)
+        return available.entries.map { it.key to it.value }
+    }
+
+    private fun renderQuantityForms(
+        expression: ParsedNumericExpression,
+        notationPreference: NumericNotationPreference,
+    ): List<Pair<NumericForm, String>> {
+        val available = linkedMapOf<NumericForm, String>()
+        addPrimaryForms(
+            target = available,
+            number = expression.number,
+            notationPreference = notationPreference,
+            suffix = expression.counter?.output.orEmpty() +
+                if (expression.hasHalfModifier) "半" else "",
+        )
+        return available.entries.map { it.key to it.value }
+    }
+
+    private fun addPrimaryForms(
+        target: LinkedHashMap<NumericForm, String>,
+        number: ParsedNumber,
+        notationPreference: NumericNotationPreference,
+        suffix: String = "",
+    ) {
+        val orderedForms = when (notationPreference) {
+            NumericNotationPreference.HALF_WIDTH_FIRST -> listOf(
+                NumericForm.HALF_WIDTH,
+                NumericForm.FULL_WIDTH,
+                NumericForm.KANJI,
+                NumericForm.MIXED_KANJI,
+                NumericForm.COMMA,
+            )
+
+            NumericNotationPreference.FULL_WIDTH_FIRST -> listOf(
+                NumericForm.FULL_WIDTH,
+                NumericForm.HALF_WIDTH,
+                NumericForm.KANJI,
+                NumericForm.MIXED_KANJI,
+                NumericForm.COMMA,
+            )
+
+            NumericNotationPreference.KANJI_FIRST -> listOf(
+                NumericForm.KANJI,
+                NumericForm.HALF_WIDTH,
+                NumericForm.FULL_WIDTH,
+                NumericForm.MIXED_KANJI,
+                NumericForm.COMMA,
+            )
+        }
+
+        orderedForms.forEach { form ->
+            val rendered = when (form) {
+                NumericForm.HALF_WIDTH -> number.halfWidthDigits
+                NumericForm.FULL_WIDTH -> number.halfWidthDigits.toFullWidthDigits()
+                NumericForm.KANJI -> number.value?.toKanji()
+                NumericForm.MIXED_KANJI -> number.value?.convertToKanjiNotation()
+                NumericForm.COMMA -> number.value?.let { number.halfWidthDigits.addCommasToNumber() }
+                else -> null
+            } ?: return@forEach
+
+            target.putIfAbsent(form, rendered + suffix)
+        }
+    }
+
+    private fun createCandidate(
+        input: String,
+        expression: ParsedNumericExpression,
+        form: NumericForm,
+        string: String,
+        rank: Int,
+    ): Candidate {
+        val counter = expression.counter
+        val timeLike = counter?.timeLike == true
+        val type = when (form) {
+            NumericForm.HALF_WIDTH -> if (timeLike) CANDIDATE_TYPE_TIME else NUMERIC_TYPE_HALF_WIDTH
+            NumericForm.FULL_WIDTH -> NUMERIC_TYPE_FULL_WIDTH
+            NumericForm.KANJI -> NUMERIC_TYPE_KANJI
+            NumericForm.MIXED_KANJI -> NUMERIC_TYPE_KANJI_MIXED
+            NumericForm.COMMA -> NUMERIC_TYPE_SEPARATED
+            NumericForm.EXPONENT -> NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT
+            NumericForm.SUPERSCRIPT -> NUMERIC_TYPE_SUPERSCRIPT
+            NumericForm.SUBSCRIPT -> NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT
+        }
+        val rightId = when {
+            counter == null -> when (form) {
+                NumericForm.COMMA -> NUMERIC_POS_ID_NUMBER_SEPARATED
+                NumericForm.KANJI, NumericForm.MIXED_KANJI -> NUMERIC_POS_ID_NUMBER_KANJI
+                else -> NUMERIC_POS_ID_NUMBER_ARABIC
+            }
+
+            else -> counter.rightId
+        }
+        val leftId = when (form) {
+            NumericForm.COMMA -> NUMERIC_POS_ID_NUMBER_SEPARATED
+            NumericForm.KANJI, NumericForm.MIXED_KANJI -> NUMERIC_POS_ID_NUMBER_KANJI
+            else -> NUMERIC_POS_ID_NUMBER_ARABIC
+        }
+        return Candidate(
+            string = string,
+            type = type,
+            length = input.length.toUByte(),
+            score = NUMERIC_BASE_SCORE + rank,
+            leftId = leftId,
+            rightId = rightId,
+        )
+    }
+
+    private fun Long.toNumberExponentOrNull(): String? {
+        if (this < 100_000_000L) return null
+        return this.toString().length.minus(1).let { exponent ->
+            val superscripts = mapOf(
+                '0' to '⁰', '1' to '¹', '2' to '²', '3' to '³', '4' to '⁴',
+                '5' to '⁵', '6' to '⁶', '7' to '⁷', '8' to '⁸', '9' to '⁹',
+            )
+            "10${exponent.toString().map { superscripts[it] ?: it }.joinToString("")}"
+        }
+    }
+
+    private fun String.toFullWidthDigits(): String = map { character ->
+        if (character in '0'..'9') (character.code + 0xFEE0).toChar() else character
+    }.joinToString("")
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProvider.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProvider.kt
@@ -1,407 +1,56 @@
 package com.kazumaproject.markdownhelperkeyboard.converter.engine
 
-import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_TIME
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.addCommasToNumber
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertFullWidthNumbersToHalfWidth
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.convertToKanjiNotation
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.createValueBasedSymbolCandidates
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toKanji
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toNumber
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toSubscriptDigits
-import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.toSuperscriptDigits
 
-private const val NUMERIC_POS_ID_COUNTER_GENERIC: Short = 2011
-private const val NUMERIC_POS_ID_COUNTER_TIME: Short = 2015
-private const val NUMERIC_POS_ID_NUMBER_ARABIC: Short = 2044
-private const val NUMERIC_POS_ID_NUMBER_SEPARATED: Short = 2045
-private const val NUMERIC_POS_ID_NUMBER_KANJI: Short = 2046
-
-private const val NUMERIC_TYPE_KANJI_MIXED: Byte = 17
-private const val NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT: Byte = 20
-private const val NUMERIC_TYPE_SUPERSCRIPT: Byte = 21
-private const val NUMERIC_TYPE_FULL_WIDTH: Byte = 30
-private const val NUMERIC_TYPE_HALF_WIDTH: Byte = 31
-private const val NUMERIC_TYPE_KANJI: Byte = 32
-private const val NUMERIC_TYPE_SEPARATED: Byte = 19
-
-private const val NUMERIC_BASE_SCORE = 700
-
-/**
- * A lexical definition for a Japanese counter.
- *
- * Counter readings belong here instead of in the conversion engine so the parser can apply the
- * same number + counter grammar to every conversion path.  The list is deliberately explicit:
- * accepting every arbitrary dictionary suffix would turn ordinary words into numbers.
- */
-private data class CounterDefinition(
-    val reading: String,
-    val output: String,
-    val timeLike: Boolean = false,
-    val supportsHalf: Boolean = false,
-    val rightId: Short = NUMERIC_POS_ID_COUNTER_GENERIC,
-    val lexicalPriorityExceptions: Set<String> = emptySet(),
-)
-
-private data class ParsedNumber(
-    val halfWidthDigits: String,
-    val value: Long?,
-)
-
-private data class ParsedNumericExpression(
-    val number: ParsedNumber,
-    val counter: CounterDefinition? = null,
-    val hasHalfModifier: Boolean = false,
-)
-
-private enum class NumericForm {
-    HALF_WIDTH,
-    FULL_WIDTH,
-    KANJI,
-    MIXED_KANJI,
-    COMMA,
-    EXPONENT,
-    SUPERSCRIPT,
-    SUBSCRIPT,
-}
-
-/**
- * Shared parser and formatter for numeric readings.
- *
- * The parser recognizes a complete numeric expression, not just a whole-string Japanese number.
- * This makes inputs such as "50えん" and "いちじかんはん" instances of the same grammar as
- * "さんにん".  Formatting is performed only after the semantic expression is parsed.
- */
+/** Compatibility entry point for the engine while the numeric pipeline remains independently testable. */
 internal object NumericCandidateProvider {
 
-    private val counters = listOf(
-        CounterDefinition(
-            reading = "じかん",
-            output = "時間",
-            timeLike = true,
-            supportsHalf = true,
-            rightId = NUMERIC_POS_ID_COUNTER_TIME,
-        ),
-        CounterDefinition("しゅうかん", "週間", supportsHalf = true),
-        CounterDefinition("かげつ", "か月", supportsHalf = true),
-        CounterDefinition("びょう", "秒", timeLike = true, supportsHalf = true),
-        CounterDefinition("ぷん", "分", timeLike = true, supportsHalf = true),
-        CounterDefinition("ふん", "分", timeLike = true, supportsHalf = true),
-        CounterDefinition("にち", "日", supportsHalf = true),
-        CounterDefinition(
-            reading = "ねん",
-            output = "年",
-            supportsHalf = true,
-        ),
-        CounterDefinition("えん", "円"),
-        CounterDefinition("にん", "人"),
-        CounterDefinition(
-            reading = "じ",
-            output = "時",
-            timeLike = true,
-            supportsHalf = true,
-            rightId = NUMERIC_POS_ID_COUNTER_TIME,
-        ),
-        CounterDefinition(
-            reading = "しゅう",
-            output = "週",
-            supportsHalf = true,
-        ),
-        CounterDefinition("がつ", "月"),
-        CounterDefinition("こ", "個"),
-        CounterDefinition("まい", "枚"),
-        CounterDefinition("ぽん", "本"),
-        CounterDefinition("ぼん", "本"),
-        CounterDefinition(
-            reading = "ほん",
-            output = "本",
-            lexicalPriorityExceptions = setOf("にほん"),
-        ),
-        CounterDefinition("さつ", "冊"),
-        CounterDefinition("だい", "台"),
-        CounterDefinition(
-            reading = "かい",
-            output = "回",
-        ),
-        CounterDefinition("さい", "歳"),
-        CounterDefinition("けん", "件"),
-    ).sortedByDescending { it.reading.length }
+    private val parser = NumericExpressionParser(BundledNumericSuffixCatalog)
+    private val renderer = NumericCandidateRenderer(BundledNumericSuffixCatalog)
 
-    fun isDigitSequence(input: String): Boolean =
-        input.isNotEmpty() && input.all { it in '0'..'9' || it in '０'..'９' }
+    fun isDigitSequence(input: String): Boolean = NumericNumberParser.isDigitSequence(input)
 
-    /**
-     * Returns whether a parsed numeric expression is safe to move ahead of ordinary lexical
-     * candidates.  Some counter readings are unavoidable homophones (for example 「にほん」 can
-     * mean 日本 or 二本); the numeric candidates remain available, but the lexical candidate keeps
-     * the first position when the input is one of those readings.
-     */
-    fun shouldPrioritize(input: String): Boolean {
-        if (isDigitSequence(input)) return true
-        val expression = parse(input) ?: return false
-        return expression.counter?.lexicalPriorityExceptions?.contains(input) != true
-    }
+    fun parse(input: String): List<NumericExpression> = parser.parse(input)
+
+    fun generateRendered(
+        input: String,
+        notationPreference: NumericNotationPreference = NumericNotationPreference.HALF_WIDTH_FIRST,
+        showSymbolCandidates: Boolean = true,
+    ): List<RenderedNumericCandidate> = renderer.render(
+        input = input,
+        expressions = parser.parse(input),
+        notationPreference = notationPreference,
+        showSymbolCandidates = showSymbolCandidates,
+    )
 
     fun generate(
         input: String,
         notationPreference: NumericNotationPreference = NumericNotationPreference.HALF_WIDTH_FIRST,
         showSymbolCandidates: Boolean = true,
-    ): List<Candidate> {
-        val expression = parse(input) ?: return emptyList()
-        return render(
-            input = input,
-            expression = expression,
-            notationPreference = notationPreference,
-            showSymbolCandidates = showSymbolCandidates,
-        )
-    }
+    ): List<Candidate> = generateRendered(
+        input = input,
+        notationPreference = notationPreference,
+        showSymbolCandidates = showSymbolCandidates,
+    ).map { it.candidate }
 
-    private fun parse(input: String): ParsedNumericExpression? {
-        if (input.isEmpty()) return null
-
-        if (isDigitSequence(input)) {
-            return ParsedNumericExpression(parseNumber(input))
-        }
-
-        input.toNumber()?.let { return ParsedNumericExpression(parseNumber(it.second)) }
-
-        val (body, hasHalfModifier) = when {
-            input.endsWith("はん") -> input.dropLast(2) to true
-            input.endsWith("半") -> input.dropLast(1) to true
-            else -> input to false
-        }
-
-        for (counter in counters) {
-            if (!body.endsWith(counter.reading)) continue
-            if (hasHalfModifier && !counter.supportsHalf) continue
-
-            val numberReading = body.dropLast(counter.reading.length)
-            val number = parseNumberReadingForCounter(numberReading) ?: continue
-            return ParsedNumericExpression(
-                number = number,
-                counter = counter,
-                hasHalfModifier = hasHalfModifier,
-            )
-        }
-
-        return null
-    }
-
-    private fun parseNumber(raw: String): ParsedNumber {
-        val halfWidthDigits = raw.convertFullWidthNumbersToHalfWidth()
-        return ParsedNumber(
-            halfWidthDigits = halfWidthDigits,
-            value = halfWidthDigits.toLongOrNull(),
-        )
-    }
-
-    private fun parseNumberReadingForCounter(reading: String): ParsedNumber? {
-        if (reading.isEmpty()) return null
-        if (isDigitSequence(reading)) return parseNumber(reading)
-
-        // Bare 「し」 and a final 「し」 after a place value are highly ambiguous before a
-        // counter (しえん, しじ, じゅうしにん).  The canonical alternatives remain usable:
-        // よんえん, よにん, しじゅうにん, etc.
-        if (reading.endsWith("し")) return null
-
-        val number = reading.toNumber() ?: return null
-        return parseNumber(number.second)
-    }
-
-    private fun render(
-        input: String,
-        expression: ParsedNumericExpression,
-        notationPreference: NumericNotationPreference,
-        showSymbolCandidates: Boolean,
-    ): List<Candidate> {
-        val forms = if (expression.counter == null) {
-            renderNumberOnlyForms(expression.number, notationPreference)
-        } else {
-            renderQuantityForms(expression, notationPreference)
-        }
-
-        val candidates = ArrayList<Candidate>(forms.size + 8)
-        val seen = LinkedHashSet<String>()
-        forms.forEachIndexed { index, (form, string) ->
-            if (!seen.add(string)) return@forEachIndexed
-            candidates += createCandidate(
-                input = input,
-                expression = expression,
-                form = form,
-                string = string,
-                rank = index,
-            )
-        }
-
-        if (expression.counter == null && expression.number.value != null) {
-            val value = expression.number.value
-            val halfWidthDigits = expression.number.halfWidthDigits
-            val inputLength = input.length.toUByte()
-            if (halfWidthDigits.isNotEmpty()) {
-                val exponent = value.toNumberExponentOrNull()
-                if (exponent != null && seen.add(exponent)) {
-                    candidates += Candidate(
-                        string = exponent,
-                        type = NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT,
-                        length = inputLength,
-                        score = NUMERIC_BASE_SCORE + candidates.size,
-                        leftId = NUMERIC_POS_ID_NUMBER_ARABIC,
-                        rightId = NUMERIC_POS_ID_NUMBER_ARABIC,
-                    )
-                }
-            }
-
-            listOf(
-                halfWidthDigits.toSuperscriptDigits() to NUMERIC_TYPE_SUPERSCRIPT,
-                halfWidthDigits.toSubscriptDigits() to NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT,
-            ).forEach { (string, type) ->
-                if (seen.add(string)) {
-                    candidates += Candidate(
-                        string = string,
-                        type = type,
-                        length = inputLength,
-                        score = NUMERIC_BASE_SCORE + candidates.size,
-                        leftId = NUMERIC_POS_ID_NUMBER_ARABIC,
-                        rightId = NUMERIC_POS_ID_NUMBER_ARABIC,
-                    )
-                }
-            }
-
-            if (showSymbolCandidates) {
-                createValueBasedSymbolCandidates(value, inputLength).forEach { candidate ->
-                    if (seen.add(candidate.string)) candidates += candidate
-                }
+    /**
+     * Numeric preference is applied for explicit digits and unambiguous readings.  A very short
+     * numeric prefix followed by a counter/unit is intentionally left to the lexical ranking;
+     * this is a grammar-level ambiguity policy that applies equally to every catalog definition.
+     */
+    fun shouldPrioritize(input: String): Boolean {
+        if (isDigitSequence(input)) return true
+        val expressions = parser.parse(input)
+        if (expressions.isEmpty()) return false
+        return expressions.none { expression ->
+            val sourceReading = expression.number.sourceReading ?: return@none false
+            sourceReading.length <= 1 && expression.suffixes.any {
+                it.type in setOf(
+                    NumericSuffixType.COUNTER,
+                    NumericSuffixType.TIME,
+                    NumericSuffixType.ORDINAL,
+                )
             }
         }
-
-        return candidates
     }
-
-    private fun renderNumberOnlyForms(
-        number: ParsedNumber,
-        notationPreference: NumericNotationPreference,
-    ): List<Pair<NumericForm, String>> {
-        val available = linkedMapOf<NumericForm, String>()
-        addPrimaryForms(available, number, notationPreference)
-        return available.entries.map { it.key to it.value }
-    }
-
-    private fun renderQuantityForms(
-        expression: ParsedNumericExpression,
-        notationPreference: NumericNotationPreference,
-    ): List<Pair<NumericForm, String>> {
-        val available = linkedMapOf<NumericForm, String>()
-        addPrimaryForms(
-            target = available,
-            number = expression.number,
-            notationPreference = notationPreference,
-            suffix = expression.counter?.output.orEmpty() +
-                if (expression.hasHalfModifier) "半" else "",
-        )
-        return available.entries.map { it.key to it.value }
-    }
-
-    private fun addPrimaryForms(
-        target: LinkedHashMap<NumericForm, String>,
-        number: ParsedNumber,
-        notationPreference: NumericNotationPreference,
-        suffix: String = "",
-    ) {
-        val orderedForms = when (notationPreference) {
-            NumericNotationPreference.HALF_WIDTH_FIRST -> listOf(
-                NumericForm.HALF_WIDTH,
-                NumericForm.FULL_WIDTH,
-                NumericForm.KANJI,
-                NumericForm.MIXED_KANJI,
-                NumericForm.COMMA,
-            )
-
-            NumericNotationPreference.FULL_WIDTH_FIRST -> listOf(
-                NumericForm.FULL_WIDTH,
-                NumericForm.HALF_WIDTH,
-                NumericForm.KANJI,
-                NumericForm.MIXED_KANJI,
-                NumericForm.COMMA,
-            )
-
-            NumericNotationPreference.KANJI_FIRST -> listOf(
-                NumericForm.KANJI,
-                NumericForm.HALF_WIDTH,
-                NumericForm.FULL_WIDTH,
-                NumericForm.MIXED_KANJI,
-                NumericForm.COMMA,
-            )
-        }
-
-        orderedForms.forEach { form ->
-            val rendered = when (form) {
-                NumericForm.HALF_WIDTH -> number.halfWidthDigits
-                NumericForm.FULL_WIDTH -> number.halfWidthDigits.toFullWidthDigits()
-                NumericForm.KANJI -> number.value?.toKanji()
-                NumericForm.MIXED_KANJI -> number.value?.convertToKanjiNotation()
-                NumericForm.COMMA -> number.value?.let { number.halfWidthDigits.addCommasToNumber() }
-                else -> null
-            } ?: return@forEach
-
-            target.putIfAbsent(form, rendered + suffix)
-        }
-    }
-
-    private fun createCandidate(
-        input: String,
-        expression: ParsedNumericExpression,
-        form: NumericForm,
-        string: String,
-        rank: Int,
-    ): Candidate {
-        val counter = expression.counter
-        val timeLike = counter?.timeLike == true
-        val type = when (form) {
-            NumericForm.HALF_WIDTH -> if (timeLike) CANDIDATE_TYPE_TIME else NUMERIC_TYPE_HALF_WIDTH
-            NumericForm.FULL_WIDTH -> NUMERIC_TYPE_FULL_WIDTH
-            NumericForm.KANJI -> NUMERIC_TYPE_KANJI
-            NumericForm.MIXED_KANJI -> NUMERIC_TYPE_KANJI_MIXED
-            NumericForm.COMMA -> NUMERIC_TYPE_SEPARATED
-            NumericForm.EXPONENT -> NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT
-            NumericForm.SUPERSCRIPT -> NUMERIC_TYPE_SUPERSCRIPT
-            NumericForm.SUBSCRIPT -> NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT
-        }
-        val rightId = when {
-            counter == null -> when (form) {
-                NumericForm.COMMA -> NUMERIC_POS_ID_NUMBER_SEPARATED
-                NumericForm.KANJI, NumericForm.MIXED_KANJI -> NUMERIC_POS_ID_NUMBER_KANJI
-                else -> NUMERIC_POS_ID_NUMBER_ARABIC
-            }
-
-            else -> counter.rightId
-        }
-        val leftId = when (form) {
-            NumericForm.COMMA -> NUMERIC_POS_ID_NUMBER_SEPARATED
-            NumericForm.KANJI, NumericForm.MIXED_KANJI -> NUMERIC_POS_ID_NUMBER_KANJI
-            else -> NUMERIC_POS_ID_NUMBER_ARABIC
-        }
-        return Candidate(
-            string = string,
-            type = type,
-            length = input.length.toUByte(),
-            score = NUMERIC_BASE_SCORE + rank,
-            leftId = leftId,
-            rightId = rightId,
-        )
-    }
-
-    private fun Long.toNumberExponentOrNull(): String? {
-        if (this < 100_000_000L) return null
-        return this.toString().length.minus(1).let { exponent ->
-            val superscripts = mapOf(
-                '0' to '⁰', '1' to '¹', '2' to '²', '3' to '³', '4' to '⁴',
-                '5' to '⁵', '6' to '⁶', '7' to '⁷', '8' to '⁸', '9' to '⁹',
-            )
-            "10${exponent.toString().map { superscripts[it] ?: it }.joinToString("")}"
-        }
-    }
-
-    private fun String.toFullWidthDigits(): String = map { character ->
-        if (character in '0'..'9') (character.code + 0xFEE0).toChar() else character
-    }.joinToString("")
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProvider.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProvider.kt
@@ -33,24 +33,11 @@ internal object NumericCandidateProvider {
         showSymbolCandidates = showSymbolCandidates,
     ).map { it.candidate }
 
-    /**
-     * Numeric preference is applied for explicit digits and unambiguous readings.  A very short
-     * numeric prefix followed by a counter/unit is intentionally left to the lexical ranking;
-     * this is a grammar-level ambiguity policy that applies equally to every catalog definition.
-     */
-    fun shouldPrioritize(input: String): Boolean {
-        if (isDigitSequence(input)) return true
-        val expressions = parser.parse(input)
-        if (expressions.isEmpty()) return false
-        return expressions.none { expression ->
-            val sourceReading = expression.number.sourceReading ?: return@none false
-            sourceReading.length <= 1 && expression.suffixes.any {
-                it.type in setOf(
-                    NumericSuffixType.COUNTER,
-                    NumericSuffixType.TIME,
-                    NumericSuffixType.ORDINAL,
-                )
-            }
-        }
-    }
+    /** Explicit numeric spelling, including a following counter, opts into notation ordering. */
+    fun shouldPrioritize(input: String): Boolean =
+        input.firstOrNull()?.let { it in '0'..'9' || it in '０'..'９' } == true &&
+            parser.parse(input).isNotEmpty()
+
+    fun isLearnableConversion(input: String, output: String): Boolean =
+        generate(input, showSymbolCandidates = false).any { it.string == output }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateRenderer.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateRenderer.kt
@@ -1,0 +1,376 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_TIME
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CandidateConversionSegment
+import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.createValueBasedSymbolCandidates
+
+private const val NUMERIC_POS_ID_COUNTER_GENERIC: Short = 2011
+private const val NUMERIC_POS_ID_COUNTER_TIME: Short = 2015
+private const val NUMERIC_POS_ID_NUMBER_ARABIC: Short = 2044
+private const val NUMERIC_POS_ID_NUMBER_SEPARATED: Short = 2045
+private const val NUMERIC_POS_ID_NUMBER_KANJI: Short = 2046
+
+private const val NUMERIC_TYPE_KANJI_MIXED: Byte = 17
+private const val NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT: Byte = 20
+private const val NUMERIC_TYPE_SUPERSCRIPT: Byte = 21
+private const val NUMERIC_TYPE_FULL_WIDTH: Byte = 30
+private const val NUMERIC_TYPE_HALF_WIDTH: Byte = 31
+private const val NUMERIC_TYPE_KANJI: Byte = 32
+private const val NUMERIC_TYPE_SEPARATED: Byte = 19
+
+private const val NUMERIC_BASE_SCORE = 700
+
+data class RenderedNumericCandidate(
+    val candidate: Candidate,
+    val segments: List<CandidateConversionSegment>,
+    val expression: NumericExpression,
+)
+
+/** Renders a semantic expression into the configured numeric notation variants. */
+class NumericCandidateRenderer(
+    private val catalog: NumericSuffixCatalog,
+    private val readingResolver: NumericReadingResolver = NumericReadingResolver(),
+) {
+
+    init {
+        require(catalog.validate().isEmpty()) { catalog.validate().joinToString() }
+    }
+
+    private data class PrimaryForm(
+        val style: NumberStyle,
+        val number: String,
+    )
+
+    fun render(
+        input: String,
+        expressions: List<NumericExpression>,
+        notationPreference: NumericNotationPreference = NumericNotationPreference.HALF_WIDTH_FIRST,
+        showSymbolCandidates: Boolean = true,
+    ): List<RenderedNumericCandidate> {
+        if (expressions.isEmpty()) return emptyList()
+
+        val results = ArrayList<RenderedNumericCandidate>()
+        val seen = LinkedHashSet<String>()
+        expressions.forEach { expression ->
+            val canonicalSuffixVariants = renderSuffixVariants(expression, canonicalOnly = true)
+            val suffixVariants = renderSuffixVariants(expression, canonicalOnly = false)
+                .filterNot { it in canonicalSuffixVariants }
+            val primaryForms = primaryForms(expression.number, notationPreference)
+            primaryForms.forEach { form ->
+                canonicalSuffixVariants.forEach suffixLoop@{ suffixes ->
+                    val string = form.number + suffixes.joinToString("")
+                    if (!seen.add(string)) return@suffixLoop
+                    results += renderedCandidate(
+                        input = input,
+                        expression = expression,
+                        numberStyle = form.style,
+                        string = string,
+                        suffixOutputs = suffixes,
+                        rank = results.size,
+                    )
+                }
+            }
+            primaryForms.forEach { form ->
+                suffixVariants.forEach suffixLoop@{ suffixes ->
+                    val string = form.number + suffixes.joinToString("")
+                    if (!seen.add(string)) return@suffixLoop
+                    results += renderedCandidate(
+                        input = input,
+                        expression = expression,
+                        numberStyle = form.style,
+                        string = string,
+                        suffixOutputs = suffixes,
+                        rank = results.size,
+                    )
+                }
+            }
+
+            if (expression.suffixes.isEmpty()) {
+                renderExtendedNumberCandidates(
+                    input = input,
+                    expression = expression,
+                    seen = seen,
+                    results = results,
+                    showSymbolCandidates = showSymbolCandidates,
+                )
+            }
+        }
+        return results
+    }
+
+    private fun primaryForms(
+        number: NumericValue,
+        notationPreference: NumericNotationPreference,
+    ): List<PrimaryForm> {
+        val digits = number.sourceDigits ?: number.value.toString()
+        val forms = linkedMapOf<NumberStyle, String>()
+        val orderedStyles = when (notationPreference) {
+            NumericNotationPreference.HALF_WIDTH_FIRST -> listOf(
+                NumberStyle.ASCII,
+                NumberStyle.FULL_WIDTH,
+                NumberStyle.KANJI,
+                NumberStyle.MIXED_KANJI,
+                NumberStyle.COMMA,
+            )
+
+            NumericNotationPreference.FULL_WIDTH_FIRST -> listOf(
+                NumberStyle.FULL_WIDTH,
+                NumberStyle.ASCII,
+                NumberStyle.KANJI,
+                NumberStyle.MIXED_KANJI,
+                NumberStyle.COMMA,
+            )
+
+            NumericNotationPreference.KANJI_FIRST -> listOf(
+                NumberStyle.KANJI,
+                NumberStyle.ASCII,
+                NumberStyle.FULL_WIDTH,
+                NumberStyle.MIXED_KANJI,
+                NumberStyle.COMMA,
+            )
+        }
+
+        orderedStyles.forEach { style ->
+            val rendered = when (style) {
+                NumberStyle.ASCII -> digits
+                NumberStyle.FULL_WIDTH -> NumericNumberFormatter.toFullWidthDigits(digits)
+                NumberStyle.KANJI -> NumericNumberFormatter.toJapaneseKanji(number.value)
+                NumberStyle.MIXED_KANJI -> NumericNumberFormatter.toMixedKanji(number.value)
+                NumberStyle.COMMA -> NumericNumberFormatter.addDigitGrouping(digits)
+            }
+            forms.putIfAbsent(style, rendered)
+        }
+        return forms.map { (style, value) -> PrimaryForm(style, value) }
+    }
+
+    private fun renderSuffixVariants(
+        expression: NumericExpression,
+        canonicalOnly: Boolean,
+    ): List<List<String>> {
+        if (expression.suffixes.isEmpty()) return listOf(emptyList())
+
+        var variants: List<List<String>> = listOf(emptyList())
+        expression.suffixes.forEachIndexed suffixLoop@{ index, suffix ->
+            val definition = catalog.definition(suffix.definitionId) ?: return@suffixLoop
+            val surfaces = suffixSurfaces(
+                suffix = suffix,
+                definition = definition,
+                canonicalOnly = canonicalOnly,
+                number = expression.number,
+                previousSuffixes = expression.suffixes.take(index),
+            )
+            variants = variants.flatMap { prefix -> surfaces.map { prefix + it } }
+        }
+        return variants.distinct()
+    }
+
+    private fun suffixSurfaces(
+        suffix: NumericSuffix,
+        definition: NumericSuffixDefinition,
+        canonicalOnly: Boolean,
+        number: NumericValue,
+        previousSuffixes: List<NumericSuffix>,
+    ): List<String> {
+        val surfaces = LinkedHashSet<String>()
+        if (SuffixStyle.CANONICAL in definition.allowedStyles) {
+            definition.surfaces
+                .filter { it.style == SuffixStyle.CANONICAL }
+                .forEach { surfaces += it.surface }
+        }
+        if (canonicalOnly) return surfaces.toList()
+        val validReadings = definition.readingRules
+            .asSequence()
+            .filter { it.wholeExpressionValue == null }
+            .filter {
+                readingResolver.matches(
+                    condition = it.condition,
+                    value = number,
+                    previousSuffixes = previousSuffixes,
+                )
+            }
+            .map { it.reading }
+            .toList()
+            .let { readings -> listOf(suffix.matchedReading) + readings }
+            .distinct()
+        if (SuffixStyle.HIRAGANA in definition.allowedStyles) {
+            definition.surfaces
+                .filter { it.style == SuffixStyle.HIRAGANA }
+                .forEach { surfaces += it.surface }
+            validReadings.forEach { reading -> surfaces += reading.toHiragana() }
+        }
+        if (SuffixStyle.KATAKANA in definition.allowedStyles) {
+            definition.surfaces
+                .filter { it.style == SuffixStyle.KATAKANA }
+                .forEach { surfaces += it.surface }
+            validReadings.forEach { reading -> surfaces += reading.toKatakana() }
+        }
+        return surfaces.toList()
+    }
+
+    private fun renderedCandidate(
+        input: String,
+        expression: NumericExpression,
+        numberStyle: NumberStyle,
+        string: String,
+        suffixOutputs: List<String>,
+        rank: Int,
+    ): RenderedNumericCandidate {
+        val timeLike = expression.suffixes.any { it.type == NumericSuffixType.TIME }
+        val type = when (numberStyle) {
+            NumberStyle.ASCII -> if (timeLike) CANDIDATE_TYPE_TIME else NUMERIC_TYPE_HALF_WIDTH
+            NumberStyle.FULL_WIDTH -> NUMERIC_TYPE_FULL_WIDTH
+            NumberStyle.KANJI -> NUMERIC_TYPE_KANJI
+            NumberStyle.MIXED_KANJI -> NUMERIC_TYPE_KANJI_MIXED
+            NumberStyle.COMMA -> NUMERIC_TYPE_SEPARATED
+        }
+        val leftId = when (numberStyle) {
+            NumberStyle.COMMA -> NUMERIC_POS_ID_NUMBER_SEPARATED
+            NumberStyle.KANJI, NumberStyle.MIXED_KANJI -> NUMERIC_POS_ID_NUMBER_KANJI
+            else -> NUMERIC_POS_ID_NUMBER_ARABIC
+        }
+        val lastSuffixDefinition = expression.suffixes.lastOrNull()?.let {
+            catalog.definition(it.definitionId)
+        }
+        val rightId = if (expression.suffixes.isNotEmpty()) {
+            lastSuffixDefinition?.rightId ?: if (timeLike) {
+                NUMERIC_POS_ID_COUNTER_TIME
+            } else {
+                NUMERIC_POS_ID_COUNTER_GENERIC
+            }
+        } else {
+            when (numberStyle) {
+                NumberStyle.COMMA -> NUMERIC_POS_ID_NUMBER_SEPARATED
+                NumberStyle.KANJI, NumberStyle.MIXED_KANJI -> NUMERIC_POS_ID_NUMBER_KANJI
+                else -> NUMERIC_POS_ID_NUMBER_ARABIC
+            }
+        }
+
+        return RenderedNumericCandidate(
+            candidate = Candidate(
+                string = string,
+                type = type,
+                length = input.length.toUByte(),
+                score = NUMERIC_BASE_SCORE + rank,
+                leftId = leftId,
+                rightId = rightId,
+            ),
+            segments = createSegments(expression, string, suffixOutputs),
+            expression = expression,
+        )
+    }
+
+    private fun createSegments(
+        expression: NumericExpression,
+        string: String,
+        suffixOutputs: List<String>,
+    ): List<CandidateConversionSegment> {
+        val number = expression.number
+        val suffixes = expression.suffixes
+        if (
+            suffixes.size == 1 &&
+            number.inputStart == suffixes.first().inputStart &&
+            number.inputEnd == suffixes.first().inputEnd
+        ) {
+            return listOf(
+                CandidateConversionSegment(
+                    inputStart = number.inputStart,
+                    inputEnd = number.inputEnd,
+                    output = string,
+                ),
+            )
+        }
+
+        val segments = mutableListOf<CandidateConversionSegment>()
+        if (number.inputEnd > number.inputStart) {
+            val numberOutputLength = string.length - suffixOutputs.sumOf { it.length }
+            segments += CandidateConversionSegment(
+                inputStart = number.inputStart,
+                inputEnd = number.inputEnd,
+                output = string.take(numberOutputLength),
+            )
+        }
+        suffixes.forEachIndexed { index, suffix ->
+            segments += CandidateConversionSegment(
+                inputStart = suffix.inputStart,
+                inputEnd = suffix.inputEnd,
+                output = suffixOutputs.getOrElse(index) { suffix.surface },
+            )
+        }
+        return segments
+    }
+
+    private fun renderExtendedNumberCandidates(
+        input: String,
+        expression: NumericExpression,
+        seen: MutableSet<String>,
+        results: MutableList<RenderedNumericCandidate>,
+        showSymbolCandidates: Boolean,
+    ) {
+        val number = expression.number
+        val digits = number.sourceDigits ?: number.value.toString()
+        val exponent = NumericNumberFormatter.toExponentOrNull(number.value)
+        if (exponent != null && seen.add(exponent)) {
+            val candidate = Candidate(
+                string = exponent,
+                type = NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT,
+                length = input.length.toUByte(),
+                score = NUMERIC_BASE_SCORE + results.size,
+                leftId = NUMERIC_POS_ID_NUMBER_ARABIC,
+                rightId = NUMERIC_POS_ID_NUMBER_ARABIC,
+            )
+            results += RenderedNumericCandidate(
+                candidate = candidate,
+                segments = listOf(
+                    CandidateConversionSegment(number.inputStart, number.inputEnd, exponent),
+                ),
+                expression = expression,
+            )
+        }
+
+        listOf(
+            NumericNumberFormatter.toSuperscript(digits) to NUMERIC_TYPE_SUPERSCRIPT,
+            NumericNumberFormatter.toSubscript(digits) to NUMERIC_TYPE_EXPONENT_OR_SUBSCRIPT,
+        ).forEach { (string, type) ->
+            if (!seen.add(string)) return@forEach
+            val candidate = Candidate(
+                string = string,
+                type = type,
+                length = input.length.toUByte(),
+                score = NUMERIC_BASE_SCORE + results.size,
+                leftId = NUMERIC_POS_ID_NUMBER_ARABIC,
+                rightId = NUMERIC_POS_ID_NUMBER_ARABIC,
+            )
+            results += RenderedNumericCandidate(
+                candidate = candidate,
+                segments = listOf(
+                    CandidateConversionSegment(number.inputStart, number.inputEnd, string),
+                ),
+                expression = expression,
+            )
+        }
+
+        if (showSymbolCandidates && number.value.bitLength() <= 63) {
+            val value = number.value.toLong()
+            createValueBasedSymbolCandidates(value, input.length.toUByte()).forEach { candidate ->
+                if (seen.add(candidate.string)) {
+                    results += RenderedNumericCandidate(
+                        candidate = candidate,
+                        segments = listOf(
+                            CandidateConversionSegment(number.inputStart, number.inputEnd, candidate.string),
+                        ),
+                        expression = expression,
+                    )
+                }
+            }
+        }
+    }
+
+    private fun String.toHiragana(): String = map { character ->
+        if (character in 'ァ'..'ヶ') (character.code - 0x60).toChar() else character
+    }.joinToString("")
+
+    private fun String.toKatakana(): String = map { character ->
+        if (character in 'ぁ'..'ゖ') (character.code + 0x60).toChar() else character
+    }.joinToString("")
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericExpression.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericExpression.kt
@@ -1,0 +1,178 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import java.math.BigInteger
+
+/** The semantic category of a numeric suffix. */
+enum class NumericSuffixType {
+    COUNTER,
+    UNIT,
+    CURRENCY,
+    TIME,
+    DATE,
+    ORDINAL,
+    OTHER,
+}
+
+enum class SuffixStyle {
+    CANONICAL,
+    HIRAGANA,
+    KATAKANA,
+}
+
+enum class NumberStyle {
+    ASCII,
+    FULL_WIDTH,
+    KANJI,
+    MIXED_KANJI,
+    COMMA,
+}
+
+enum class NumericPhonologicalFeature {
+    GEMINATE,
+}
+
+data class NumericValue(
+    val value: BigInteger,
+    val sourceReading: String? = null,
+    val sourceDigits: String? = null,
+    val phonologicalFeatures: Set<NumericPhonologicalFeature> = emptySet(),
+    /** UTF-16 range occupied by the number in the original reading. */
+    val inputStart: Int = 0,
+    val inputEnd: Int = 0,
+)
+
+data class NumericSuffix(
+    val definitionId: String,
+    val matchedReading: String,
+    val surface: String,
+    val type: NumericSuffixType,
+    val inputStart: Int,
+    val inputEnd: Int,
+)
+
+data class NumericExpression(
+    val number: NumericValue,
+    val suffixes: List<NumericSuffix>,
+)
+
+data class NumericSurface(
+    val style: SuffixStyle,
+    val surface: String,
+)
+
+/** A data-only rule describing one accepted reading of a suffix. */
+data class NumericReadingRule(
+    val reading: String,
+    val condition: NumericCondition = NumericCondition.Always,
+    /** Non-null rules represent lexicalized readings such as 「ひとり」 or 「ふつか」. */
+    val wholeExpressionValue: BigInteger? = null,
+)
+
+sealed interface NumericCondition {
+    data object Always : NumericCondition
+
+    data class ValueEquals(val value: BigInteger) : NumericCondition
+
+    data class LastDigitIn(val digits: Set<Int>) : NumericCondition
+
+    data class ModuloIn(
+        val modulo: Int,
+        val values: Set<Int>,
+    ) : NumericCondition
+
+    data class SourceReadingEndsWith(val readings: Set<String>) : NumericCondition
+
+    data class FeatureIn(val features: Set<NumericPhonologicalFeature>) : NumericCondition
+
+    data class AllOf(val conditions: List<NumericCondition>) : NumericCondition
+
+    data class AnyOf(val conditions: List<NumericCondition>) : NumericCondition
+}
+
+/** Data-driven constraints for suffix chains such as 「時間」 + 「半」. */
+data class NumericCompositionRule(
+    val allowedPreviousTypes: Set<NumericSuffixType>? = null,
+    val allowedPreviousIds: Set<String>? = null,
+) {
+    fun allows(previous: List<NumericSuffix>): Boolean {
+        if (previous.isEmpty()) {
+            return allowedPreviousTypes == null && allowedPreviousIds == null
+        }
+        val previousSuffix = previous.last()
+        val typeAllowed = allowedPreviousTypes?.contains(previousSuffix.type) ?: true
+        val idAllowed = allowedPreviousIds?.contains(previousSuffix.definitionId) ?: true
+        return typeAllowed && idAllowed
+    }
+
+    companion object {
+        fun none(): NumericCompositionRule = NumericCompositionRule()
+    }
+}
+
+/** A suffix definition contains vocabulary and rules only; it contains no conversion logic. */
+data class NumericSuffixDefinition(
+    val id: String,
+    val type: NumericSuffixType,
+    val surfaces: List<NumericSurface>,
+    val allowedStyles: Set<SuffixStyle>,
+    val readingRules: List<NumericReadingRule>,
+    val composition: NumericCompositionRule = NumericCompositionRule.none(),
+    /** Optional dictionary POS ids used when the rendered candidate enters the main lattice. */
+    val leftId: Short? = null,
+    val rightId: Short? = null,
+) {
+    val canonicalSurfaces: List<String>
+        get() = surfaces.filter { it.style == SuffixStyle.CANONICAL }.map { it.surface }
+}
+
+/**
+ * The parser and renderer depend on this abstraction rather than on a fixed counter list.
+ * A catalog is vocabulary data and can be replaced in tests or by a future dictionary loader
+ * without changing the conversion algorithms.
+ */
+interface NumericSuffixCatalog {
+    val definitions: List<NumericSuffixDefinition>
+
+    fun definition(id: String): NumericSuffixDefinition? =
+        definitions.firstOrNull { it.id == id }
+
+    fun validate(): List<String> {
+        val errors = mutableListOf<String>()
+        val ids = definitions.map { it.id }.toSet()
+        val duplicateIds = definitions.groupingBy { it.id }.eachCount().filterValues { it > 1 }
+        duplicateIds.keys.forEach { errors += "duplicate suffix id: $it" }
+        definitions.forEach { definition ->
+            if (definition.id.isBlank()) errors += "blank suffix id"
+            if (definition.surfaces.isEmpty()) errors += "no surface for ${definition.id}"
+            definition.surfaces.forEach { surface ->
+                if (surface.surface.isBlank()) {
+                    errors += "blank surface for ${definition.id}"
+                }
+                if (surface.style !in definition.allowedStyles) {
+                    errors += "surface style ${surface.style} is not allowed for ${definition.id}"
+                }
+            }
+            if (definition.surfaces.none { it.style == SuffixStyle.CANONICAL }) {
+                errors += "no canonical surface for ${definition.id}"
+            }
+            if (definition.allowedStyles.isEmpty()) {
+                errors += "no allowed suffix style for ${definition.id}"
+            }
+            if (SuffixStyle.CANONICAL !in definition.allowedStyles) {
+                errors += "canonical style is not allowed for ${definition.id}"
+            }
+            if (definition.readingRules.isEmpty()) {
+                errors += "no reading rule for ${definition.id}"
+            }
+            definition.readingRules.forEach { rule ->
+                if (rule.reading.isBlank()) errors += "blank reading for ${definition.id}"
+            }
+            definition.composition.allowedPreviousIds.orEmpty().forEach { previousId ->
+                if (previousId !in ids) {
+                    errors += "unknown previous suffix $previousId for ${definition.id}"
+                }
+            }
+        }
+        return errors
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericExpressionParser.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericExpressionParser.kt
@@ -1,0 +1,131 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+/**
+ * Parses a reading into every semantic numeric interpretation available in a suffix catalog.
+ *
+ * The parser knows only the number grammar and the catalog protocol.  In particular, it never
+ * names a counter, unit, or reading exception; those are supplied by [NumericSuffixDefinition].
+ */
+class NumericExpressionParser(
+    private val catalog: NumericSuffixCatalog,
+    private val readingResolver: NumericReadingResolver = NumericReadingResolver(),
+) {
+
+    init {
+        require(catalog.validate().isEmpty()) { catalog.validate().joinToString() }
+    }
+
+    private val definitionsByReadingLength = catalog.definitions
+        .sortedByDescending { definition ->
+            definition.readingRules.maxOfOrNull { it.reading.length } ?: 0
+        }
+
+    fun parse(input: String): List<NumericExpression> {
+        if (input.isEmpty()) return emptyList()
+
+        val expressions = LinkedHashSet<NumericExpression>()
+        addWholeExpressionInterpretations(input, expressions)
+
+        NumericNumberParser.parsePrefixes(input).forEach { prefix ->
+            val number = prefix.number.toValue(0, prefix.end)
+
+            // A final 「し」 is a valid standalone cardinal reading, but is not a reliable
+            // counter prefix.  This is a grammar-level ambiguity rule and does not single out a
+            // suffix or lexical word.
+            if (prefix.end < input.length && number.sourceReading?.endsWith("し") == true) {
+                return@forEach
+            }
+
+            if (prefix.end == input.length) {
+                expressions += NumericExpression(number = number, suffixes = emptyList())
+            } else {
+                parseSuffixes(
+                    input = input,
+                    offset = prefix.end,
+                    number = number,
+                    previousSuffixes = emptyList(),
+                ).forEach { suffixes ->
+                    expressions += NumericExpression(number = number, suffixes = suffixes)
+                }
+            }
+        }
+
+        return expressions.toList()
+    }
+
+    private fun addWholeExpressionInterpretations(
+        input: String,
+        expressions: MutableSet<NumericExpression>,
+    ) {
+        catalog.definitions.forEach definitionLoop@{ definition ->
+            readingResolver.resolveWholeExpression(definition, input).forEach ruleLoop@{ rule ->
+                val value = rule.wholeExpressionValue ?: return@ruleLoop
+                val number = NumericValue(
+                    value = value,
+                    sourceReading = input,
+                    inputStart = 0,
+                    inputEnd = input.length,
+                )
+                expressions += NumericExpression(
+                    number = number,
+                    suffixes = listOf(
+                        NumericSuffix(
+                            definitionId = definition.id,
+                            matchedReading = input,
+                            surface = definition.canonicalSurfaces.first(),
+                            type = definition.type,
+                            inputStart = 0,
+                            inputEnd = input.length,
+                        ),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun parseSuffixes(
+        input: String,
+        offset: Int,
+        number: NumericValue,
+        previousSuffixes: List<NumericSuffix>,
+    ): List<List<NumericSuffix>> {
+        if (offset == input.length) return listOf(previousSuffixes)
+
+        val results = LinkedHashSet<List<NumericSuffix>>()
+        definitionsByReadingLength.forEach definitionLoop@{ definition ->
+            if (!definition.composition.allows(previousSuffixes)) return@definitionLoop
+
+            definition.readingRules
+                .asSequence()
+                .filter { it.wholeExpressionValue == null }
+                .sortedByDescending { it.reading.length }
+                .forEach ruleLoop@{ rule ->
+                    if (!input.startsWith(rule.reading, offset)) return@ruleLoop
+                    val end = offset + rule.reading.length
+                    val suffix = NumericSuffix(
+                        definitionId = definition.id,
+                        matchedReading = rule.reading,
+                        surface = definition.canonicalSurfaces.first(),
+                        type = definition.type,
+                        inputStart = offset,
+                        inputEnd = end,
+                    )
+                    val value = readingResolver.resolve(
+                        definition = definition,
+                        value = number,
+                        matchedReading = rule.reading,
+                        previousSuffixes = previousSuffixes,
+                    )
+                    if (value.isEmpty()) return@ruleLoop
+
+                    parseSuffixes(
+                        input = input,
+                        offset = end,
+                        number = number,
+                        previousSuffixes = previousSuffixes + suffix,
+                    ).forEach { suffixes -> results += suffixes }
+                }
+        }
+        return results.toList()
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericNumberFormatter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericNumberFormatter.kt
@@ -64,7 +64,7 @@ internal object NumericNumberFormatter {
         return if (restStart == digitsText.length) {
             digitsText
         } else {
-            first + digitsText.substring(restStart).chunked(3).joinToString("", prefix = ",")
+            first + digitsText.substring(restStart).chunked(3).joinToString(",", prefix = ",")
         }
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericNumberFormatter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericNumberFormatter.kt
@@ -1,0 +1,114 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import java.math.BigInteger
+
+/** Shared BigInteger formatting used by the numeric renderer and legacy number extensions. */
+internal object NumericNumberFormatter {
+
+    private val tenThousand = BigInteger.valueOf(10_000)
+    private val zero = BigInteger.ZERO
+    private val bigUnits = listOf(
+        "", "万", "億", "兆", "京", "垓", "𥝱", "穣", "溝", "澗", "正", "載", "極",
+        "恒河沙", "阿僧祇", "那由他", "不可思議", "無量大数",
+    )
+    private val digits = listOf("〇", "一", "二", "三", "四", "五", "六", "七", "八", "九")
+    private val smallUnits = listOf("", "十", "百", "千")
+
+    fun toJapaneseKanji(value: BigInteger): String {
+        if (value == zero) return "〇"
+        if (value.signum() < 0) return "−" + toJapaneseKanji(value.negate())
+
+        var remaining = value
+        var unitIndex = 0
+        var result = ""
+        while (remaining > zero) {
+            val chunk = remaining.mod(tenThousand).toInt()
+            if (chunk != 0) {
+                if (unitIndex >= bigUnits.size) return value.toString()
+                result = renderSmallChunk(chunk) + bigUnits[unitIndex] + result
+            }
+            remaining = remaining.divide(tenThousand)
+            unitIndex++
+        }
+        return result
+    }
+
+    fun toMixedKanji(value: BigInteger): String {
+        if (value < tenThousand) return value.toString()
+        if (value.signum() < 0) return "−" + toMixedKanji(value.negate())
+
+        var remaining = value
+        var unitIndex = 0
+        val chunks = mutableListOf<Pair<Int, Int>>()
+        while (remaining > zero) {
+            val chunk = remaining.mod(tenThousand).toInt()
+            if (chunk != 0) chunks += chunk to unitIndex
+            remaining = remaining.divide(tenThousand)
+            unitIndex++
+        }
+        if (chunks.any { it.second >= bigUnits.size }) return value.toString()
+        return chunks.asReversed().joinToString("") { (chunk, index) ->
+            chunk.toString() + bigUnits[index]
+        }
+    }
+
+    fun addDigitGrouping(digitsText: String): String {
+        if (digitsText.length <= 3) return digitsText
+        val firstLength = digitsText.length % 3
+        val first = if (firstLength == 0) {
+            digitsText.substring(0, 3)
+        } else {
+            digitsText.substring(0, firstLength)
+        }
+        val restStart = first.length
+        return if (restStart == digitsText.length) {
+            digitsText
+        } else {
+            first + digitsText.substring(restStart).chunked(3).joinToString("", prefix = ",")
+        }
+    }
+
+    fun toFullWidthDigits(digitsText: String): String = digitsText.map { character ->
+        if (character in '0'..'9') (character.code + 0xFEE0).toChar() else character
+    }.joinToString("")
+
+    fun toExponentOrNull(value: BigInteger): String? {
+        if (value < BigInteger.valueOf(100_000_000L)) return null
+        val exponent = value.toString().length - 1
+        return "10" + exponent.toString().map { superscript(it) }.joinToString("")
+    }
+
+    fun toSuperscript(digitsText: String): String = digitsText.map(::superscript).joinToString("")
+
+    fun toSubscript(digitsText: String): String = digitsText.map { character ->
+        subscriptDigits[character] ?: character
+    }.joinToString("")
+
+    private fun renderSmallChunk(chunk: Int): String {
+        var value = chunk
+        var unitIndex = 0
+        var result = ""
+        while (value > 0) {
+            val digit = value % 10
+            if (digit != 0) {
+                val digitText = if (digit == 1 && unitIndex > 0) "" else digits[digit]
+                result = digitText + smallUnits[unitIndex] + result
+            }
+            value /= 10
+            unitIndex++
+        }
+        return result
+    }
+
+    private val superscriptDigits = mapOf(
+        '0' to '⁰', '1' to '¹', '2' to '²', '3' to '³', '4' to '⁴',
+        '5' to '⁵', '6' to '⁶', '7' to '⁷', '8' to '⁸', '9' to '⁹',
+    )
+
+    private val subscriptDigits = mapOf(
+        '0' to '₀', '1' to '₁', '2' to '₂', '3' to '₃', '4' to '₄',
+        '5' to '₅', '6' to '₆', '7' to '₇', '8' to '₈', '9' to '₉',
+    )
+
+    private fun superscript(character: Char): Char = superscriptDigits[character] ?: character
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericNumberParser.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericNumberParser.kt
@@ -1,0 +1,204 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import java.math.BigInteger
+
+internal data class ParsedNumericNumber(
+    val value: BigInteger,
+    val sourceReading: String? = null,
+    val sourceDigits: String? = null,
+    val phonologicalFeatures: Set<NumericPhonologicalFeature> = emptySet(),
+) {
+    fun toValue(inputStart: Int, inputEnd: Int): NumericValue = NumericValue(
+        value = value,
+        sourceReading = sourceReading,
+        sourceDigits = sourceDigits,
+        phonologicalFeatures = phonologicalFeatures,
+        inputStart = inputStart,
+        inputEnd = inputEnd,
+    )
+}
+
+internal data class NumericNumberPrefix(
+    val end: Int,
+    val number: ParsedNumericNumber,
+)
+
+/**
+ * The one grammar for numeric values used by both the public number extensions and the numeric
+ * expression parser.  It intentionally has no knowledge of counters or units.
+ */
+internal object NumericNumberParser {
+
+    private enum class ReadingType {
+        UNIT,
+        SMALL_PLACE,
+        BIG_PLACE,
+    }
+
+    private data class ReadingToken(
+        val reading: String,
+        val type: ReadingType,
+        val value: BigInteger,
+        val placeOrder: Int = 1,
+    )
+
+    private val zero = BigInteger.ZERO
+
+    private val readings = listOf(
+        ReadingToken("ぜろ", ReadingType.UNIT, BigInteger.ZERO),
+        ReadingToken("れい", ReadingType.UNIT, BigInteger.ZERO),
+        ReadingToken("いち", ReadingType.UNIT, BigInteger.ONE),
+        ReadingToken("いっ", ReadingType.UNIT, BigInteger.ONE),
+        ReadingToken("に", ReadingType.UNIT, BigInteger.valueOf(2)),
+        ReadingToken("さん", ReadingType.UNIT, BigInteger.valueOf(3)),
+        ReadingToken("し", ReadingType.UNIT, BigInteger.valueOf(4)),
+        ReadingToken("よん", ReadingType.UNIT, BigInteger.valueOf(4)),
+        ReadingToken("よ", ReadingType.UNIT, BigInteger.valueOf(4)),
+        ReadingToken("ご", ReadingType.UNIT, BigInteger.valueOf(5)),
+        ReadingToken("ろく", ReadingType.UNIT, BigInteger.valueOf(6)),
+        ReadingToken("ろっ", ReadingType.UNIT, BigInteger.valueOf(6)),
+        ReadingToken("なな", ReadingType.UNIT, BigInteger.valueOf(7)),
+        ReadingToken("しち", ReadingType.UNIT, BigInteger.valueOf(7)),
+        ReadingToken("はち", ReadingType.UNIT, BigInteger.valueOf(8)),
+        ReadingToken("はっ", ReadingType.UNIT, BigInteger.valueOf(8)),
+        ReadingToken("きゅう", ReadingType.UNIT, BigInteger.valueOf(9)),
+        ReadingToken("きゅー", ReadingType.UNIT, BigInteger.valueOf(9)),
+        ReadingToken("く", ReadingType.UNIT, BigInteger.valueOf(9)),
+        ReadingToken("じゅう", ReadingType.SMALL_PLACE, BigInteger.TEN, 2),
+        ReadingToken("じゅー", ReadingType.SMALL_PLACE, BigInteger.TEN, 2),
+        ReadingToken("じゅっ", ReadingType.SMALL_PLACE, BigInteger.TEN, 2),
+        ReadingToken("じっ", ReadingType.SMALL_PLACE, BigInteger.TEN, 2),
+        ReadingToken("ひゃく", ReadingType.SMALL_PLACE, BigInteger.valueOf(100), 3),
+        ReadingToken("ひゃっ", ReadingType.SMALL_PLACE, BigInteger.valueOf(100), 3),
+        ReadingToken("びゃく", ReadingType.SMALL_PLACE, BigInteger.valueOf(100), 3),
+        ReadingToken("びゃっ", ReadingType.SMALL_PLACE, BigInteger.valueOf(100), 3),
+        ReadingToken("ぴゃく", ReadingType.SMALL_PLACE, BigInteger.valueOf(100), 3),
+        ReadingToken("ぴゃっ", ReadingType.SMALL_PLACE, BigInteger.valueOf(100), 3),
+        ReadingToken("せん", ReadingType.SMALL_PLACE, BigInteger.valueOf(1_000), 4),
+        ReadingToken("ぜん", ReadingType.SMALL_PLACE, BigInteger.valueOf(1_000), 4),
+        ReadingToken("まん", ReadingType.BIG_PLACE, BigInteger.valueOf(10_000), 5),
+        ReadingToken("おく", ReadingType.BIG_PLACE, BigInteger.valueOf(100_000_000), 9),
+        ReadingToken("おっ", ReadingType.BIG_PLACE, BigInteger.valueOf(100_000_000), 9),
+        ReadingToken("ちょう", ReadingType.BIG_PLACE, BigInteger.valueOf(1_000_000_000_000L), 13),
+    ).sortedByDescending { it.reading.length }
+
+    fun parse(input: String): ParsedNumericNumber? {
+        if (input.isEmpty()) return null
+        if (isDigitSequence(input)) return parseDigits(input)
+
+        var index = 0
+        var total = zero
+        var section: BigInteger? = null
+        var smallPlaceOrder = -1
+        var bigPlaceOrder = Int.MAX_VALUE
+        var hasNumber = false
+        var restrictedUnit: String? = null
+
+        while (index < input.length) {
+            val token = readings.firstOrNull { input.startsWith(it.reading, index) }
+                ?: return null
+
+            // 「よ」「く」は final-unit readings and 「し」 may only be followed by 十.
+            when (restrictedUnit) {
+                "よ", "く" -> return null
+                "し" -> if (token.reading != "じゅう") return null
+            }
+            restrictedUnit = if (
+                token.type == ReadingType.UNIT &&
+                token.reading in setOf("し", "よ", "く")
+            ) {
+                token.reading
+            } else {
+                null
+            }
+
+            when (token.type) {
+                ReadingType.UNIT -> {
+                    if (hasNumber && token.value == zero) return null
+                    if (section == zero || (section != null && section.mod(BigInteger.TEN) != zero)) {
+                        return null
+                    }
+                    section = if (section == null) token.value else section.add(token.value)
+                    hasNumber = true
+                }
+
+                ReadingType.SMALL_PLACE -> {
+                    if (smallPlaceOrder > 1 && token.placeOrder >= smallPlaceOrder) return null
+                    if (section == zero) return null
+
+                    section = if (section == null) {
+                        token.value
+                    } else {
+                        val unit = section.mod(BigInteger.TEN).max(BigInteger.ONE)
+                        val base = section.divide(BigInteger.TEN).multiply(BigInteger.TEN)
+                        base.add(unit.multiply(token.value))
+                    }
+                    smallPlaceOrder = token.placeOrder
+                    hasNumber = true
+                }
+
+                ReadingType.BIG_PLACE -> {
+                    if (token.placeOrder >= bigPlaceOrder || section == null || section <= zero) {
+                        return null
+                    }
+                    total = total.add(section.multiply(token.value))
+                    section = null
+                    smallPlaceOrder = -1
+                    bigPlaceOrder = token.placeOrder
+                    hasNumber = true
+                }
+            }
+            index += token.reading.length
+        }
+
+        if (!hasNumber) return null
+        return ParsedNumericNumber(
+            value = if (section == null) total else total.add(section),
+            sourceReading = input,
+            phonologicalFeatures = if ('っ' in input) {
+                setOf(NumericPhonologicalFeature.GEMINATE)
+            } else {
+                emptySet()
+            },
+        )
+    }
+
+    /** Returns the longest contiguous ASCII/full-width digit prefix. */
+    fun digitPrefixLength(input: String, start: Int = 0): Int {
+        var index = start
+        while (index < input.length && isDigit(input[index])) index++
+        return index - start
+    }
+
+    /** Enumerates every valid Japanese-number prefix so the suffix parser can keep ambiguities. */
+    fun parsePrefixes(input: String): List<NumericNumberPrefix> {
+        if (input.isEmpty()) return emptyList()
+        val digitLength = digitPrefixLength(input)
+        if (digitLength > 0) {
+            val raw = input.substring(0, digitLength)
+            return listOf(NumericNumberPrefix(digitLength, parseDigits(raw)))
+        }
+
+        return (1..input.length).mapNotNull { end ->
+            parse(input.substring(0, end))?.let { NumericNumberPrefix(end, it) }
+        }
+    }
+
+    fun normalizeDigits(input: String): String = input.map { character ->
+        if (character in '０'..'９') {
+            (character.code - '０'.code + '0'.code).toChar()
+        } else {
+            character
+        }
+    }.joinToString("")
+
+    fun isDigitSequence(input: String): Boolean =
+        input.isNotEmpty() && input.all(::isDigit)
+
+    private fun parseDigits(raw: String): ParsedNumericNumber = ParsedNumericNumber(
+        value = BigInteger(normalizeDigits(raw)),
+        sourceDigits = normalizeDigits(raw),
+    )
+
+    private fun isDigit(character: Char): Boolean = character in '0'..'9' || character in '０'..'９'
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericReadingResolver.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericReadingResolver.kt
@@ -1,0 +1,54 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import java.math.BigInteger
+
+/** Evaluates the data-defined phonological and value conditions for a suffix reading. */
+class NumericReadingResolver {
+
+    fun resolve(
+        definition: NumericSuffixDefinition,
+        value: NumericValue,
+        matchedReading: String,
+        previousSuffixes: List<NumericSuffix> = emptyList(),
+    ): List<NumericReadingRule> = definition.readingRules.filter { rule ->
+        rule.wholeExpressionValue == null &&
+            rule.reading == matchedReading &&
+            matches(rule.condition, value, previousSuffixes)
+    }
+
+    fun resolveWholeExpression(
+        definition: NumericSuffixDefinition,
+        reading: String,
+    ): List<NumericReadingRule> = definition.readingRules.filter { rule ->
+        val value = rule.wholeExpressionValue
+        value != null &&
+            rule.reading == reading &&
+            matches(
+                condition = rule.condition,
+                value = NumericValue(value = value, sourceReading = reading),
+            )
+    }
+
+    fun matches(
+        condition: NumericCondition,
+        value: NumericValue,
+        previousSuffixes: List<NumericSuffix> = emptyList(),
+    ): Boolean = when (condition) {
+        NumericCondition.Always -> true
+        is NumericCondition.ValueEquals -> value.value == condition.value
+        is NumericCondition.LastDigitIn -> value.value.mod(BigInteger.TEN).toInt() in condition.digits
+        is NumericCondition.ModuloIn -> {
+            condition.modulo > 0 &&
+                value.value.mod(BigInteger.valueOf(condition.modulo.toLong())).toInt() in condition.values
+        }
+
+        is NumericCondition.SourceReadingEndsWith ->
+            condition.readings.any { value.sourceReading?.endsWith(it) == true }
+
+        is NumericCondition.FeatureIn ->
+            value.phonologicalFeatures.any { it in condition.features }
+
+        is NumericCondition.AllOf -> condition.conditions.all { matches(it, value, previousSuffixes) }
+        is NumericCondition.AnyOf -> condition.conditions.any { matches(it, value, previousSuffixes) }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/PredictionConfig.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/PredictionConfig.kt
@@ -11,6 +11,17 @@ enum class PredictionAggressiveness(val preferenceValue: String) {
     }
 }
 
+enum class NumericNotationPreference(val preferenceValue: String) {
+    HALF_WIDTH_FIRST("half_width"),
+    FULL_WIDTH_FIRST("full_width"),
+    KANJI_FIRST("kanji");
+
+    companion object {
+        fun fromPreference(value: String?): NumericNotationPreference =
+            entries.firstOrNull { it.preferenceValue == value } ?: HALF_WIDTH_FIRST
+    }
+}
+
 /** Runtime settings for dictionary-based completion candidates. */
 data class PredictionConfig(
     val japanesePredictionEnabled: Boolean = true,
@@ -28,6 +39,8 @@ data class PredictionConfig(
     val showSymbolCandidates: Boolean = true,
     val showEmojiCandidates: Boolean = true,
     val showEmoticonCandidates: Boolean = true,
+    val numericNotationPreference: NumericNotationPreference =
+        NumericNotationPreference.HALF_WIDTH_FIRST,
 ) {
     val normalizedMinimumInputLength: Int
         get() = minimumInputLength.coerceIn(MIN_INPUT_LENGTH, MAX_INPUT_LENGTH)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSession.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSession.kt
@@ -86,12 +86,17 @@ class KanaKanjiConversionSession(
         incrementalState?.beginQueryTransaction()
         try {
             val result = when (request.mode) {
-                CandidateQueryMode.EISUKANA -> KanaKanjiQueryResult(
-                    candidates = engine.getCandidatesEnglishKana(
-                        input = request.input,
-                        predictionConfig = request.predictionConfig,
-                    ),
-                )
+                CandidateQueryMode.EISUKANA -> {
+                    val segmentCollector = request.newCandidateSegmentCollector()
+                    KanaKanjiQueryResult(
+                        candidates = engine.getCandidatesEnglishKana(
+                            input = request.input,
+                            predictionConfig = request.predictionConfig,
+                            candidateSegmentCollector = segmentCollector,
+                        ),
+                        candidateSegmentsByString = segmentCollector.orEmpty(),
+                    )
+                }
 
                 CandidateQueryMode.NO_TAB_DEFAULT -> queryOriginal(request)
                 CandidateQueryMode.PREDICTION -> queryPrediction(request)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImePreferencesSnapshot.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImePreferencesSnapshot.kt
@@ -362,6 +362,7 @@ data class ImePreferencesSnapshot(
                         appPreference.emoji_candidate_enable_preference,
                     showEmoticonCandidates =
                         appPreference.emoticon_candidate_enable_preference,
+                    numericNotationPreference = appPreference.numeric_notation_preference,
                 ),
                 flickSensitivityPreferenceValue = appPreference.flick_sensitivity_preference ?: 100,
                 flickThresholdShapePreferenceValue =

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/NumberExtenstion.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/extensions/NumberExtenstion.kt
@@ -1,154 +1,17 @@
 package com.kazumaproject.markdownhelperkeyboard.ime_service.extensions
 
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.NumericNumberParser
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.NumericNumberFormatter
 import java.text.DecimalFormat
+import java.math.BigInteger
 
 fun detectMultipleSen(input: String): Boolean {
     val regex = """^(せん){2,}$""".toRegex()
     return regex.matches(input)
 }
 
-private enum class JapaneseNumberReadingType {
-    UNIT,
-    SMALL_PLACE,
-    BIG_PLACE,
-}
-
-private data class JapaneseNumberReading(
-    val reading: String,
-    val type: JapaneseNumberReadingType,
-    val value: Long,
-    val placeOrder: Int = 1,
-)
-
-/**
- * Number readings accepted by Mozc's NumberDecoder, limited to the range that
- * can be represented by this app's Long-based number candidate API.
- *
- * Sound changes such as 「いっ」「ろっ」「はっ」 are units here, not global
- * string replacements.  Decoder state determines where they are usable.
- */
-private val japaneseNumberReadings = listOf(
-    JapaneseNumberReading("ぜろ", JapaneseNumberReadingType.UNIT, 0L),
-    JapaneseNumberReading("れい", JapaneseNumberReadingType.UNIT, 0L),
-    JapaneseNumberReading("いち", JapaneseNumberReadingType.UNIT, 1L),
-    JapaneseNumberReading("いっ", JapaneseNumberReadingType.UNIT, 1L),
-    JapaneseNumberReading("に", JapaneseNumberReadingType.UNIT, 2L),
-    JapaneseNumberReading("さん", JapaneseNumberReadingType.UNIT, 3L),
-    JapaneseNumberReading("し", JapaneseNumberReadingType.UNIT, 4L),
-    JapaneseNumberReading("よん", JapaneseNumberReadingType.UNIT, 4L),
-    JapaneseNumberReading("よ", JapaneseNumberReadingType.UNIT, 4L),
-    JapaneseNumberReading("ご", JapaneseNumberReadingType.UNIT, 5L),
-    JapaneseNumberReading("ろく", JapaneseNumberReadingType.UNIT, 6L),
-    JapaneseNumberReading("ろっ", JapaneseNumberReadingType.UNIT, 6L),
-    JapaneseNumberReading("なな", JapaneseNumberReadingType.UNIT, 7L),
-    JapaneseNumberReading("しち", JapaneseNumberReadingType.UNIT, 7L),
-    JapaneseNumberReading("はち", JapaneseNumberReadingType.UNIT, 8L),
-    JapaneseNumberReading("はっ", JapaneseNumberReadingType.UNIT, 8L),
-    JapaneseNumberReading("きゅう", JapaneseNumberReadingType.UNIT, 9L),
-    JapaneseNumberReading("きゅー", JapaneseNumberReadingType.UNIT, 9L),
-    JapaneseNumberReading("く", JapaneseNumberReadingType.UNIT, 9L),
-    JapaneseNumberReading("じゅう", JapaneseNumberReadingType.SMALL_PLACE, 10L, 2),
-    JapaneseNumberReading("じゅー", JapaneseNumberReadingType.SMALL_PLACE, 10L, 2),
-    JapaneseNumberReading("じゅっ", JapaneseNumberReadingType.SMALL_PLACE, 10L, 2),
-    JapaneseNumberReading("じっ", JapaneseNumberReadingType.SMALL_PLACE, 10L, 2),
-    JapaneseNumberReading("ひゃく", JapaneseNumberReadingType.SMALL_PLACE, 100L, 3),
-    JapaneseNumberReading("ひゃっ", JapaneseNumberReadingType.SMALL_PLACE, 100L, 3),
-    JapaneseNumberReading("びゃく", JapaneseNumberReadingType.SMALL_PLACE, 100L, 3),
-    JapaneseNumberReading("びゃっ", JapaneseNumberReadingType.SMALL_PLACE, 100L, 3),
-    JapaneseNumberReading("ぴゃく", JapaneseNumberReadingType.SMALL_PLACE, 100L, 3),
-    JapaneseNumberReading("ぴゃっ", JapaneseNumberReadingType.SMALL_PLACE, 100L, 3),
-    JapaneseNumberReading("せん", JapaneseNumberReadingType.SMALL_PLACE, 1_000L, 4),
-    JapaneseNumberReading("ぜん", JapaneseNumberReadingType.SMALL_PLACE, 1_000L, 4),
-    JapaneseNumberReading("まん", JapaneseNumberReadingType.BIG_PLACE, 10_000L, 5),
-    JapaneseNumberReading("おく", JapaneseNumberReadingType.BIG_PLACE, 100_000_000L, 9),
-    JapaneseNumberReading("おっ", JapaneseNumberReadingType.BIG_PLACE, 100_000_000L, 9),
-    JapaneseNumberReading("ちょう", JapaneseNumberReadingType.BIG_PLACE, 1_000_000_000_000L, 13),
-).sortedByDescending { it.reading.length }
-
-private fun parseJapaneseNumberValue(input: String): Long? {
-    if (input.isEmpty()) return null
-
-    var index = 0
-    var total = 0L
-    var section = -1L
-    var smallPlaceOrder = -1
-    var bigPlaceOrder = Int.MAX_VALUE
-    var hasNumber = false
-    var restrictedUnit: String? = null
-
-    while (index < input.length) {
-        val entry = japaneseNumberReadings.firstOrNull {
-            input.startsWith(it.reading, index)
-        } ?: return null
-
-        // Mozc accepts these historical readings only in constrained places:
-        // 「よ」「く」 must finish the number, while 「し」 may additionally
-        // precede canonical 「じゅう」 (e.g. 四十 = しじゅう).
-        when (restrictedUnit) {
-            "よ", "く" -> return null
-            "し" -> if (entry.reading != "じゅう") return null
-        }
-        restrictedUnit = if (
-            entry.type == JapaneseNumberReadingType.UNIT &&
-            (entry.reading == "し" || entry.reading == "よ" || entry.reading == "く")
-        ) {
-            entry.reading
-        } else {
-            null
-        }
-
-        when (entry.type) {
-            JapaneseNumberReadingType.UNIT -> {
-                if (hasNumber && entry.value == 0L) return null
-                if (section == 0L || (section >= 0L && section % 10L != 0L)) return null
-
-                section = if (section < 0L) {
-                    entry.value
-                } else {
-                    Math.addExact(section, entry.value)
-                }
-                hasNumber = true
-            }
-
-            JapaneseNumberReadingType.SMALL_PLACE -> {
-                if (smallPlaceOrder > 1 && entry.placeOrder >= smallPlaceOrder) return null
-                if (section == 0L) return null
-
-                section = if (section < 0L) {
-                    entry.value
-                } else {
-                    val unit = maxOf(1L, section % 10L)
-                    val base = section / 10L * 10L
-                    Math.addExact(base, Math.multiplyExact(unit, entry.value))
-                }
-                smallPlaceOrder = entry.placeOrder
-                hasNumber = true
-            }
-
-            JapaneseNumberReadingType.BIG_PLACE -> {
-                if (entry.placeOrder >= bigPlaceOrder || section <= 0L) return null
-
-                total = Math.addExact(total, Math.multiplyExact(section, entry.value))
-                section = -1L
-                smallPlaceOrder = -1
-                bigPlaceOrder = entry.placeOrder
-                hasNumber = true
-            }
-        }
-
-        index += entry.reading.length
-    }
-
-    if (!hasNumber) return null
-    return if (section >= 0L) Math.addExact(total, section) else total
-}
-
 fun String.toNumber(): Pair<String, String>? {
-    val total = try {
-        parseJapaneseNumberValue(this)
-    } catch (_: ArithmeticException) {
-        null
-    } ?: return null
+    val total = NumericNumberParser.parse(this)?.value ?: return null
 
     val fullWidth = total.toString().map { it.toFullWidthChar() }.joinToString("")
     val halfWidth = total.toString()
@@ -157,13 +20,9 @@ fun String.toNumber(): Pair<String, String>? {
 }
 
 fun String.toNumberExponent(): Pair<String, String>? {
-    val total = try {
-        parseJapaneseNumberValue(this)
-    } catch (_: ArithmeticException) {
-        null
-    } ?: return null
+    val total = NumericNumberParser.parse(this)?.value ?: return null
 
-    val result = if (total < 100_000_000L) {
+    val result = if (total < BigInteger.valueOf(100_000_000L)) {
         null
     } else {
         val exponent = total.toString().length - 1
@@ -195,30 +54,7 @@ fun displayExponent(base: Int, exponent: Int): String {
 }
 
 fun Long.convertToKanjiNotation(): String {
-    if (this == 0L) return "0"
-
-    val units = listOf(
-        Pair(1_000_000_000_000L, "兆"),      // 10^12
-        Pair(100_000_000L, "億"),           // 10^8
-        Pair(10_000L, "万")                 // 10^4
-    )
-
-    var remaining = this
-    val parts = mutableListOf<String>()
-
-    for ((unitValue, unitName) in units) {
-        if (remaining >= unitValue) {
-            val unitCount = remaining / unitValue
-            remaining %= unitValue
-            parts.add("${unitCount}${unitName}")
-        }
-    }
-
-    if (remaining > 0 || parts.isEmpty()) {
-        parts.add(remaining.toString())
-    }
-
-    return parts.joinToString("")
+    return NumericNumberFormatter.toMixedKanji(BigInteger.valueOf(this))
 }
 
 fun String.addCommasToNumber(): String {
@@ -239,36 +75,9 @@ fun String.addCommasToNumber(): String {
 
 // この関数をどこか（例えば NumberConverter.kt の末尾）に追加します
 fun Long.toKanji(): String {
-    if (this == 0L) return "〇"
-
-    val kanjiDigits = listOf("〇", "一", "二", "三", "四", "五", "六", "七", "八", "九")
-    val kanjiUnits = listOf("", "十", "百", "千")
-    val kanjiBigUnits = listOf("", "万", "億", "兆", "京")
-
-    var num = this
-    var result = ""
-    var bigUnitIndex = 0
-
-    while (num > 0) {
-        val chunk = (num % 10000).toInt()
-        if (chunk > 0) {
-            var chunkStr = ""
-            var n = chunk
-            var unitIndex = 0
-            while (n > 0) {
-                val digit = n % 10
-                if (digit > 0) {
-                    // 10, 100, 1000 の場合、先頭の「一」は省略する
-                    val digitStr = if (digit == 1 && unitIndex > 0) "" else kanjiDigits[digit]
-                    chunkStr = digitStr + kanjiUnits[unitIndex] + chunkStr
-                }
-                n /= 10
-                unitIndex++
-            }
-            result = chunkStr + kanjiBigUnits[bigUnitIndex] + result
-        }
-        num /= 10000
-        bigUnitIndex++
-    }
-    return result
+    return NumericNumberFormatter.toJapaneseKanji(BigInteger.valueOf(this))
 }
+
+fun BigInteger.convertToKanjiNotation(): String = NumericNumberFormatter.toMixedKanji(this)
+
+fun BigInteger.toKanji(): String = NumericNumberFormatter.toJapaneseKanji(this)

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/learning/LearningEligibilityPolicy.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/learning/LearningEligibilityPolicy.kt
@@ -1,5 +1,6 @@
 package com.kazumaproject.markdownhelperkeyboard.learning
 
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.NumericCandidateProvider
 import com.kazumaproject.markdownhelperkeyboard.ime_service.extensions.containsSymbolNumberOrEmoji
 
 object LearningEligibilityPolicy {
@@ -9,11 +10,14 @@ object LearningEligibilityPolicy {
         allowJapaneseWithSymbolsAndNumbers: Boolean,
     ): Boolean {
         if (input.isBlank() || output.isBlank()) return false
-        if (!output.containsSymbolNumberOrEmoji()) return true
+        // Supplementary-plane emoji occupy two UTF-16 chars; inspect their code points too.
+        val containsSymbolsOrNumbers = output.containsSymbolNumberOrEmoji() ||
+            output.codePoints().anyMatch { Character.getType(it) == Character.OTHER_SYMBOL.toInt() }
+        if (!containsSymbolsOrNumbers) return true
         if (!allowJapaneseWithSymbolsAndNumbers) return false
 
-        // Keep useful mixed phrases such as「令和8年」or「C++入門」while excluding entries that
-        // consist only of numbers, symbols, or emoji.
-        return output.any { character -> Character.isLetter(character.code) }
+        // Keep mixed phrases and recognized numeric conversions, but not arbitrary symbols.
+        return output.codePoints().anyMatch { Character.isLetter(it) } ||
+            NumericCandidateProvider.isLearnableConversion(input, output)
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/AppPreference.kt
@@ -33,6 +33,7 @@ import com.kazumaproject.markdownhelperkeyboard.setting_activity.backup.PrefBack
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.backup.PrefEntry
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.circular_slot.CircularSlotActionSetting
 import com.kazumaproject.core.R as CoreR
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.NumericNotationPreference
 
 internal object CustomThemeColorPreferenceKeys {
     const val CANDIDATE_TEXT_COLOR = "custom_theme_candidate_text_color"
@@ -165,6 +166,11 @@ object AppPreference {
     private val CONVERSION_BEAM_WIDTH_PREFERENCE = Pair("conversion_beam_width_preference", 20)
     private val INCREMENTAL_CONVERSION_SESSION_PREFERENCE =
         Pair("incremental_conversion_session_preference", false)
+    private val NUMERIC_NOTATION_PREFERENCE =
+        Pair(
+            "numeric_notation_preference",
+            NumericNotationPreference.HALF_WIDTH_FIRST.preferenceValue,
+        )
     private val JAPANESE_PREDICTION_ENABLE_PREFERENCE =
         Pair("japanese_prediction_enable_preference", true)
     private val ENGLISH_PREDICTION_ENABLE_PREFERENCE =
@@ -1810,6 +1816,17 @@ object AppPreference {
         )
         set(value) = preferences.edit {
             it.putBoolean(INCREMENTAL_CONVERSION_SESSION_PREFERENCE.first, value)
+        }
+
+    var numeric_notation_preference: NumericNotationPreference
+        get() = NumericNotationPreference.fromPreference(
+            preferences.getString(
+                NUMERIC_NOTATION_PREFERENCE.first,
+                NUMERIC_NOTATION_PREFERENCE.second,
+            ),
+        )
+        set(value) = preferences.edit {
+            it.putString(NUMERIC_NOTATION_PREFERENCE.first, value.preferenceValue)
         }
 
     var utility_candidate_config: UtilityCandidateConfig

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -1587,6 +1587,11 @@
     <string name="incremental_conversion_session_title">セッション型変換エンジン</string>
     <string name="incremental_conversion_session_summary_on">変換状態を保持し、差分更新で候補を生成します。次の入力セッションから反映されます。</string>
     <string name="incremental_conversion_session_summary_off">従来の変換エンジンを使用します。</string>
+    <string name="numeric_notation_preference_title">数値候補の優先表記</string>
+    <string name="numeric_notation_preference_summary">数字を半角・全角・漢数字のどの表記から表示するかを選択します。候補はすべて保持されます。</string>
+    <string name="numeric_notation_half_width_first">半角数字優先</string>
+    <string name="numeric_notation_full_width_first">全角数字優先</string>
+    <string name="numeric_notation_kanji_first">漢数字優先</string>
     <string name="prediction_behavior_category_title">予測変換</string>
     <string name="prediction_language_category_title">対象言語</string>
     <string name="prediction_source_category_title">候補ソース</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -225,7 +225,7 @@
     <string name="category_ng_word_summary">変換候補を長押しで登録できます。</string>
     <string name="category_learning_dictionary_title">学習辞書</string>
     <string name="learn_dictionary_allow_mixed_symbols_numbers_title">記号・数字を含む日本語を学習</string>
-    <string name="learn_dictionary_allow_mixed_symbols_numbers_summary">「令和8年」などを学習します。記号・数字だけの候補は学習しません。</string>
+    <string name="learn_dictionary_allow_mixed_symbols_numbers_summary">「令和8年」などの表現や「ひゃく → 100」のような数値変換を学習します。記号だけの候補は学習しません。</string>
     <string name="category_user_dictionary_title">ユーザー辞書</string>
     <string name="dictionary_candidate_label_category_title">候補ラベル</string>
     <string name="show_dictionary_candidate_labels_title">辞書候補のラベルを表示</string>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -62,6 +62,18 @@
         <item>aggressive</item>
     </string-array>
 
+    <string-array name="numeric_notation_preference_entries">
+        <item>@string/numeric_notation_half_width_first</item>
+        <item>@string/numeric_notation_full_width_first</item>
+        <item>@string/numeric_notation_kanji_first</item>
+    </string-array>
+
+    <string-array name="numeric_notation_preference_values">
+        <item>half_width</item>
+        <item>full_width</item>
+        <item>kanji</item>
+    </string-array>
+
     <string-array name="keyboard_background_image_display_mode_entries">
         <item>@string/keyboard_background_image_display_mode_fit</item>
         <item>@string/keyboard_background_image_display_mode_center_crop</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1627,6 +1627,11 @@
     <string name="incremental_conversion_session_title">Session-based conversion engine</string>
     <string name="incremental_conversion_session_summary_on">Keep conversion state and update candidates incrementally. Applies from the next input session.</string>
     <string name="incremental_conversion_session_summary_off">Use the conventional conversion engine.</string>
+    <string name="numeric_notation_preference_title">Preferred numeric notation</string>
+    <string name="numeric_notation_preference_summary">Choose whether numeric candidates start with half-width digits, full-width digits, or Kanji. All forms remain available.</string>
+    <string name="numeric_notation_half_width_first">Half-width digits first</string>
+    <string name="numeric_notation_full_width_first">Full-width digits first</string>
+    <string name="numeric_notation_kanji_first">Kanji numerals first</string>
     <string name="prediction_behavior_category_title">Prediction behavior</string>
     <string name="prediction_language_category_title">Prediction languages</string>
     <string name="prediction_source_category_title">Prediction sources</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,7 @@
     <string name="category_ng_word_summary">You can register words by long-pressing a conversion candidate.</string>
     <string name="category_learning_dictionary_title">Learning Dictionary</string>
     <string name="learn_dictionary_allow_mixed_symbols_numbers_title">Learn Japanese containing symbols and numbers</string>
-    <string name="learn_dictionary_allow_mixed_symbols_numbers_summary">Learn mixed phrases such as “令和8年” while excluding candidates made only of symbols or numbers.</string>
+    <string name="learn_dictionary_allow_mixed_symbols_numbers_summary">Learn mixed phrases such as “令和8年” and numeric conversions such as “ひゃく → 100”. Symbol-only candidates are excluded.</string>
     <string name="category_user_dictionary_title">User Dictionary</string>
     <string name="dictionary_candidate_label_category_title">Candidate labels</string>
     <string name="show_dictionary_candidate_labels_title">Show dictionary candidate labels</string>

--- a/app/src/main/res/xml/pref_conversion_engine.xml
+++ b/app/src/main/res/xml/pref_conversion_engine.xml
@@ -12,6 +12,15 @@
             android:title="@string/incremental_conversion_session_title"
             app:iconSpaceReserved="false" />
 
+        <ListPreference
+            android:defaultValue="half_width"
+            android:entries="@array/numeric_notation_preference_entries"
+            android:entryValues="@array/numeric_notation_preference_values"
+            android:key="numeric_notation_preference"
+            android:summary="@string/numeric_notation_preference_summary"
+            android:title="@string/numeric_notation_preference_title"
+            app:useSimpleSummaryProvider="true" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/prediction_language_category_title">

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngineEnglishKanaNumberTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/KanaKanjiEngineEnglishKanaNumberTest.kt
@@ -96,6 +96,15 @@ class KanaKanjiEngineEnglishKanaNumberTest {
     }
 
     @Test
+    fun getCandidatesEnglishKana_keeps_lexical_counter_homophones_before_numeric_candidates() {
+        val candidates = engine.getCandidatesEnglishKana("にほん")
+
+        assertEquals("にほん", candidates.first().string)
+        assertTrue(candidates.any { it.string == "2本" })
+        assertTrue(candidates.any { it.string == "二本" })
+    }
+
+    @Test
     fun getCandidatesEnglishKana_keeps_valid_cardinal_and_counter_candidates() {
         val fourThousand = engine.getCandidatesEnglishKana("よんせん")
         assertTrue(fourThousand.any { it.string == "4000" })

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateComposerTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateComposerTest.kt
@@ -1,0 +1,38 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import org.junit.Assert.*
+import org.junit.Test
+
+class NumericCandidateComposerTest {
+    @Test fun readingsPreserveLexicalOrderRegardlessOfNumericScore() {
+        for (input in listOf("にほん", "ひゃく", "いちじかんはん")) {
+            val numeric = NumericCandidateProvider.generate(input)
+            assertTrue(numeric.isNotEmpty())
+            val lexical = Candidate("通常候補", 1, input.length.toUByte(), 9000)
+            val result = NumericCandidateComposer.compose(input, numeric + lexical, numeric)
+            assertSame(lexical, result.first())
+            assertEquals(numeric.map { it.string }, result.drop(1).map { it.string })
+        }
+    }
+
+    @Test fun identicalDictionaryEntryIsNotDemotedOrReplaced() {
+        val numeric = NumericCandidateProvider.generate("ひゃく")
+        val dictionary = numeric.first().copy()
+        val second = Candidate("百という語", 1, 3u, 8000)
+        val result = NumericCandidateComposer.compose("ひゃく", numeric + listOf(dictionary, second), numeric)
+        assertSame(dictionary, result.first())
+        assertSame(second, result[1])
+        assertEquals(1, result.count { it.string == dictionary.string })
+    }
+
+    @Test fun explicitDigitsRespectNotationButKeepLearnedSelection() {
+        val numeric = NumericCandidateProvider.generate("100", NumericNotationPreference.FULL_WIDTH_FIRST)
+        val lexical = Candidate("100", 1, 3u, 9000)
+        assertEquals("１００", NumericCandidateComposer.compose("100", listOf(lexical) + numeric, numeric).first().string)
+        val learned = Candidate("百", 34, 3u, 0)
+        val result = NumericCandidateComposer.compose("100", listOf(learned, lexical) + numeric, numeric)
+        assertSame(learned, result.first())
+        assertEquals(1, result.count { it.string == "百" })
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProviderTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProviderTest.kt
@@ -1,0 +1,125 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_TIME
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NumericCandidateProviderTest {
+
+    @Test
+    fun notationPreferenceOrdersTheSameFormsForStandaloneNumbers() {
+        assertEquals(
+            listOf("100", "１００", "百"),
+            strings("ひゃく", NumericNotationPreference.HALF_WIDTH_FIRST).take(3),
+        )
+        assertEquals(
+            listOf("１００", "100", "百"),
+            strings("ひゃく", NumericNotationPreference.FULL_WIDTH_FIRST).take(3),
+        )
+        assertEquals(
+            listOf("百", "100", "１００"),
+            strings("ひゃく", NumericNotationPreference.KANJI_FIRST).take(3),
+        )
+    }
+
+    @Test
+    fun notationPreferenceOrdersTheSameFormsForNumbersWithCounters() {
+        val cases = mapOf(
+            "ひゃくえん" to listOf("100円", "１００円", "百円"),
+            "50えん" to listOf("50円", "５０円", "五十円"),
+            "いちじかんはん" to listOf("1時間半", "１時間半", "一時間半"),
+            "さんびゃくまい" to listOf("300枚", "３００枚", "三百枚"),
+            "にじゅっぷん" to listOf("20分", "２０分", "二十分"),
+        )
+
+        cases.forEach { (input, expectedHalfWidthFirst) ->
+            assertEquals(
+                "$input half-width",
+                expectedHalfWidthFirst,
+                strings(input, NumericNotationPreference.HALF_WIDTH_FIRST).take(3),
+            )
+            assertEquals(
+                "$input full-width",
+                listOf(
+                    expectedHalfWidthFirst[1],
+                    expectedHalfWidthFirst[0],
+                    expectedHalfWidthFirst[2],
+                ),
+                strings(input, NumericNotationPreference.FULL_WIDTH_FIRST).take(3),
+            )
+            assertEquals(
+                "$input Kanji",
+                listOf(
+                    expectedHalfWidthFirst[2],
+                    expectedHalfWidthFirst[0],
+                    expectedHalfWidthFirst[1],
+                ),
+                strings(input, NumericNotationPreference.KANJI_FIRST).take(3),
+            )
+        }
+    }
+
+    @Test
+    fun explicitDigitInputIsNormalizedAndKeepsEveryPrimaryNotation() {
+        val candidates = NumericCandidateProvider.generate("１２３４")
+        val strings = candidates.map { it.string }
+
+        assertEquals("1234", strings.first())
+        assertTrue(strings.containsAll(listOf("1234", "１２３４", "千二百三十四", "1,234")))
+        assertTrue(candidates.any { it.string == "1234" && it.type == 31.toByte() })
+        assertTrue(candidates.any { it.string == "１２３４" && it.type == 30.toByte() })
+    }
+
+    @Test
+    fun timeCountersUseTimeTypeOnlyForHalfWidthNumericForm() {
+        val candidates = NumericCandidateProvider.generate("にじゅっぷん")
+
+        assertTrue(candidates.any { it.string == "20分" && it.type == CANDIDATE_TYPE_TIME })
+        assertTrue(candidates.any { it.string == "２０分" && it.type == 30.toByte() })
+        assertFalse(candidates.any { it.string == "20分" && it.type == 30.toByte() })
+    }
+
+    @Test
+    fun ordinaryWordsThatOnlyLookLikeNumbersAreRejected() {
+        listOf(
+            "しえん",
+            "しじ",
+            "ごはん",
+            "よしよし",
+        ).forEach { input ->
+            assertTrue(
+                "$input produced ${NumericCandidateProvider.generate(input)}",
+                NumericCandidateProvider.generate(input).isEmpty(),
+            )
+        }
+    }
+
+    @Test
+    fun unavoidableCounterHomophonesKeepNumericCandidatesButDoNotTakeTheFirstPosition() {
+        val input = "にほん"
+        assertTrue(NumericCandidateProvider.generate(input).isNotEmpty())
+        assertFalse(NumericCandidateProvider.shouldPrioritize(input))
+    }
+
+    @Test
+    fun valueBasedSymbolsFollowThePrimaryNumericCandidatesSetting() {
+        val withoutSymbols = NumericCandidateProvider.generate(
+            input = "いち",
+            showSymbolCandidates = false,
+        )
+
+        assertFalse(withoutSymbols.any { it.string == "①" })
+        assertEquals("1", withoutSymbols.first().string)
+    }
+
+    private fun strings(
+        input: String,
+        preference: NumericNotationPreference,
+    ): List<String> = NumericCandidateProvider.generate(
+        input = input,
+        notationPreference = preference,
+        showSymbolCandidates = false,
+    ).map { it.string }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProviderTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProviderTest.kt
@@ -114,6 +114,51 @@ class NumericCandidateProviderTest {
         assertEquals("1", withoutSymbols.first().string)
     }
 
+    @Test
+    fun bundledCatalogCoversTheSharedCounterAndUnitVocabulary() {
+        val expectedSurfaces = setOf(
+            "時", "時間", "分", "秒", "日", "週", "週間", "か月", "月", "年",
+            "円", "ドル", "ユーロ", "%", "℃", "mm", "cm", "m", "km", "mg", "g", "kg", "ml", "l",
+            "人", "名", "個", "箇", "本", "匹", "羽", "頭", "枚", "冊", "台", "代",
+            "軒", "棟", "戸", "件", "点", "杯", "缶", "瓶", "箱", "袋", "粒", "束", "房",
+            "着", "足", "面", "通", "部", "巻", "章", "口", "席", "列", "基", "株", "式", "丁",
+            "階", "回", "番", "号", "番目", "位", "組", "対", "段", "度", "倍", "割",
+        )
+        val actualSurfaces = BundledNumericSuffixCatalog.definitions
+            .flatMap { it.canonicalSurfaces }
+            .toSet()
+
+        assertTrue(expectedSurfaces.all(actualSurfaces::contains))
+    }
+
+    @Test
+    fun homophonousReadingsKeepEveryCatalogInterpretation() {
+        val cases = mapOf(
+            "ごかい" to setOf("5階", "5回"),
+            "にけん" to setOf("2件", "2軒"),
+            "にこ" to setOf("2個", "2戸"),
+            "にだい" to setOf("2台", "2代"),
+            "にど" to setOf("2℃", "2度"),
+        )
+
+        cases.forEach { (input, expected) ->
+            val strings = NumericCandidateProvider.generate(input, showSymbolCandidates = false)
+                .map { it.string }
+            assertTrue("$input: $strings", strings.containsAll(expected))
+        }
+    }
+
+    @Test
+    fun lexicalPriorityPolicyIsGenericAcrossShortHomophonousExpressions() {
+        listOf("にほん", "にかい", "にじ", "にけん").forEach { input ->
+            assertFalse(input, NumericCandidateProvider.shouldPrioritize(input))
+            assertTrue(
+                "$input has no numeric interpretation",
+                NumericCandidateProvider.generate(input).isNotEmpty(),
+            )
+        }
+    }
+
     private fun strings(
         input: String,
         preference: NumericNotationPreference,

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProviderTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericCandidateProviderTest.kt
@@ -7,6 +7,18 @@ import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NumericCandidateProviderTest {
+    @Test
+    fun digitGroupingSeparatesEveryThreeDigitsForDigitsAndReadings() {
+        for (input in listOf("1234567", "１２３４５６７", "ひゃくにじゅうさんまんよんせんごひゃくろくじゅうなな")) {
+            val surfaces = NumericCandidateProvider.generate(input).map { it.string }
+            assertTrue("$input: $surfaces", "1,234,567" in surfaces)
+            assertFalse("$input: $surfaces", "1,234567" in surfaces)
+        }
+        assertEquals("123,456,789", NumericNumberFormatter.addDigitGrouping("123456789"))
+        assertEquals("12,345,678", NumericNumberFormatter.addDigitGrouping("12345678"))
+        assertEquals("123", NumericNumberFormatter.addDigitGrouping("123"))
+    }
+
 
     @Test
     fun notationPreferenceOrdersTheSameFormsForStandaloneNumbers() {

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericExpressionTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/engine/NumericExpressionTest.kt
@@ -1,0 +1,262 @@
+package com.kazumaproject.markdownhelperkeyboard.converter.engine
+
+import java.math.BigInteger
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NumericExpressionTest {
+
+    private val parser = NumericExpressionParser(BundledNumericSuffixCatalog)
+    private val renderer = NumericCandidateRenderer(BundledNumericSuffixCatalog)
+
+    @Test
+    fun everyBundledDefinitionHasAParseableReading() {
+        assertTrue(BundledNumericSuffixCatalog.validate().isEmpty())
+
+        BundledNumericSuffixCatalog.definitions.forEach { definition ->
+            definition.readingRules.forEach { rule ->
+                val found = if (rule.wholeExpressionValue != null) {
+                    parser.parse(rule.reading).any { expression ->
+                        expression.suffixes.any { it.definitionId == definition.id }
+                    }
+                } else {
+                    val previousIds = definition.composition.allowedPreviousIds
+                    val previousTypes = definition.composition.allowedPreviousTypes
+                    val precedingReadings = when {
+                        previousIds != null ->
+                            previousIds.mapNotNull { id ->
+                                BundledNumericSuffixCatalog.definition(id)
+                                    ?.readingRules
+                                    ?.firstOrNull { it.wholeExpressionValue == null }
+                                    ?.reading
+                            }
+
+                        previousTypes != null ->
+                            BundledNumericSuffixCatalog.definitions
+                                .filter { it.type in previousTypes }
+                                .mapNotNull { candidate ->
+                                    candidate.readingRules
+                                        .firstOrNull { it.wholeExpressionValue == null }
+                                        ?.reading
+                                }
+
+                        else -> listOf("")
+                    }
+                    precedingReadings.any { precedingReading ->
+                        (1..100).any { value ->
+                            parser.parse("$value$precedingReading${rule.reading}").any { expression ->
+                                expression.suffixes.any { it.definitionId == definition.id }
+                            }
+                        }
+                    }
+                }
+                assertTrue(
+                    "${definition.id}/${rule.reading} was not accepted by the generic parser",
+                    found,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun homophonousSuffixDefinitionsProduceSeparateExpressions() {
+        val expressions = parser.parse("ごかい")
+        val suffixIds = expressions.mapNotNull { it.suffixes.singleOrNull()?.definitionId }.toSet()
+
+        assertTrue("counter.building.floor" in suffixIds)
+        assertTrue("counter.times" in suffixIds)
+
+        val strings = renderer.render("ごかい", expressions, showSymbolCandidates = false)
+            .map { it.candidate.string }
+        assertTrue(strings.contains("5階"))
+        assertTrue(strings.contains("5回"))
+    }
+
+    @Test
+    fun everyBundledDefinitionRendersCanonicalMetadataThroughTheSamePipeline() {
+        BundledNumericSuffixCatalog.definitions
+            .filter { definition ->
+                definition.readingRules.any { it.wholeExpressionValue == null }
+            }
+            .forEach { definition ->
+                val baseRule = definition.readingRules.first { it.wholeExpressionValue == null }
+                val input = if (definition.id == "modifier.half") {
+                    "2じ${baseRule.reading}"
+                } else {
+                    "2${baseRule.reading}"
+                }
+                val expression = parser.parse(input).first { candidate ->
+                    candidate.suffixes.lastOrNull()?.definitionId == definition.id
+                }
+                val expectedString = "2" + expression.suffixes.joinToString("") { suffix ->
+                    BundledNumericSuffixCatalog.definition(suffix.definitionId)!!
+                        .canonicalSurfaces.first()
+                }
+                val rendered = renderer.render(
+                    input = input,
+                    expressions = listOf(expression),
+                    showSymbolCandidates = false,
+                ).firstOrNull { candidate ->
+                    candidate.expression.suffixes.lastOrNull()?.definitionId == definition.id &&
+                        candidate.candidate.string == expectedString
+                }
+
+                assertTrue("${definition.id}/${baseRule.reading}: $input", rendered != null)
+                rendered ?: return@forEach
+                assertEquals(input.length.toUByte(), rendered.candidate.length)
+                assertEquals(
+                    if (expression.suffixes.any { it.type == NumericSuffixType.TIME }) {
+                        com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_TIME
+                    } else {
+                        31.toByte()
+                    },
+                    renderer.render(
+                        input = input,
+                        expressions = listOf(rendered.expression),
+                        showSymbolCandidates = false,
+                    ).first { it.candidate.string == rendered.candidate.string }.candidate.type,
+                )
+                assertEquals(
+                    if (expression.suffixes.any { it.type == NumericSuffixType.TIME }) {
+                        2015.toShort()
+                    } else {
+                        2011.toShort()
+                    },
+                    rendered.candidate.rightId,
+                )
+                assertEquals(
+                    listOf(Triple(0, 1, "2")) + expression.suffixes.map { suffix ->
+                        Triple(
+                            suffix.inputStart,
+                            suffix.inputEnd,
+                            BundledNumericSuffixCatalog.definition(suffix.definitionId)!!
+                                .canonicalSurfaces.first(),
+                        )
+                    },
+                    rendered.segments.map { Triple(it.inputStart, it.inputEnd, it.output) },
+                )
+            }
+    }
+
+    @Test
+    fun soundChangesAreResolvedFromRulesRatherThanSuffixBranches() {
+        val cases = mapOf(
+            "1ぽん" to "1本",
+            "2ほん" to "2本",
+            "3ぼん" to "3本",
+            "1ぴき" to "1匹",
+            "3びき" to "3匹",
+            "いっぱい" to "1杯",
+            "3ばい" to "3杯",
+            "1ぷん" to "1分",
+            "3ぷん" to "3分",
+            "3がい" to "3階",
+        )
+
+        cases.forEach { (input, expected) ->
+            assertTrue(
+                "$input -> ${renderer.render(input, parser.parse(input), showSymbolCandidates = false)}",
+                renderer.render(input, parser.parse(input), showSymbolCandidates = false)
+                    .any { it.candidate.string == expected },
+            )
+        }
+    }
+
+    @Test
+    fun suffixNotationVariantsUseOnlyReadingsValidForTheNumericValue() {
+        val twoHourStrings = renderer.render(
+            input = "2時",
+            expressions = parser.parse("2時"),
+            showSymbolCandidates = false,
+        ).map { it.candidate.string }
+        assertTrue(twoHourStrings.containsAll(listOf("2時", "2じ", "2ジ")))
+
+        val twoHonStrings = renderer.render(
+            input = "2ほん",
+            expressions = parser.parse("2ほん"),
+            showSymbolCandidates = false,
+        ).map { it.candidate.string }
+        assertTrue(twoHonStrings.containsAll(listOf("2本", "2ほん", "2ホン")))
+        assertTrue(twoHonStrings.none { it == "2ぽん" || it == "2ポン" })
+    }
+
+    @Test
+    fun suffixChainsAndSegmentsPreserveTheExpressionStructure() {
+        val input = "にじかんはん"
+        val rendered = renderer.render(input, parser.parse(input), showSymbolCandidates = false)
+            .first { it.candidate.string == "2時間半" }
+
+        assertEquals(
+            listOf(
+                Triple(0, 1, "2"),
+                Triple(1, 4, "時間"),
+                Triple(4, 6, "半"),
+            ),
+            rendered.segments.map { Triple(it.inputStart, it.inputEnd, it.output) },
+        )
+        assertEquals(NumericSuffixType.TIME, rendered.expression.suffixes.first().type)
+        assertEquals("modifier.half", rendered.expression.suffixes.last().definitionId)
+    }
+
+    @Test
+    fun syntheticCatalogCanAddAUnitWithoutParserChanges() {
+        val catalog = object : NumericSuffixCatalog {
+            override val definitions = listOf(
+                NumericSuffixDefinition(
+                    id = "test.synthetic.measure",
+                    type = NumericSuffixType.UNIT,
+                    surfaces = listOf(NumericSurface(SuffixStyle.CANONICAL, "¤")),
+                    allowedStyles = setOf(
+                        SuffixStyle.CANONICAL,
+                        SuffixStyle.HIRAGANA,
+                        SuffixStyle.KATAKANA,
+                    ),
+                    readingRules = listOf(NumericReadingRule("ふー")),
+                ),
+            )
+        }
+        val syntheticParser = NumericExpressionParser(catalog)
+        val syntheticRenderer = NumericCandidateRenderer(catalog)
+
+        val expressions = syntheticParser.parse("12ふー")
+        val candidates = syntheticRenderer.render(
+            input = "12ふー",
+            expressions = expressions,
+            showSymbolCandidates = false,
+        ).map { it.candidate.string }
+
+        assertEquals(listOf("12¤", "１２¤", "十二¤"), candidates.take(3))
+        assertEquals("test.synthetic.measure", expressions.single().suffixes.single().definitionId)
+    }
+
+    @Test
+    fun bigIntegerAndLeadingZeroInputsRemainStructured() {
+        val input = "000000000000000000000000000000000000000001えん"
+        val expression = parser.parse(input).single()
+
+        assertEquals(BigInteger.ONE, expression.number.value)
+        val candidates = renderer.render(input, listOf(expression), showSymbolCandidates = false)
+            .map { it.candidate.string }
+        assertTrue(candidates.contains("000000000000000000000000000000000000000001円"))
+        assertTrue(candidates.contains("${NumericNumberFormatter.toFullWidthDigits("000000000000000000000000000000000000000001")}円"))
+        assertTrue(candidates.contains("一円"))
+    }
+
+    @Test
+    fun irregularCalendarReadingsAreCatalogData() {
+        val cases = mapOf(
+            "ついたち" to "1日",
+            "ふつか" to "2日",
+            "みっか" to "3日",
+            "はつか" to "20日",
+        )
+        cases.forEach { (input, expected) ->
+            assertTrue(
+                input,
+                renderer.render(input, parser.parse(input), showSymbolCandidates = false)
+                    .any { it.candidate.string == expected },
+            )
+        }
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
@@ -2,6 +2,7 @@ package com.kazumaproject.markdownhelperkeyboard.converter.session
 
 import com.kazumaproject.markdownhelperkeyboard.converter.TestEngineFactory
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.NumericNotationPreference
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.PredictionConfig
 import com.kazumaproject.markdownhelperkeyboard.repository.UserDictionaryRepository
 import com.kazumaproject.markdownhelperkeyboard.user_dictionary.database.UserWord
@@ -65,6 +66,82 @@ class KanaKanjiConversionSessionParityTest {
                     legacyResult.candidateSegmentsByString,
                     incrementalResult.candidateSegmentsByString,
                 )
+            }
+        }
+    }
+
+    @Test
+    fun numericNotationPreferenceIsAppliedAcrossConversionModesAndBunsetsu() = runBlocking {
+        val session = KanaKanjiConversionSession(engine, ConversionBackend.LEGACY)
+        val cases = mapOf(
+            "50えん" to listOf("50円", "５０円", "五十円"),
+            "５０えん" to listOf("50円", "５０円", "五十円"),
+            "いちじかんはん" to listOf("1時間半", "１時間半", "一時間半"),
+        )
+        val modes = listOf(
+            CandidateQueryMode.PREDICTION,
+            CandidateQueryMode.CONVERSION,
+            CandidateQueryMode.NO_TAB_DEFAULT,
+            CandidateQueryMode.EISUKANA,
+        )
+
+        for (preference in NumericNotationPreference.entries) {
+            for ((input, forms) in cases) {
+                for (mode in modes) {
+                    for (bunsetsu in listOf(false, true)) {
+                        val result = session.query(
+                            request(input, mode, bunsetsu).copy(
+                                predictionConfig = PredictionConfig(
+                                    numericNotationPreference = preference,
+                                ),
+                            ),
+                        )
+                        val strings = result.candidates.map { it.string }
+                        val expectedFirst = when (preference) {
+                            NumericNotationPreference.HALF_WIDTH_FIRST -> forms[0]
+                            NumericNotationPreference.FULL_WIDTH_FIRST -> forms[1]
+                            NumericNotationPreference.KANJI_FIRST -> forms[2]
+                        }
+                        assertEquals(
+                            "$input/$mode/bunsetsu=$bunsetsu/$preference",
+                            expectedFirst,
+                            strings.firstOrNull(),
+                        )
+                        assertTrue(
+                            "$input/$mode/bunsetsu=$bunsetsu missing forms from $strings",
+                            strings.containsAll(forms),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun numericCounterHomophonesRemainAvailableWithoutOverridingLexicalCandidates() = runBlocking {
+        val numericForms = setOf("2本", "２本", "二本")
+
+        for (backend in ConversionBackend.entries) {
+            val session = KanaKanjiConversionSession(engine, backend)
+            for (mode in listOf(
+                CandidateQueryMode.PREDICTION,
+                CandidateQueryMode.CONVERSION,
+                CandidateQueryMode.NO_TAB_DEFAULT,
+                CandidateQueryMode.EISUKANA,
+            )) {
+                for (bunsetsu in listOf(false, true)) {
+                    val result = session.query(
+                        request("にほん", mode, bunsetsu),
+                    )
+                    assertFalse(
+                        "$backend/$mode/bunsetsu=$bunsetsu promoted ${result.candidates.firstOrNull()}",
+                        result.candidates.firstOrNull()?.string in numericForms,
+                    )
+                    assertTrue(
+                        "$backend/$mode/bunsetsu=$bunsetsu missing numeric candidates",
+                        result.candidates.any { it.string in numericForms },
+                    )
+                }
             }
         }
     }

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
@@ -119,7 +119,13 @@ class KanaKanjiConversionSessionParityTest {
 
     @Test
     fun numericCounterHomophonesRemainAvailableWithoutOverridingLexicalCandidates() = runBlocking {
-        val numericForms = setOf("2本", "２本", "二本")
+        val numericCandidateTypes = setOf(17, 19, 20, 21, 30, 31, 32, 47)
+        val cases = mapOf(
+            "にほん" to setOf("2本", "２本", "二本"),
+            "にかい" to setOf("2階", "２階", "二階", "2回", "２回", "二回"),
+            "にじ" to setOf("2時", "２時", "二時"),
+            "にけん" to setOf("2件", "２件", "二件", "2軒", "２軒", "二軒"),
+        )
 
         for (backend in ConversionBackend.entries) {
             val session = KanaKanjiConversionSession(engine, backend)
@@ -130,16 +136,57 @@ class KanaKanjiConversionSessionParityTest {
                 CandidateQueryMode.EISUKANA,
             )) {
                 for (bunsetsu in listOf(false, true)) {
-                    val result = session.query(
-                        request("にほん", mode, bunsetsu),
+                    cases.forEach { (input, numericForms) ->
+                        val result = session.query(
+                            request(input, mode, bunsetsu),
+                        )
+                        assertFalse(
+                            "$backend/$mode/bunsetsu=$bunsetsu/$input promoted " +
+                                result.candidates.firstOrNull(),
+                            result.candidates.firstOrNull()?.let { candidate ->
+                                candidate.string in numericForms &&
+                                    candidate.type.toInt() in numericCandidateTypes
+                            } == true,
+                        )
+                        assertTrue(
+                            "$backend/$mode/bunsetsu=$bunsetsu/$input missing numeric candidates",
+                            result.candidates.any { candidate ->
+                                candidate.string in numericForms &&
+                                    candidate.type.toInt() in numericCandidateTypes
+                            },
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun structuredNumericSegmentsSurviveEverySessionModeAndBackend() = runBlocking {
+        val expected = listOf(
+            Triple(0, 1, "2"),
+            Triple(1, 4, "時間"),
+            Triple(4, 6, "半"),
+        )
+        val modes = listOf(
+            CandidateQueryMode.PREDICTION,
+            CandidateQueryMode.CONVERSION,
+            CandidateQueryMode.NO_TAB_DEFAULT,
+            CandidateQueryMode.EISUKANA,
+        )
+
+        for (backend in ConversionBackend.entries) {
+            for (mode in modes) {
+                for (bunsetsu in listOf(false, true)) {
+                    val result = KanaKanjiConversionSession(engine, backend).query(
+                        request("にじかんはん", mode, bunsetsu),
                     )
-                    assertFalse(
-                        "$backend/$mode/bunsetsu=$bunsetsu promoted ${result.candidates.firstOrNull()}",
-                        result.candidates.firstOrNull()?.string in numericForms,
-                    )
-                    assertTrue(
-                        "$backend/$mode/bunsetsu=$bunsetsu missing numeric candidates",
-                        result.candidates.any { it.string in numericForms },
+                    assertEquals(
+                        "$backend/$mode/bunsetsu=$bunsetsu",
+                        expected,
+                        result.candidateSegmentsByString.getValue("2時間半").map {
+                            Triple(it.inputStart, it.inputEnd, it.output)
+                        },
                     )
                 }
             }

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
@@ -102,11 +102,13 @@ class KanaKanjiConversionSessionParityTest {
                             NumericNotationPreference.FULL_WIDTH_FIRST -> forms[1]
                             NumericNotationPreference.KANJI_FIRST -> forms[2]
                         }
-                        assertEquals(
-                            "$input/$mode/bunsetsu=$bunsetsu/$preference",
-                            expectedFirst,
-                            strings.firstOrNull(),
-                        )
+                        if (input.first() in '0'..'9' || input.first() in '０'..'９') {
+                            assertEquals(
+                                "$input/$mode/bunsetsu=$bunsetsu/$preference",
+                                expectedFirst,
+                                strings.firstOrNull(),
+                            )
+                        }
                         assertTrue(
                             "$input/$mode/bunsetsu=$bunsetsu missing forms from $strings",
                             strings.containsAll(forms),
@@ -502,6 +504,48 @@ class KanaKanjiConversionSessionParityTest {
             legacyResult.bunsetsuResult?.splitPatterns,
             incrementalResult.bunsetsuResult?.splitPatterns,
         )
+    }
+
+    @Test
+    fun selectedNumericReadingIsPersistedAndReusedAcrossBackends() = runBlocking {
+        val database = androidx.room.Room.inMemoryDatabaseBuilder(
+            androidx.test.core.app.ApplicationProvider.getApplicationContext(),
+            com.kazumaproject.markdownhelperkeyboard.database.AppDatabase::class.java,
+        ).allowMainThreadQueries().build()
+        try {
+            val repository = com.kazumaproject.markdownhelperkeyboard.repository.LearnRepository(database.learnDao())
+            for (backend in ConversionBackend.entries) {
+                val session = KanaKanjiConversionSession(engine, backend)
+                val query = request("ひゃく", CandidateQueryMode.CONVERSION, false)
+                    .copy(learnRepository = repository)
+                val initial = session.query(query).candidates
+                val index = initial.indexOfFirst { it.string == "１００" }
+                assertTrue(index >= 0)
+                val candidate = initial[index]
+                val learning = com.kazumaproject.markdownhelperkeyboard.learning.session.ConversionLearningSession()
+                learning.beginIfNeeded("ひゃく")
+                learning.record(com.kazumaproject.markdownhelperkeyboard.learning.session.LearningFragment(
+                    reading = "ひゃく", output = candidate.string,
+                    candidateScore = candidate.score, candidateIndex = index,
+                    leftId = candidate.leftId, rightId = candidate.rightId,
+                    explicitlySelected = true,
+                ))
+                repository.upsertLearnedDataBatch(learning.finish(false), true)
+                assertTrue(repository.findLearnDataByInput("ひゃく").orEmpty().any { it.out == "１００" })
+                for (mode in listOf(CandidateQueryMode.CONVERSION, CandidateQueryMode.PREDICTION, CandidateQueryMode.NO_TAB_DEFAULT)) {
+                    for (bunsetsu in listOf(false, true)) {
+                        val result = session.query(query.copy(mode = mode, bunsetsuSeparation = bunsetsu)).candidates
+                        assertEquals("$backend/$mode/$bunsetsu", "１００", result.first().string)
+                        assertEquals(1, result.count { it.string == "１００" })
+                    }
+                }
+                assertTrue(repository.findLearnDataByInput("にひゃく").isNullOrEmpty())
+                repository.deleteByInput("ひゃく")
+                assertEquals(initial.fingerprint(), session.query(query).candidates.fingerprint())
+            }
+        } finally {
+            database.close()
+        }
     }
 
     private fun request(

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/learning/LearningEligibilityPolicyTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/learning/LearningEligibilityPolicyTest.kt
@@ -16,4 +16,15 @@ class LearningEligibilityPolicyTest {
         assertFalse(LearningEligibilityPolicy.isEligible("いちにさん", "123", true))
         assertFalse(LearningEligibilityPolicy.isEligible("かお", "(^^)", true))
     }
+    @Test
+    fun numericLearningRequiresRecognizedReadingAndEnabledSetting() {
+        for (output in listOf("100", "１００", "1,000")) {
+            val input = if (output == "1,000") "せん" else "ひゃく"
+            assertTrue(LearningEligibilityPolicy.isEligible(input, output, true))
+            assertFalse(LearningEligibilityPolicy.isEligible(input, output, false))
+        }
+        assertFalse(LearningEligibilityPolicy.isEligible("ひゃく", "200", true))
+        assertFalse(LearningEligibilityPolicy.isEligible("ひゃく", "💯", true))
+        assertFalse(LearningEligibilityPolicy.isEligible("", "100", true))
+    }
 }

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/PredictionPreferenceTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/setting/PredictionPreferenceTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ApplicationProvider
 import com.kazumaproject.markdownhelperkeyboard.R
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.PredictionAggressiveness
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.PredictionConfig
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.NumericNotationPreference
 import com.kazumaproject.markdownhelperkeyboard.ime_service.ImePreferencesSnapshot
 import com.kazumaproject.markdownhelperkeyboard.setting_activity.AppPreference
 import org.junit.Assert.assertEquals
@@ -35,6 +36,10 @@ class PredictionPreferenceTest {
         val snapshot = ImePreferencesSnapshot.from(AppPreference)
 
         assertEquals(PredictionConfig(), snapshot.predictionConfig)
+        assertEquals(
+            NumericNotationPreference.HALF_WIDTH_FIRST,
+            snapshot.predictionConfig.numericNotationPreference,
+        )
         assertEquals(4, snapshot.nBest)
         assertEquals(4, snapshot.userDictionaryPredictionCandidateLimit)
         assertEquals(4, snapshot.learnDictionaryPredictionCandidateLimit)
@@ -58,6 +63,7 @@ class PredictionPreferenceTest {
         AppPreference.symbol_candidate_enable_preference = false
         AppPreference.emoji_candidate_enable_preference = false
         AppPreference.emoticon_candidate_enable_preference = false
+        AppPreference.numeric_notation_preference = NumericNotationPreference.KANJI_FIRST
         AppPreference.user_dictionary_prediction_candidate_limit_preference = 2
         AppPreference.learn_dictionary_prediction_candidate_limit_preference = 7
 
@@ -79,6 +85,7 @@ class PredictionPreferenceTest {
         assertFalse(prediction.showSymbolCandidates)
         assertFalse(prediction.showEmojiCandidates)
         assertFalse(prediction.showEmoticonCandidates)
+        assertEquals(NumericNotationPreference.KANJI_FIRST, prediction.numericNotationPreference)
         assertEquals(2, snapshot.userDictionaryPredictionCandidateLimit)
         assertEquals(7, snapshot.learnDictionaryPredictionCandidateLimit)
     }
@@ -175,6 +182,14 @@ class PredictionPreferenceTest {
             val preference = screen.findPreference<androidx.preference.SwitchPreferenceCompat>(key)
             assertTrue(preference?.isChecked == true)
         }
+
+        val numericPreference = screen.findPreference<androidx.preference.ListPreference>(
+            "numeric_notation_preference",
+        )
+        assertEquals("numeric_notation_preference", numericPreference?.key)
+        assertEquals("half_width", numericPreference?.value)
+        assertEquals(3, numericPreference?.entries?.size)
+        assertEquals(3, numericPreference?.entryValues?.size)
     }
 
     private companion object {
@@ -194,6 +209,7 @@ class PredictionPreferenceTest {
             "symbol_candidate_enable_preference",
             "emoji_candidate_enable_preference",
             "emoticon_candidate_enable_preference",
+            "numeric_notation_preference",
         )
         val DICTIONARY_KEYS = listOf(
             "user_dictionary_prediction_candidate_limit_preference",


### PR DESCRIPTION
## 概要

数字入力と読み入力で、同じ数値・助数詞には一貫した表記候補を生成します。読み入力では通常の辞書候補を優先し、選択した数字表記は同じ読みの次回変換に学習結果として反映します。

## 変更内容

- 数値・助数詞の解析、音便や不規則読みの解決、表記生成を共通パイプラインに統合。助数詞の定義はデータカタログで管理します。
- 半角・全角・漢数字・混在漢数字・桁区切りを共通の数値表現から生成。BigInteger、先頭ゼロ、同音の助数詞、構造化された変換区間を保持します。
- 読み入力では、読みの長さによる例外処理をやめ、辞書・学習候補の既存順位を保って不足する数字候補を補完します。
- 明示的な数字入力では表記設定を適用し、学習候補を優先します。同じ表記の辞書・学習候補は情報を保持し、重複表示を防ぎます。
- 数字だけの出力も、入力から生成できる数値表記に限って既存の学習設定に従い保存します。別の数値へ表記傾向を共有せず、学習DBの形式も変更しません。
- 補助平面の絵文字を学習判定で正しく検出し、設定の説明文を更新します。
- 7桁以上の桁区切りを修正し、`1234567` と対応する読みから `1,234,567` を生成します。

## 検証

ローカルの `:app:testFullStandardDebugUnitTest` で関連80テストが成功しました。

- 数値解析・表記生成・候補統合・数字拡張の回帰テスト
- 実辞書を使った通常変換・予測・EisuKana・文節変換と LEGACY / INCREMENTAL_SESSION の整合性
- 学習DBへの「ひゃく → １００」の保存、再変換、重複抑制、削除後の復元
- 学習可否、学習セッション、手動候補順、学習候補の優先処理
- 数字入力・全角数字入力・読み入力での複数桁区切り

今回の更新ではCI設定を変更していません。実機での操作確認は今回の更新では実施していません。
