### PR TITLE
fix(zenz): 壊れた変換候補を防止 / Prevent malformed conversion candidates

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/zenz/ZenzRuntimeInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/zenz/ZenzRuntimeInstrumentedTest.kt
@@ -92,6 +92,69 @@ class ZenzRuntimeInstrumentedTest {
         assertTrue("Final request was blocked by cancelled work", finalResult.isNotBlank())
     }
 
+    @Test(timeout = 180_000)
+    fun generatedCandidatesStopAtProtocolBoundaryAcrossReadings() {
+        val service = bindRuntime()
+        initialize(service, copyBundledModel())
+
+        val readings = arrayOf(
+            "マツ",
+            "まつ",
+            "セイドガタカイ",
+            "コンニチハ",
+            "アリガトウ",
+        )
+        readings.forEachIndexed { index, reading ->
+            val candidate = generate(
+                service = service,
+                requestId = 300L + index,
+                input = reading,
+            )
+            assertTrue("No complete candidate for reading=$reading", candidate.isNotBlank())
+            assertSafeCandidate(reading, candidate)
+            if (reading == "マツ") {
+                // This is a semantic regression guard for the bundled model:
+                // text after U+EE08 must never be appended to the candidate.
+                assertEquals("末", candidate)
+            }
+        }
+
+        // The protocol range is reserved by Zenz, so even a context value that
+        // contains a marker must not be able to change the output contract.
+        val candidateWithCleanContext = generateWithFields(
+            service = service,
+            requestId = 400L,
+            profile = "一般",
+            topic = "日常",
+            style = "普通",
+            preference = "標準",
+            leftContext = "左文脈",
+            rightContext = "右文脈",
+            input = "まつ",
+        )
+        val candidateWithMarkerInContext = generateWithFields(
+            service = service,
+            requestId = 401L,
+            profile = "一般\uEE00",
+            topic = "日常\uEE0F",
+            style = "普通\uEE08",
+            preference = "標準\uEE06",
+            leftContext = "左文脈\uEE02",
+            rightContext = "右文脈\uEE07",
+            input = "まつ",
+        )
+        assertEquals(
+            "Protocol markers in structured fields changed the prompt",
+            candidateWithCleanContext,
+            candidateWithMarkerInContext,
+        )
+        assertTrue(
+            "Context marker caused an incomplete candidate",
+            candidateWithMarkerInContext.isNotBlank(),
+        )
+        assertSafeCandidate("まつ with marked context", candidateWithMarkerInContext)
+    }
+
     private fun bindRuntime(): IZenzRuntime {
         val connected = CountDownLatch(1)
         val connection = object : ServiceConnection {
@@ -160,17 +223,35 @@ class ZenzRuntimeInstrumentedTest {
     }
 
     private fun generate(service: IZenzRuntime, requestId: Long, input: String): String {
+        return generateWithFields(
+            service = service,
+            requestId = requestId,
+            input = input,
+        )
+    }
+
+    private fun generateWithFields(
+        service: IZenzRuntime,
+        requestId: Long,
+        profile: String = "",
+        topic: String = "",
+        style: String = "",
+        preference: String = "",
+        leftContext: String = "",
+        rightContext: String = "",
+        input: String,
+    ): String {
         val completed = CountDownLatch(1)
         val result = AtomicReference<String?>(null)
         val error = AtomicReference<String?>(null)
         service.generate(
             requestId,
-            "",
-            "",
-            "",
-            "",
-            "",
-            "",
+            profile,
+            topic,
+            style,
+            preference,
+            leftContext,
+            rightContext,
             input,
             32,
             object : IZenzRuntimeCallback.Stub() {
@@ -196,6 +277,17 @@ class ZenzRuntimeInstrumentedTest {
         assertTrue("Zenz generate timed out", completed.await(30, TimeUnit.SECONDS))
         check(error.get() == null) { "Zenz generate failed: ${error.get()}" }
         return result.get().orEmpty()
+    }
+
+    private fun assertSafeCandidate(reading: String, candidate: String) {
+        assertTrue(
+            "Protocol marker leaked for reading=$reading",
+            candidate.none { it.code in 0xEE00..0xEE0F },
+        )
+        assertTrue(
+            "Control character leaked for reading=$reading",
+            candidate.none { it.isISOControl() || it == '\uFFFD' },
+        )
     }
 
     private fun score(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -15008,7 +15008,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun acceptZenzLiveResult(resultFromZenz: List<ZenzCandidate>) {
         val meta = zenzLiveLatestResultMeta
         val state = _zenzLiveSlotState.value
-        val firstResult = resultFromZenz.firstOrNull()
+        val rawFirstResult = resultFromZenz.firstOrNull()
+        val firstResult = rawFirstResult?.takeIf {
+            ZenzOutputPolicy.acceptedTextOrNull(it.string) != null
+        }
+        if (rawFirstResult != null && firstResult == null) {
+            Timber.w("Rejected unsafe Zenz live output before candidate adoption")
+        }
         if (state?.bunsetsuTarget != null) {
             acceptBunsetsuZenzLiveResult(
                 firstResult = firstResult,
@@ -15768,6 +15774,22 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
      * Zenzエンジンを使用して変換候補を生成するサスペンド関数
      * collectLatest 内から呼び出されることを想定しています。
      */
+    private fun buildAcceptedZenzCandidate(
+        generatedText: String?,
+        type: Byte,
+        insertString: String,
+        score: Int = 2000,
+    ): ZenzCandidate? {
+        val acceptedText = ZenzOutputPolicy.acceptedTextOrNull(generatedText) ?: return null
+        return ZenzCandidate(
+            string = acceptedText,
+            type = type,
+            length = insertString.length.toUByte(),
+            score = score,
+            originalString = insertString,
+        )
+    }
+
     private suspend fun performZenzRequest(
         insertString: String,
         leftContextOverride: String? = null
@@ -15814,14 +15836,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             // 生成後もチェック
             ensureActive()
 
-            // 結果を返却
-            listOf(
-                ZenzCandidate(
-                    string = stringFromZenz,
+            // Native returns an empty string for any generation that did not
+            // reach a clean EOG/protocol boundary. Never publish such a
+            // result as a live candidate.
+            listOfNotNull(
+                buildAcceptedZenzCandidate(
+                    generatedText = stringFromZenz,
                     type = (33).toByte(),
-                    length = (insertString.length).toUByte(),
-                    score = 2000,
-                    originalString = insertString
+                    insertString = insertString,
                 )
             )
         } catch (e: CancellationException) {
@@ -15876,13 +15898,15 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             val zenzaiResultType = CandidateEvaluationResult.parse(stringFromZenz)
 
-            var type = 33
-            var parsedResultText = ""
-
-            when (zenzaiResultType) {
+            return@withContext when (zenzaiResultType) {
                 CandidateEvaluationResult.Error -> {
-                    type = 39
-                    parsedResultText = firstCandidate
+                    listOfNotNull(
+                        buildAcceptedZenzCandidate(
+                            generatedText = firstCandidate,
+                            type = (39).toByte(),
+                            insertString = insertString,
+                        )
+                    )
                 }
 
                 is CandidateEvaluationResult.FixRequired -> {
@@ -15898,16 +15922,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     Timber.d("CandidateEvaluationResult.FixRequired :[$firstCandidateFromPrefix] [$prefix] [$insertString] [${suggesions.map { it.string }}]")
 
 
-                    val firstCandidateFromKanakanjiEngine = ZenzCandidate(
-                        string = firstCandidateFromPrefix ?: firstCandidate,
+                    val firstCandidateFromKanakanjiEngine = buildAcceptedZenzCandidate(
+                        generatedText = firstCandidateFromPrefix ?: firstCandidate,
                         type = (37).toByte(),
-                        length = insertString.length.toUByte(),
-                        score = 2000,
-                        originalString = insertString
+                        insertString = insertString,
                     )
 
-                    val secondCandidateFromZenz = ZenzCandidate(
-                        string = zenzRuntimeClient.generate(
+                    val secondCandidateFromZenz = buildAcceptedZenzCandidate(
+                        generatedText = zenzRuntimeClient.generate(
                             config = runtimeConfig,
                             profile = zenzProfilePreference ?: "",
                             topic = "",
@@ -15919,43 +15941,39 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             maxTokens = zenzMaximumLetterSizePreference ?: 32
                         ),
                         type = (40).toByte(),
-                        length = insertString.length.toUByte(),
-                        score = 2000,
-                        originalString = insertString
+                        insertString = insertString,
                     )
 
-                    val candidates = listOf(
+                    val candidates = listOfNotNull(
                         secondCandidateFromZenz,
                         firstCandidateFromKanakanjiEngine,
                     )
 
-                    val topCandidate = candidates
-                        .maxByOrNull { it.rank(prefix) }
-                        ?: secondCandidateFromZenz
+                    val topCandidate = candidates.maxByOrNull { it.rank(prefix) }
 
-                    return@withContext listOfNotNull(topCandidate)
+                    listOfNotNull(topCandidate)
                 }
 
                 is CandidateEvaluationResult.Pass -> {
-                    type = 36
-                    parsedResultText = firstCandidate
+                    listOfNotNull(
+                        buildAcceptedZenzCandidate(
+                            generatedText = firstCandidate,
+                            type = (36).toByte(),
+                            insertString = insertString,
+                        )
+                    )
                 }
 
                 is CandidateEvaluationResult.WholeResult -> {
-                    type = 38
-                    parsedResultText = zenzaiResultType.result
+                    listOfNotNull(
+                        buildAcceptedZenzCandidate(
+                            generatedText = zenzaiResultType.result,
+                            type = (38).toByte(),
+                            insertString = insertString,
+                        )
+                    )
                 }
             }
-
-            listOf(
-                ZenzCandidate(
-                    string = parsedResultText,
-                    type = type.toByte(),
-                    length = insertString.length.toUByte(),
-                    score = 2000,
-                    originalString = insertString
-                )
-            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ZenzOutputPolicy.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ZenzOutputPolicy.kt
@@ -1,0 +1,39 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+/**
+ * Validates text crossing from the Zenz runtime into the user-visible
+ * candidate pipeline.
+ *
+ * The U+EE00..U+EE0F range belongs to the Zenz prompt protocol. It is never
+ * valid candidate text, even if a native/runtime regression accidentally
+ * returns it. Completion length is deliberately not inferred from the input
+ * reading: a valid conversion may be longer or shorter than its reading.
+ */
+internal object ZenzOutputPolicy {
+    private const val PROTOCOL_MARKER_FIRST = 0xEE00
+    private const val PROTOCOL_MARKER_LAST = 0xEE0F
+
+    fun acceptedTextOrNull(value: String?): String? {
+        if (value.isNullOrEmpty()) return null
+        if (!isSafeUserVisibleText(value)) return null
+        return value
+    }
+
+    fun isSafeUserVisibleText(value: String): Boolean {
+        var index = 0
+        while (index < value.length) {
+            val codePoint = value.codePointAt(index)
+            if (
+                codePoint in PROTOCOL_MARKER_FIRST..PROTOCOL_MARKER_LAST ||
+                codePoint < 0x20 ||
+                codePoint == 0x7F ||
+                codePoint == 0xFFFD ||
+                codePoint in 0xD800..0xDFFF
+            ) {
+                return false
+            }
+            index += Character.charCount(codePoint)
+        }
+        return true
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/models/CandidateEvaluationResult.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/models/CandidateEvaluationResult.kt
@@ -1,5 +1,7 @@
 package com.kazumaproject.markdownhelperkeyboard.ime_service.models
 
+import com.kazumaproject.markdownhelperkeyboard.ime_service.ZenzOutputPolicy
+
 sealed class CandidateEvaluationResult {
     /** エラーが発生した場合 */
     data object Error : CandidateEvaluationResult()
@@ -26,18 +28,18 @@ sealed class CandidateEvaluationResult {
             return when {
                 null == raw -> Error
                 raw.startsWith("PASS:") -> {
-                    val score = raw.removePrefix("PASS:").toFloatOrNull() ?: 0f
-                    Pass(score)
+                    val score = raw.removePrefix("PASS:").toFloatOrNull()
+                    if (score == null || !score.isFinite()) Error else Pass(score)
                 }
 
                 raw.startsWith("FIX:") -> {
                     val prefix = raw.removePrefix("FIX:")
-                    FixRequired(prefix)
+                    ZenzOutputPolicy.acceptedTextOrNull(prefix)?.let(::FixRequired) ?: Error
                 }
 
                 raw.startsWith("WHOLE:") -> {
                     val result = raw.removePrefix("WHOLE:")
-                    WholeResult(result)
+                    ZenzOutputPolicy.acceptedTextOrNull(result)?.let(::WholeResult) ?: Error
                 }
 
                 else -> Error

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ZenzOutputPolicyTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ZenzOutputPolicyTest.kt
@@ -1,0 +1,45 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import com.kazumaproject.markdownhelperkeyboard.ime_service.models.CandidateEvaluationResult
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ZenzOutputPolicyTest {
+    @Test
+    fun acceptsNormalAndLongConversionTextWithoutInputLengthHeuristic() {
+        assertEquals("末", ZenzOutputPolicy.acceptedTextOrNull("末"))
+
+        val longValidText = "これは意味のある長い変換結果です。".repeat(8)
+        assertEquals(longValidText, ZenzOutputPolicy.acceptedTextOrNull(longValidText))
+    }
+
+    @Test
+    fun rejectsEveryReservedProtocolMarker() {
+        for (codePoint in 0xEE00..0xEE0F) {
+            val marker = String(Character.toChars(codePoint))
+            assertNull(
+                "U+${codePoint.toString(16).uppercase()} must not reach candidates",
+                ZenzOutputPolicy.acceptedTextOrNull("末${marker}まつ"),
+            )
+        }
+    }
+
+    @Test
+    fun rejectsEmptyControlAndReplacementText() {
+        assertNull(ZenzOutputPolicy.acceptedTextOrNull(null))
+        assertNull(ZenzOutputPolicy.acceptedTextOrNull(""))
+        assertNull(ZenzOutputPolicy.acceptedTextOrNull("末\n"))
+        assertNull(ZenzOutputPolicy.acceptedTextOrNull("末\uFFFD"))
+        assertNull(ZenzOutputPolicy.acceptedTextOrNull("末\u0001"))
+    }
+
+    @Test
+    fun candidateEvaluationParserRejectsUnsafePayloadsAndNonFiniteScores() {
+        assertTrue(CandidateEvaluationResult.parse("PASS:-1.25") is CandidateEvaluationResult.Pass)
+        assertTrue(CandidateEvaluationResult.parse("PASS:NaN") is CandidateEvaluationResult.Error)
+        assertTrue(CandidateEvaluationResult.parse("FIX:末\uEE08まつ") is CandidateEvaluationResult.Error)
+        assertTrue(CandidateEvaluationResult.parse("WHOLE:\u0001") is CandidateEvaluationResult.Error)
+    }
+}

--- a/zenz/src/main/cpp/zenz_bridge.cpp
+++ b/zenz/src/main/cpp/zenz_bridge.cpp
@@ -1,5 +1,7 @@
 #include <jni.h>
+#include <algorithm>
 #include <string>
+#include <string_view>
 #include <vector>
 #include <mutex>
 #include <atomic>
@@ -55,6 +57,109 @@ struct CandidateEvaluationResult {
     std::string prefix;         // FIX_REQUIRED の場合の接頭辞
     std::string whole_result;   // WHOLE_RESULT の場合の結果
 };
+
+// Zenz v3.x reserves the private-use range U+EE00..U+EE0F for prompt,
+// alignment, and future protocol markers.  These code points are not
+// necessarily classified as llama control tokens, so they must be handled by
+// the Zenz decoder itself.
+constexpr uint32_t kZenzProtocolMarkerFirst = 0xEE00;
+constexpr uint32_t kZenzProtocolMarkerLast = 0xEE0F;
+
+enum class ZenzGenerationTermination {
+    EOG,
+    PROTOCOL_MARKER,
+    EMPTY_OUTPUT,
+    TOKEN_LIMIT,
+    CONTEXT_LIMIT,
+    INVALID_UTF8,
+    DECODE_ERROR,
+    CANCELLED,
+    MODEL_UNAVAILABLE,
+    INVALID_REQUEST,
+};
+
+struct ZenzGenerationResult {
+    std::string text;
+    ZenzGenerationTermination termination = ZenzGenerationTermination::INVALID_REQUEST;
+
+    bool accepted() const {
+        return !text.empty() &&
+               (termination == ZenzGenerationTermination::EOG ||
+                termination == ZenzGenerationTermination::PROTOCOL_MARKER);
+    }
+};
+
+enum class Utf8DecodeResult {
+    OK,
+    INCOMPLETE,
+    INVALID,
+};
+
+static Utf8DecodeResult decode_utf8_codepoint(
+        std::string_view text,
+        size_t offset,
+        uint32_t *codepoint,
+        size_t *width
+) {
+    if (!codepoint || !width || offset >= text.size()) {
+        return Utf8DecodeResult::INVALID;
+    }
+
+    const auto byte = [&](size_t index) -> uint8_t {
+        return static_cast<uint8_t>(text[index]);
+    };
+
+    const uint8_t first = byte(offset);
+    size_t sequence_width = 0;
+    if (first <= 0x7F) {
+        *codepoint = first;
+        *width = 1;
+        return Utf8DecodeResult::OK;
+    } else if (first >= 0xC2 && first <= 0xDF) {
+        sequence_width = 2;
+    } else if (first >= 0xE0 && first <= 0xEF) {
+        sequence_width = 3;
+    } else if (first >= 0xF0 && first <= 0xF4) {
+        sequence_width = 4;
+    } else {
+        return Utf8DecodeResult::INVALID;
+    }
+
+    if (offset + sequence_width > text.size()) {
+        return Utf8DecodeResult::INCOMPLETE;
+    }
+
+    for (size_t i = 1; i < sequence_width; ++i) {
+        if ((byte(offset + i) & 0xC0) != 0x80) {
+            return Utf8DecodeResult::INVALID;
+        }
+    }
+
+    uint32_t value = first & ((1u << (8 - sequence_width - 1)) - 1u);
+    for (size_t i = 1; i < sequence_width; ++i) {
+        value = (value << 6) | (byte(offset + i) & 0x3F);
+    }
+
+    // Reject overlong encodings, UTF-16 surrogates, and values outside
+    // Unicode.  The first-byte constraints above already reject most of
+    // these, but keeping the checks here makes the helper self-contained.
+    if ((sequence_width == 2 && value < 0x80) ||
+        (sequence_width == 3 && value < 0x800) ||
+        (sequence_width == 4 && value < 0x10000) ||
+        (value >= 0xD800 && value <= 0xDFFF) ||
+        value > 0x10FFFF) {
+        return Utf8DecodeResult::INVALID;
+    }
+
+    *codepoint = value;
+    *width = sequence_width;
+    return Utf8DecodeResult::OK;
+}
+
+static bool is_zenz_protocol_marker(uint32_t codepoint) {
+    return codepoint >= kZenzProtocolMarkerFirst &&
+           codepoint <= kZenzProtocolMarkerLast;
+}
 
 // ------- JNI文字列変換（重要） -------
 // llama_token_to_piece() が返すバイト列は不正UTF-8になり得るため、NewStringUTFは禁止。
@@ -174,6 +279,8 @@ __attribute__((used)) static const char styleTag[] = u8"\uEE05";
 __attribute__((used)) static const char preferenceTag[] = u8"\uEE06";
 __attribute__((used)) static const char rightContextTag[] = u8"\uEE07";
 
+static std::string sanitize_prompt_field(std::string_view text);
+
 static std::string jstring_to_string(JNIEnv *env, jstring value) {
     if (!value) {
         return "";
@@ -221,17 +328,29 @@ static std::string build_zenz_prompt(
         const std::string &rightContext,
         const std::string &input
 ) {
-    std::string prompt = build_conditions(profile, topic, style, preference);
-    if (!leftContext.empty()) {
+    const std::string safeProfile = sanitize_prompt_field(profile);
+    const std::string safeTopic = sanitize_prompt_field(topic);
+    const std::string safeStyle = sanitize_prompt_field(style);
+    const std::string safePreference = sanitize_prompt_field(preference);
+    const std::string safeLeftContext = sanitize_prompt_field(leftContext);
+    const std::string safeRightContext = sanitize_prompt_field(rightContext);
+    const std::string safeInput = sanitize_prompt_field(input);
+
+    std::string prompt = build_conditions(
+            safeProfile,
+            safeTopic,
+            safeStyle,
+            safePreference);
+    if (!safeLeftContext.empty()) {
         prompt += leftContextTag;
-        prompt += leftContext;
+        prompt += safeLeftContext;
     }
-    if (!rightContext.empty()) {
+    if (!safeRightContext.empty()) {
         prompt += rightContextTag;
-        prompt += rightContext;
+        prompt += safeRightContext;
     }
     prompt += inputTag;
-    prompt += input;
+    prompt += safeInput;
     prompt += outputTag;
     return prompt;
 }
@@ -320,6 +439,136 @@ static std::string token_to_piece_str(llama_token token) {
     return out;
 }
 
+class ZenzOutputDecoder {
+public:
+    enum class AppendResult {
+        CONTINUE,
+        PROTOCOL_MARKER,
+        INVALID_UTF8,
+    };
+
+    AppendResult append_piece(std::string_view piece) {
+        pending_utf8_.append(piece.data(), piece.size());
+
+        size_t offset = 0;
+        while (offset < pending_utf8_.size()) {
+            uint32_t codepoint = 0;
+            size_t width = 0;
+            const Utf8DecodeResult status = decode_utf8_codepoint(
+                    pending_utf8_, offset, &codepoint, &width);
+            if (status == Utf8DecodeResult::INCOMPLETE) {
+                break;
+            }
+            if (status == Utf8DecodeResult::INVALID) {
+                return AppendResult::INVALID_UTF8;
+            }
+
+            if (is_zenz_protocol_marker(codepoint)) {
+                pending_utf8_.clear();
+                return AppendResult::PROTOCOL_MARKER;
+            }
+
+            // A conversion candidate is user-visible text.  Prompt/control
+            // bytes, replacement characters, and C0/DEL controls must never
+            // cross the native boundary as candidate text.
+            if (codepoint == 0xFFFD || codepoint < 0x20 || codepoint == 0x7F) {
+                return AppendResult::INVALID_UTF8;
+            }
+
+            output_.append(pending_utf8_, offset, width);
+            offset += width;
+        }
+
+        if (offset > 0) {
+            pending_utf8_.erase(0, offset);
+        }
+        return AppendResult::CONTINUE;
+    }
+
+    bool finish() const {
+        return pending_utf8_.empty();
+    }
+
+    bool has_text() const {
+        return !output_.empty();
+    }
+
+    const std::string &text() const {
+        return output_;
+    }
+
+private:
+    std::string output_;
+    std::string pending_utf8_;
+};
+
+static bool is_safe_user_text(std::string_view text) {
+    ZenzOutputDecoder decoder;
+    return decoder.append_piece(text) == ZenzOutputDecoder::AppendResult::CONTINUE &&
+           decoder.finish();
+}
+
+// Structured prompt fields are user-controlled, while the private-use range
+// is the model protocol itself.  Strip protocol/control code points before
+// attaching field tags so context/profile text cannot alter the prompt
+// grammar. Invalid UTF-8 is dropped from the field; the generated output is
+// handled fail-closed instead.
+static std::string sanitize_prompt_field(std::string_view text) {
+    std::string sanitized;
+    sanitized.reserve(text.size());
+
+    size_t offset = 0;
+    while (offset < text.size()) {
+        uint32_t codepoint = 0;
+        size_t width = 0;
+        const Utf8DecodeResult status = decode_utf8_codepoint(
+                text, offset, &codepoint, &width);
+        if (status != Utf8DecodeResult::OK) {
+            break;
+        }
+
+        if (!is_zenz_protocol_marker(codepoint) &&
+            codepoint >= 0x20 && codepoint != 0x7F) {
+            sanitized.append(text, offset, width);
+        }
+        offset += width;
+    }
+    return sanitized;
+}
+
+static std::string decode_token_range(
+        const std::vector<llama_token> &tokens,
+        size_t begin,
+        size_t end,
+        bool *valid
+) {
+    ZenzOutputDecoder decoder;
+    if (begin > end || end > tokens.size()) {
+        if (valid) *valid = false;
+        return "";
+    }
+
+    for (size_t index = begin; index < end; ++index) {
+        const llama_token token = tokens[index];
+        if (g_vocab && llama_vocab_is_eog(g_vocab, token)) {
+            if (valid) *valid = false;
+            return "";
+        }
+
+        const std::string piece = token_to_piece_str(token);
+        const ZenzOutputDecoder::AppendResult append_result =
+                decoder.append_piece(piece);
+        if (append_result != ZenzOutputDecoder::AppendResult::CONTINUE) {
+            if (valid) *valid = false;
+            return "";
+        }
+    }
+
+    const bool complete = decoder.finish();
+    if (valid) *valid = complete;
+    return complete ? decoder.text() : "";
+}
+
 static RuntimeConfig get_runtime_config() {
     std::lock_guard<std::mutex> lock(g_param_mutex);
     return RuntimeConfig{
@@ -395,34 +644,100 @@ static llama_context *ensure_session_context_locked() {
     return g_session.ctx;
 }
 
-// Swift の pure_greedy_decoding 相当
-static std::string pure_greedy_decoding(
+static ZenzGenerationResult no_zenz_result(ZenzGenerationTermination termination) {
+    return ZenzGenerationResult{"", termination};
+}
+
+static ZenzGenerationResult finish_zenz_generation(
+        const ZenzOutputDecoder &decoder,
+        ZenzGenerationTermination termination
+) {
+    if (!decoder.finish()) {
+        return no_zenz_result(ZenzGenerationTermination::INVALID_UTF8);
+    }
+    if (!decoder.has_text()) {
+        return no_zenz_result(ZenzGenerationTermination::EMPTY_OUTPUT);
+    }
+    return ZenzGenerationResult{decoder.text(), termination};
+}
+
+static const char *zenz_generation_termination_name(
+        ZenzGenerationTermination termination
+) {
+    switch (termination) {
+        case ZenzGenerationTermination::EOG: return "eog";
+        case ZenzGenerationTermination::PROTOCOL_MARKER: return "protocol_marker";
+        case ZenzGenerationTermination::EMPTY_OUTPUT: return "empty_output";
+        case ZenzGenerationTermination::TOKEN_LIMIT: return "token_limit";
+        case ZenzGenerationTermination::CONTEXT_LIMIT: return "context_limit";
+        case ZenzGenerationTermination::INVALID_UTF8: return "invalid_utf8";
+        case ZenzGenerationTermination::DECODE_ERROR: return "decode_error";
+        case ZenzGenerationTermination::CANCELLED: return "cancelled";
+        case ZenzGenerationTermination::MODEL_UNAVAILABLE: return "model_unavailable";
+        case ZenzGenerationTermination::INVALID_REQUEST: return "invalid_request";
+    }
+    return "unknown";
+}
+
+static std::string accepted_zenz_text(const ZenzGenerationResult &result) {
+    LOGI("Zenz generation termination=%s accepted=%s bytes=%zu",
+         zenz_generation_termination_name(result.termination),
+         result.accepted() ? "true" : "false",
+         result.text.size());
+    return result.accepted() ? result.text : "";
+}
+
+// Swift の pure_greedy_decoding 相当。ただし、候補として返せるのは
+// EOG または Zenz プロトコルマーカーで正常終了した完全な出力だけにする。
+static ZenzGenerationResult pure_greedy_decoding(
         const std::string &leftSideContext,
         int maxCount,
         uint64_t request_seq
 ) {
     std::unique_lock<std::mutex> session_lock(g_session.mutex);
     if (is_request_stale(request_seq)) {
-        return "";
+        return no_zenz_result(ZenzGenerationTermination::CANCELLED);
     }
     if (!g_model || !g_vocab) {
-        return "[error] model not initialized";
+        return no_zenz_result(ZenzGenerationTermination::MODEL_UNAVAILABLE);
     }
 
     llama_context *ctx = ensure_session_context_locked();
     if (!ctx) {
-        return "[error] failed to create context";
+        return no_zenz_result(ZenzGenerationTermination::DECODE_ERROR);
     }
     llama_kv_cache_clear(ctx);
 
     AbortRequestState abort_state{request_seq};
     llama_set_abort_callback(ctx, abort_if_stale, &abort_state);
+    const auto clear_abort_callback = [&]() {
+        llama_set_abort_callback(ctx, never_abort, nullptr);
+    };
 
     std::string pre = preprocess_text(leftSideContext);
     auto prompt_tokens = tokenize_text(pre, /*add_bos=*/false, /*add_eos=*/false);
     if (prompt_tokens.empty()) {
-        llama_set_abort_callback(ctx, never_abort, nullptr);
-        return "";
+        clear_abort_callback();
+        return no_zenz_result(ZenzGenerationTermination::INVALID_REQUEST);
+    }
+
+    const RuntimeConfig config = get_runtime_config();
+    if (config.n_ctx <= 0 || prompt_tokens.size() >= static_cast<size_t>(config.n_ctx)) {
+        clear_abort_callback();
+        LOGE("pure_greedy_decoding: prompt exceeds context window: prompt=%zu n_ctx=%d",
+             prompt_tokens.size(), config.n_ctx);
+        return no_zenz_result(ZenzGenerationTermination::CONTEXT_LIMIT);
+    }
+
+    const int requested_count = std::max(maxCount, 0);
+    const int available_count = config.n_ctx - static_cast<int>(prompt_tokens.size());
+    const int generation_limit = std::min(requested_count, available_count);
+    if (generation_limit <= 0) {
+        clear_abort_callback();
+        return no_zenz_result(
+                requested_count <= 0
+                        ? ZenzGenerationTermination::INVALID_REQUEST
+                        : ZenzGenerationTermination::CONTEXT_LIMIT);
     }
 
     {
@@ -436,22 +751,28 @@ static std::string pure_greedy_decoding(
             if (is_request_stale(request_seq)) {
                 LOGI("pure_greedy_decoding aborted while decoding prompt");
             }
-            llama_set_abort_callback(ctx, never_abort, nullptr);
-            return "";
+            clear_abort_callback();
+            return no_zenz_result(
+                    is_request_stale(request_seq)
+                            ? ZenzGenerationTermination::CANCELLED
+                            : ZenzGenerationTermination::DECODE_ERROR);
         }
     }
 
-    std::vector<llama_token> generated;
-    generated.reserve(maxCount);
-
-    const llama_token eos = llama_vocab_eos(g_vocab);
     const int32_t n_vocab = llama_vocab_n_tokens(g_vocab);
+    ZenzOutputDecoder decoder;
 
-    for (int i = 0; i < maxCount; ++i) {
+    for (int i = 0; i < generation_limit; ++i) {
+        if (is_request_stale(request_seq)) {
+            clear_abort_callback();
+            return no_zenz_result(ZenzGenerationTermination::CANCELLED);
+        }
+
         float *logits = llama_get_logits_ith(ctx, -1);
         if (!logits) {
             LOGE("logits is null");
-            break;
+            clear_abort_callback();
+            return no_zenz_result(ZenzGenerationTermination::DECODE_ERROR);
         }
 
         int best_id = 0;
@@ -464,36 +785,52 @@ static std::string pure_greedy_decoding(
         }
 
         llama_token next = (llama_token) best_id;
-        if (next == eos) {
-            break;
+        if (llama_vocab_is_eog(g_vocab, next)) {
+            const ZenzGenerationResult result = finish_zenz_generation(
+                    decoder,
+                    ZenzGenerationTermination::EOG);
+            clear_abort_callback();
+            return result;
         }
 
-        generated.push_back(next);
+        const std::string piece = token_to_piece_str(next);
+        const ZenzOutputDecoder::AppendResult append_result =
+                decoder.append_piece(piece);
+        if (append_result == ZenzOutputDecoder::AppendResult::PROTOCOL_MARKER) {
+            const ZenzGenerationResult result = finish_zenz_generation(
+                    decoder,
+                    ZenzGenerationTermination::PROTOCOL_MARKER);
+            clear_abort_callback();
+            return result;
+        }
+        if (append_result == ZenzOutputDecoder::AppendResult::INVALID_UTF8) {
+            clear_abort_callback();
+            return no_zenz_result(ZenzGenerationTermination::INVALID_UTF8);
+        }
+
+        // The last allowed token does not need to be decoded again.  Reaching
+        // this branch means the model did not provide a clean terminator.
+        if (i + 1 >= generation_limit) {
+            break;
+        }
 
         llama_batch next_batch = llama_batch_get_one(&next, 1);
         int rc = llama_decode(ctx, next_batch);
         if (rc != 0) {
             if (is_request_stale(request_seq)) {
                 LOGI("pure_greedy_decoding aborted during token generation");
-                llama_set_abort_callback(ctx, never_abort, nullptr);
-                return "";
+                clear_abort_callback();
+                return no_zenz_result(ZenzGenerationTermination::CANCELLED);
             } else {
                 LOGE("llama_decode(step) failed: %d", rc);
             }
-            break;
+            clear_abort_callback();
+            return no_zenz_result(ZenzGenerationTermination::DECODE_ERROR);
         }
     }
 
-    std::string out;
-    for (auto t: generated) {
-        if (llama_vocab_is_control(g_vocab, t)) {
-            continue;
-        }
-        out += token_to_piece_str(t);
-    }
-
-    llama_set_abort_callback(ctx, never_abort, nullptr);
-    return out;
+    clear_abort_callback();
+    return no_zenz_result(ZenzGenerationTermination::TOKEN_LIMIT);
 }
 
 // Swift の evaluate_candidate 相当
@@ -531,7 +868,8 @@ static CandidateEvaluationResult candidate_evaluate(
     auto prompt_tokens = tokenize_text(pre_prompt, /*add_bos=*/false, /*add_eos=*/false);
     auto candidate_tokens = tokenize_text(pre_candidate, /*add_bos=*/false, /*add_eos=*/false);
 
-    if (prompt_tokens.empty()) {
+    if (prompt_tokens.empty() || candidate_tokens.empty() ||
+        pre_candidate.empty() || !is_safe_user_text(pre_candidate)) {
         LOGE("candidate_evaluate: prompt tokens empty");
         llama_set_abort_callback(ctx, never_abort, nullptr);
         return result;
@@ -539,6 +877,14 @@ static CandidateEvaluationResult candidate_evaluate(
 
     std::vector<llama_token> all_tokens = prompt_tokens;
     all_tokens.insert(all_tokens.end(), candidate_tokens.begin(), candidate_tokens.end());
+
+    const RuntimeConfig config = get_runtime_config();
+    if (config.n_ctx <= 0 || all_tokens.size() > static_cast<size_t>(config.n_ctx)) {
+        LOGE("candidate_evaluate: prompt and candidate exceed context window: tokens=%zu n_ctx=%d",
+             all_tokens.size(), config.n_ctx);
+        llama_set_abort_callback(ctx, never_abort, nullptr);
+        return result;
+    }
 
     // ★ 512固定だと長文で overflow するので必要量で確保
     const int32_t cap = (int32_t) all_tokens.size();
@@ -577,7 +923,6 @@ static CandidateEvaluationResult candidate_evaluate(
         return result;
     }
 
-    const llama_token eos = llama_vocab_eos(g_vocab);
     const int32_t n_vocab = llama_vocab_n_tokens(g_vocab);
 
     float *all_logits = llama_get_logits(ctx);
@@ -606,6 +951,12 @@ static CandidateEvaluationResult candidate_evaluate(
         }
 
         llama_token max_token = (llama_token) max_id;
+        const std::string max_piece = token_to_piece_str(max_token);
+        ZenzOutputDecoder max_piece_decoder;
+        const ZenzOutputDecoder::AppendResult max_piece_result =
+                max_piece_decoder.append_piece(max_piece);
+        const bool max_token_is_protocol_marker =
+                max_piece_result == ZenzOutputDecoder::AppendResult::PROTOCOL_MARKER;
 
         float sum_exp = 0.0f;
         for (int32_t tid = 0; tid < n_vocab; ++tid) {
@@ -615,13 +966,18 @@ static CandidateEvaluationResult candidate_evaluate(
         total_score += log_prob;
 
         if (max_token != expected_token) {
-            if (max_token == eos) {
-                std::string partial;
-                for (size_t j = prompt_tokens.size(); j < i; ++j) {
-                    llama_token t = all_tokens[j];
-                    if (!llama_vocab_is_control(g_vocab, t)) {
-                        partial += token_to_piece_str(t);
-                    }
+            if (llama_vocab_is_eog(g_vocab, max_token) || max_token_is_protocol_marker) {
+                bool valid = false;
+                const std::string partial = decode_token_range(
+                        all_tokens,
+                        prompt_tokens.size(),
+                        i,
+                        &valid);
+                if (!valid || partial.empty()) {
+                    result.type = CandidateEvaluationResultType::ERROR;
+                    llama_batch_free(batch);
+                    llama_set_abort_callback(ctx, never_abort, nullptr);
+                    return result;
                 }
                 result.type = CandidateEvaluationResultType::WHOLE_RESULT;
                 result.whole_result = partial;
@@ -630,19 +986,51 @@ static CandidateEvaluationResult candidate_evaluate(
                 llama_set_abort_callback(ctx, never_abort, nullptr);
                 return result;
             } else {
-                std::string prefix;
-                for (size_t j = prompt_tokens.size(); j < i; ++j) {
-                    llama_token t = all_tokens[j];
-                    if (!llama_vocab_is_control(g_vocab, t)) {
-                        prefix += token_to_piece_str(t);
+                bool valid = false;
+                const std::string previous_prefix = decode_token_range(
+                        all_tokens,
+                        prompt_tokens.size(),
+                        i,
+                        &valid);
+                if (!valid) {
+                    result.type = CandidateEvaluationResultType::ERROR;
+                    llama_batch_free(batch);
+                    llama_set_abort_callback(ctx, never_abort, nullptr);
+                    return result;
+                }
+
+                ZenzOutputDecoder prefix_decoder;
+                if (prefix_decoder.append_piece(previous_prefix) !=
+                            ZenzOutputDecoder::AppendResult::CONTINUE) {
+                    result.type = CandidateEvaluationResultType::ERROR;
+                    llama_batch_free(batch);
+                    llama_set_abort_callback(ctx, never_abort, nullptr);
+                    return result;
+                }
+                if (!llama_vocab_is_control(g_vocab, max_token) || !max_piece.empty()) {
+                    if (max_piece_result != ZenzOutputDecoder::AppendResult::CONTINUE) {
+                        result.type = CandidateEvaluationResultType::ERROR;
+                        llama_batch_free(batch);
+                        llama_set_abort_callback(ctx, never_abort, nullptr);
+                        return result;
+                    }
+                    if (prefix_decoder.append_piece(max_piece) !=
+                                ZenzOutputDecoder::AppendResult::CONTINUE) {
+                        result.type = CandidateEvaluationResultType::ERROR;
+                        llama_batch_free(batch);
+                        llama_set_abort_callback(ctx, never_abort, nullptr);
+                        return result;
                     }
                 }
-                if (!llama_vocab_is_control(g_vocab, max_token)) {
-                    prefix += token_to_piece_str(max_token);
+                if (!prefix_decoder.finish() || !prefix_decoder.has_text()) {
+                    result.type = CandidateEvaluationResultType::ERROR;
+                    llama_batch_free(batch);
+                    llama_set_abort_callback(ctx, never_abort, nullptr);
+                    return result;
                 }
                 result.type = CandidateEvaluationResultType::FIX_REQUIRED;
-                result.prefix = prefix;
-                LOGI("candidate_evaluate: FIX_REQUIRED at pos %zu, prefix=%s", i, prefix.c_str());
+                result.prefix = prefix_decoder.text();
+                LOGI("candidate_evaluate: FIX_REQUIRED at pos %zu, prefix=%s", i, result.prefix.c_str());
                 llama_batch_free(batch);
                 llama_set_abort_callback(ctx, never_abort, nullptr);
                 return result;
@@ -695,6 +1083,12 @@ static float score_candidate_avg_logprob_reuse_prompt_locked(
         return -INFINITY;
     }
     if (prompt_tokens.empty() || candidate_tokens.empty()) {
+        return -INFINITY;
+    }
+
+    const RuntimeConfig config = get_runtime_config();
+    if (config.n_ctx <= 0 ||
+        prompt_tokens.size() + candidate_tokens.size() > static_cast<size_t>(config.n_ctx)) {
         return -INFINITY;
     }
 
@@ -914,10 +1308,13 @@ Java_com_kazumaproject_zenz_ZenzEngine_generate(
     env->ReleaseStringUTFChars(jPrompt, c_prompt);
 
     uint64_t request_seq = g_request_seq.fetch_add(1, std::memory_order_relaxed) + 1;
-    std::string result = pure_greedy_decoding(prompt, /*maxCount=*/maxTokens, request_seq);
+    const ZenzGenerationResult result = pure_greedy_decoding(
+            prompt,
+            /*maxCount=*/maxTokens,
+            request_seq);
 
     // ★ NewStringUTFは禁止（不正UTF-8の可能性）
-    return toJString(env, result);
+    return toJString(env, accepted_zenz_text(result));
 }
 
 // ------- JNI: 文脈 + 読み で変換 -------
@@ -952,8 +1349,11 @@ static jstring generate_with_context_and_conditions(
     );
 
     uint64_t request_seq = g_request_seq.fetch_add(1, std::memory_order_relaxed) + 1;
-    std::string result = pure_greedy_decoding(prompt, /*maxCount=*/maxTokens, request_seq);
-    return toJString(env, result);
+    const ZenzGenerationResult result = pure_greedy_decoding(
+            prompt,
+            /*maxCount=*/maxTokens,
+            request_seq);
+    return toJString(env, accepted_zenz_text(result));
 }
 
 extern "C"
@@ -1223,6 +1623,15 @@ static jfloatArray score_candidates_with_context(
             return result_array;
         }
 
+        const RuntimeConfig config = get_runtime_config();
+        if (config.n_ctx <= 0 || prompt_tokens.size() >= static_cast<size_t>(config.n_ctx)) {
+            LOGE("scoreCandidates: prompt exceeds context window: prompt=%zu n_ctx=%d",
+                 prompt_tokens.size(), config.n_ctx);
+            llama_set_abort_callback(ctx, never_abort, nullptr);
+            env->SetFloatArrayRegion(result_array, 0, candidate_count, scores.data());
+            return result_array;
+        }
+
         if (!prefill_prompt_prefix_locked(ctx, prompt_tokens)) {
             LOGE("scoreCandidates: failed to prefill prompt prefix");
             llama_set_abort_callback(ctx, never_abort, nullptr);
@@ -1233,6 +1642,10 @@ static jfloatArray score_candidates_with_context(
         std::vector<std::vector<llama_token>> candidate_tokens_list((size_t) candidate_count);
         for (jsize i = 0; i < candidate_count; ++i) {
             if (candidate_strings[(size_t) i].empty()) {
+                continue;
+            }
+            if (!is_safe_user_text(candidate_strings[(size_t) i])) {
+                scores[(size_t) i] = -INFINITY;
                 continue;
             }
             candidate_tokens_list[(size_t) i] = tokenize_text(

--- a/zenz/src/test/java/com/kazumaproject/zenz/ZenzBridgePromptContractTest.kt
+++ b/zenz/src/test/java/com/kazumaproject/zenz/ZenzBridgePromptContractTest.kt
@@ -13,11 +13,11 @@ class ZenzBridgePromptContractTest {
         val builder = promptBuilder(source)
 
         val leftTagIndex = builder.indexOf("prompt += leftContextTag;")
-        val leftContextIndex = builder.indexOf("prompt += leftContext;")
+        val leftContextIndex = builder.indexOf("prompt += safeLeftContext;")
         val rightTagIndex = builder.indexOf("prompt += rightContextTag;")
-        val rightContextIndex = builder.indexOf("prompt += rightContext;")
+        val rightContextIndex = builder.indexOf("prompt += safeRightContext;")
         val inputTagIndex = builder.indexOf("prompt += inputTag;")
-        val inputIndex = builder.indexOf("prompt += input;")
+        val inputIndex = builder.indexOf("prompt += safeInput;")
         val outputTagIndex = builder.indexOf("prompt += outputTag;")
 
         assertTrue("left context tag must be appended", leftTagIndex >= 0)
@@ -41,12 +41,26 @@ class ZenzBridgePromptContractTest {
         val builder = promptBuilder(source)
 
         val tagIndex = Regex("""rightContextTag\[\]\s*=\s*u8"\\uEE07"""").find(source)?.range?.first ?: -1
-        val guardIndex = builder.indexOf("if (!rightContext.empty())")
+        val guardIndex = builder.indexOf("if (!safeRightContext.empty())")
         val appendIndex = builder.indexOf("prompt += rightContextTag;")
 
         assertTrue("right context tag must be U+EE07", tagIndex >= 0)
         assertTrue("right context append must be guarded", guardIndex >= 0)
         assertTrue("right context tag append must be inside the non-empty branch", guardIndex < appendIndex)
+    }
+
+    @Test
+    fun promptBuilderSanitizesStructuredFieldsAndReservesWholeProtocolRange() {
+        val source = bridgeSource().readText()
+        val builder = promptBuilder(source)
+
+        assertTrue("protocol marker range must start at U+EE00", source.contains("0xEE00"))
+        assertTrue("protocol marker range must end at U+EE0F", source.contains("0xEE0F"))
+        assertTrue("structured fields must be sanitized", source.contains("sanitize_prompt_field"))
+        assertTrue("profile must use sanitized value", builder.contains("safeProfile"))
+        assertTrue("left context must use sanitized value", builder.contains("safeLeftContext"))
+        assertTrue("right context must use sanitized value", builder.contains("safeRightContext"))
+        assertTrue("input must use sanitized value", builder.contains("safeInput"))
     }
 
     private fun bridgeSource(): File {


### PR DESCRIPTION
## 日本語

### 概要

Zenz を有効にした状態で「まつ」などを入力すると、モデルの変換終端後に続くプロトコル用の文字列まで候補へ流れ込み、長文で意味のない変換候補が表示される問題を修正しました。

### 根本原因

- native の greedy generation が通常の EOS トークンだけを終端として扱い、Zenz の EOG と予約マーカー U+EE00〜U+EE0F（特に U+EE08）を通常の出力として処理していました。
- 予約マーカーの後も maxTokens までデコードを継続し、モデル内部の後続出力を候補文字列へ連結していました。
- Kotlin 側は native の戻り値を検証せず ZenzCandidate として公開していたため、壊れた出力が候補 UI まで到達していました。
- context/profile/input に含まれる予約領域も prompt grammar を壊し得る状態でした。

### 実装内容

- native にトークン境界を跨ぐ UTF-8 decoder と ZenzGenerationResult を追加しました。
- EOG またはプロトコルマーカーで正常終了した出力だけを採用し、終端なし・context 超過・不正 UTF-8・decode failure は fail-closed で空結果にしました。
- prompt の profile/topic/style/preference/context/input から予約マーカーと制御文字を除去しました。
- candidate evaluation と score path にも context budget と安全な候補文字列の検証を適用しました。
- Kotlin 側に共通の ZenzOutputPolicy を追加し、通常生成、FIX、WHOLE、live candidate adoption の全経路で出力を検証するようにしました。
- 入力長による機械的な切り詰めは行っていません。意味のある長い変換結果は許可します。

### 再発防止テスト

- U+EE00〜U+EE0F の全予約マーカーを候補として拒否する unit test
- prompt の構造フィールドとタグ順序を検証する native contract test
- マツ、まつ、セイドガタカイ、コンニチハ、アリガトウの実モデル回帰テスト
- 予約マーカーを混ぜた context と通常 context が同じ結果になる実機テスト
- マツの bundled model 出力が末で終了し、後続テキストを連結しないことの回帰テスト

### 検証結果

- Zenz JVM unit tests: 成功
- App JVM unit tests: 成功
- native build: 成功
- fullStandardDebug lint: 成功
- ZenzRuntimeInstrumentedTest: Pixel 6 / Android 17 で 2/2 成功

補足: 全 connected Android test suite も実行しましたが、端末画面状態・既存リソース差異など今回の変更と無関係なテストが 27 件失敗しました。今回追加した Zenz 対象クラスは分離実行で 2/2 成功しています。

## English

### Summary

This PR fixes malformed, meaningless long conversion candidates that appeared when Zenz was enabled and inputs such as “まつ” were typed. Text generated after the model’s conversion terminator was leaking into the candidate shown by the IME.

### Root cause

- The native greedy generation loop only stopped on the ordinary EOS token. It did not treat Zenz EOG or the reserved U+EE00–U+EE0F protocol marker range, especially U+EE08, as a generation boundary.
- Decoding continued after the protocol marker until maxTokens, concatenating model-internal continuation text into the candidate.
- Kotlin exposed the raw native string as a ZenzCandidate without validating the output contract.
- User-controlled context/profile/input fields could also contain protocol markers and alter the prompt grammar.

### Implementation

- Added an incremental UTF-8 decoder and an explicit ZenzGenerationResult in native code.
- Only output terminated by EOG or a Zenz protocol marker is accepted. Unterminated output, context overflow, invalid UTF-8, and decode failures fail closed with an empty result.
- Sanitized profile, topic, style, preference, context, and input fields before assembling the prompt.
- Added context-budget and safe-text validation to candidate evaluation and scoring paths.
- Added a shared Kotlin ZenzOutputPolicy covering normal generation, FIX, WHOLE, and live candidate adoption.
- No input-length heuristic or arbitrary output truncation was introduced; meaningful long conversions remain valid.

### Regression coverage

- Unit coverage for every reserved protocol marker from U+EE00 through U+EE0F
- Native prompt tag-order and structured-field contract coverage
- Real-model coverage for multiple readings, not only “まつ”
- Device coverage proving marked context produces the same result as sanitized context
- A semantic bundled-model assertion that マツ produces 末 without appending post-marker text

### Verification

- Zenz JVM unit tests: passed
- App JVM unit tests: passed
- Native build: passed
- fullStandardDebug lint: passed
- ZenzRuntimeInstrumentedTest: 2/2 passed on Pixel 6 / Android 17

The full connected Android suite was also run, but 27 unrelated device/resource-dependent tests failed. The Zenz regression class passes independently with 2/2 tests.