### PR TITLE
[BUG] Liquid Glass 時の削除ちらつきを修正 / Fix deletion flicker with Liquid Glass

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -755,6 +755,87 @@ class FastInputMatrixInstrumentedTest {
     }
 
     @Test
+    fun liquidGlassRepeatedDeleteDoesNotRestoreEarlierInputOnPhysicalDevice() {
+        runPhysicalDeviceSession("liquid-glass-repeated-delete") { session ->
+            var scenario: ActivityScenario<FastInputHostActivity>? = null
+            try {
+                scenario = launchHost(session.context)
+                rotateAndVerify(TestOrientation.PORTRAIT)
+
+                listOf(TestKeyboard.TENKEY, TestKeyboard.QWERTY).forEach { keyboard ->
+                    val testCase = TestCase(
+                        keyboard = keyboard,
+                        columns = 1,
+                        candidateTabVisible = false,
+                        toolbarVisible = false,
+                        toolbarIntegrated = false,
+                        orientation = TestOrientation.PORTRAIT,
+                    )
+                    applyCasePreferences(session.preferences, testCase)
+                    check(
+                        session.preferences.edit()
+                            .putBoolean("liquid_glass_preference", true)
+                            .putInt("liquid_glass_blur_preference", 220)
+                            .putString("keyboard_touch_effect_type_preference", "none")
+                            .commit()
+                    )
+
+                    ensureTargetImeSelected(session)
+                    restartInput(scenario)
+                    SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                    assertDeviceReady(session.context, session.targetIme, scenario)
+                    prepareEmptyEditor(scenario)
+
+                    val geometry = awaitStableGeometry(keyboard, requireCandidateContent = false)
+                    assertTrue(
+                        "Input injection failed for liquid glass ${keyboard.name}",
+                        injectSequence(
+                            first = geometry.first.center,
+                            second = geometry.second.center,
+                            repetitions = 3,
+                        ),
+                    )
+                    var previousText = awaitTextSettled(scenario)
+                    assertTrue(
+                        "Input did not reach the editor for liquid glass ${keyboard.name}",
+                        previousText.isNotEmpty(),
+                    )
+
+                    val deleteBounds = findVisibleNodeById("key_delete")?.screenRect()
+                        ?: throw SetupException("Delete key is not visible")
+                    repeat(previousText.length) { index ->
+                        assertTrue(
+                            "Delete injection failed for liquid glass ${keyboard.name} #$index",
+                            injectTapWithoutTrailingGap(
+                                point = deleteBounds.center,
+                                holdMs = 0L,
+                            ),
+                        )
+                        val beforeDelete = previousText
+                        val nextText = awaitEditorText(scenario) {
+                            it.length < beforeDelete.length
+                        }
+                        assertTrue(
+                            "Editor text did not shrink for liquid glass ${keyboard.name} " +
+                                "#${index + 1}: [$nextText] after [$beforeDelete]",
+                            nextText.length < beforeDelete.length,
+                        )
+                        previousText = nextText
+                    }
+
+                    assertEquals(
+                        "Repeated delete did not clear liquid glass input for ${keyboard.name}",
+                        "",
+                        awaitTextSettled(scenario),
+                    )
+                }
+            } finally {
+                scenario?.close()
+            }
+        }
+    }
+
+    @Test
     fun composingTextCursorMoveAndCommitClearsCandidatesOnPhysicalDevice() {
         runPhysicalDeviceSession("composing-selection-commit-candidate-clear") { session ->
             val testCase = TestCase(

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/EditorMutationRevision.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/EditorMutationRevision.kt
@@ -1,0 +1,21 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import java.util.concurrent.atomic.AtomicLong
+
+/**
+ * Identifies editor mutations that can invalidate asynchronous candidate or composing work.
+ *
+ * Input text alone is not sufficient: deleting and then re-entering the same text must still
+ * reject work that was started before the deletion.
+ */
+internal class EditorMutationRevision {
+    private val value = AtomicLong(0L)
+
+    fun current(): Long = value.get()
+
+    fun advance(): Long = value.incrementAndGet()
+
+    fun restart(): Long = value.incrementAndGet()
+
+    fun isCurrent(revision: Long): Boolean = value.get() == revision
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -413,6 +413,7 @@ import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 import java.util.concurrent.Executors
+import java.util.function.Consumer
 import java.util.regex.Pattern
 import javax.inject.Inject
 import androidx.appcompat.R as AppCompatR
@@ -816,6 +817,20 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         ).apply { isDaemon = true }
     }.asCoroutineDispatcher()
     private val mainHandler = Handler(Looper.getMainLooper())
+    private var imeWindowManager: WindowManager? = null
+    private var crossWindowBlurEnabled: Boolean = false
+    private var crossWindowBlurListenerRegistered: Boolean = false
+    private val crossWindowBlurEnabledListener = Consumer<Boolean> { enabled ->
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            crossWindowBlurEnabled = enabled
+            updateImeWindowBlurForCurrentMode()
+        } else {
+            mainHandler.post {
+                crossWindowBlurEnabled = enabled
+                updateImeWindowBlurForCurrentMode()
+            }
+        }
+    }
     private val runtimeGestureSettingsSource = MutableRuntimeGestureSettingsSource(
         RuntimeGestureSettings()
     )
@@ -1228,6 +1243,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun invalidateZeroQueryForEditorMutation() {
+        editorMutationRevision.advance()
         clearZeroQueryAllState(refresh = true)
     }
 
@@ -1808,6 +1824,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     @Volatile
     private var kanaKanjiConversionSession: KanaKanjiConversionSession? = null
     private val candidateRequestTracker = CandidateRequestTracker()
+    private val editorMutationRevision = EditorMutationRevision()
     private var symbolKeyboardFirstItem: SymbolMode? = SymbolMode.EMOJI
     private var userDictionaryPrefixMatchNumber: Int? = 2
     private var isTablet: Boolean? = false
@@ -2306,6 +2323,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     override fun onCreate() {
         super.onCreate()
         Timber.d("onCreate")
+        registerCrossWindowBlurListener()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             inlineAutofillController = InlineAutofillController(
                 context = this,
@@ -2596,7 +2614,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         applyImePreferences(preferences)
         conversionBackend = preferences.conversionBackend
         kanaKanjiConversionSession = null
-        candidateRequestTracker.restart(preferences.conversionBackend)
+        editorMutationRevision.restart()
+        candidateRequestTracker.restart(
+            backend = preferences.conversionBackend,
+            editorMutationRevision = editorMutationRevision.current(),
+        )
         candidateRefreshCoordinator.restart()
         activateKanaKanjiEngineWhenReady(
             preferences = preferences,
@@ -2618,7 +2640,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 session.enablePerformanceProbe()
             }
         }
-        candidateRequestTracker.restart(backend)
+        candidateRequestTracker.restart(
+            backend = backend,
+            editorMutationRevision = editorMutationRevision.current(),
+        )
         candidateRefreshCoordinator.restart()
     }
 
@@ -4591,12 +4616,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private fun applyNormalKeyboardChrome(mainView: MainLayoutBinding) {
         applyKeyboardContainerBackgrounds(mainView)
-
-        if (liquidGlassThemePreference == true) {
-            mainView.root.setDrawableAlpha(liquidGlassBlurRadiousPreference ?: 220)
-            mainView.suggestionViewParent.setDrawableAlpha(0)
-            mainView.candidateTabLayout.setDrawableAlpha(0)
-        }
+        applyImeGlassSurfaceAlpha(mainView)
 
         mainView.root.outlineProvider = ViewOutlineProvider.BACKGROUND
         mainView.root.clipToOutline = isKeyboardRounded == true
@@ -5078,6 +5098,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun onDestroy() {
+        unregisterCrossWindowBlurListener()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             inlineAutofillController?.destroy()
             inlineAutofillController = null
@@ -5409,18 +5430,82 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
     }
 
-    private fun shouldApplyImeWindowBlur(): Boolean {
-        return liquidGlassThemePreference == true &&
-                isKeyboardFloatingMode != true &&
-                physicalKeyboardEnable.replayCache.firstOrNull() != true &&
-                hasHardwareKeyboardConnected != true
+    private fun registerCrossWindowBlurListener() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || crossWindowBlurListenerRegistered) {
+            return
+        }
+
+        val manager = getSystemService(Context.WINDOW_SERVICE) as? WindowManager ?: return
+        imeWindowManager = manager
+        crossWindowBlurEnabled = runCatching {
+            manager.isCrossWindowBlurEnabled
+        }.getOrDefault(false)
+
+        runCatching {
+            manager.addCrossWindowBlurEnabledListener(
+                ContextCompat.getMainExecutor(this),
+                crossWindowBlurEnabledListener,
+            )
+            crossWindowBlurListenerRegistered = true
+        }.onFailure { throwable ->
+            Timber.w(throwable, "Unable to observe cross-window blur state")
+            crossWindowBlurEnabled = false
+        }
+    }
+
+    private fun unregisterCrossWindowBlurListener() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S || !crossWindowBlurListenerRegistered) {
+            return
+        }
+
+        runCatching {
+            imeWindowManager?.removeCrossWindowBlurEnabledListener(
+                crossWindowBlurEnabledListener
+            )
+        }.onFailure { throwable ->
+            Timber.w(throwable, "Unable to remove cross-window blur listener")
+        }
+        crossWindowBlurListenerRegistered = false
+        imeWindowManager = null
+    }
+
+    private fun currentImeGlassRenderDecision(): ImeGlassRenderDecision {
+        return ImeGlassRenderPolicy.resolve(
+            sdkInt = Build.VERSION.SDK_INT,
+            glassEnabled = liquidGlassThemePreference == true,
+            floatingMode = isKeyboardFloatingMode == true,
+            physicalKeyboardEnabled = physicalKeyboardEnable.replayCache.firstOrNull() == true,
+            hardwareKeyboardConnected = hasHardwareKeyboardConnected == true,
+            crossWindowBlurEnabled = crossWindowBlurEnabled,
+        )
+    }
+
+    private fun applyImeGlassSurfaceAlpha(
+        mainView: MainLayoutBinding,
+        decision: ImeGlassRenderDecision = currentImeGlassRenderDecision(),
+    ) {
+        if (liquidGlassThemePreference != true) return
+
+        val rootAlpha = when (decision.mode) {
+            ImeGlassRenderMode.SYSTEM_BLUR -> liquidGlassBlurRadiousPreference ?: 220
+            ImeGlassRenderMode.OPAQUE_BACKDROP,
+            ImeGlassRenderMode.NO_BLUR,
+                -> 255
+        }
+        mainView.root.setDrawableAlpha(rootAlpha)
+        mainView.suggestionViewParent.setDrawableAlpha(0)
+        mainView.candidateTabLayout.setDrawableAlpha(0)
     }
 
     private fun updateImeWindowBlurForCurrentMode(targetWindow: Window? = window.window) {
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) return
+        val decision = currentImeGlassRenderDecision()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            targetWindow?.setBackgroundBlurRadius(decision.windowBlurRadius)
+        }
 
-        val blurRadius = if (shouldApplyImeWindowBlur()) 50 else 0
-        targetWindow?.setBackgroundBlurRadius(blurRadius)
+        mainLayoutBinding?.let { mainView ->
+            applyImeGlassSurfaceAlpha(mainView, decision)
+        }
     }
 
     override fun onConfigureWindow(win: Window?, isFullscreen: Boolean, isCandidatesOnly: Boolean) {
@@ -16292,7 +16377,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 !suppressSuggestions &&
                 requestInput.isNotEmpty() &&
                 inputString.value == requestInput &&
-                (token == null || candidateRequestTracker.isCurrent(token))
+                (token == null || (
+                    candidateRequestTracker.isCurrent(token) &&
+                        editorMutationRevision.isCurrent(token.editorMutationRevision)
+                    ))
     }
 
     private fun clearSuggestionStateAfterCommit() {
@@ -17407,12 +17495,17 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private fun scheduleDefaultInputFinalize(string: String) {
         val timeToDelay = delayTime?.toLong() ?: DEFAULT_DELAY_MS
+        val mutationRevision = editorMutationRevision.current()
         defaultInputFinalizeJob = scope.launch {
             measureDebugStage("IMEService.input.finalizeDelay") {
                 delay(timeToDelay)
             }
 
-            if (inputString.value != string || isLiveConversionEnable == true) {
+            if (
+                inputString.value != string ||
+                !editorMutationRevision.isCurrent(mutationRevision) ||
+                isLiveConversionEnable == true
+            ) {
                 return@launch
             }
 
@@ -18768,6 +18861,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 input = input,
                                 mode = mode,
                                 backend = conversionBackend,
+                                editorMutationRevision = editorMutationRevision.current(),
                             )
                             ioScope.launch {
                                 setCandidatesForMode(input, mainView, mode, token)
@@ -22386,6 +22480,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             composingPipeline = {}
         )
         if (handled) {
+            editorMutationRevision.advance()
             clearDirectCommitCompositionState("direct commit backspace")
         }
         return handled
@@ -22987,6 +23082,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             input = inputString,
             mode = mode,
             backend = conversionBackend,
+            editorMutationRevision = editorMutationRevision.current(),
         )
         setCandidatesForMode(inputString, mainView, mode, token)
         Timber.d("setSuggestionOnView auto: $inputString $stringInTail $tabPosition $bunsetsuPositionList ${isHenkan.get()} $henkanPressedWithBunsetsuDetect $bunsetusMultipleDetect")
@@ -26667,14 +26763,18 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
         cancelCandidateTranslationIfPreEditMutates()
-        return currentInputConnection.deleteSurroundingText(p0, p1)
+        val deleted = currentInputConnection.deleteSurroundingText(p0, p1)
+        if (deleted) editorMutationRevision.advance()
+        return deleted
     }
 
     override fun deleteSurroundingTextInCodePoints(p0: Int, p1: Int): Boolean {
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
         cancelCandidateTranslationIfPreEditMutates()
-        return currentInputConnection.deleteSurroundingTextInCodePoints(p0, p1)
+        val deleted = currentInputConnection.deleteSurroundingTextInCodePoints(p0, p1)
+        if (deleted) editorMutationRevision.advance()
+        return deleted
     }
 
     override fun setComposingText(p0: CharSequence?, p1: Int): Boolean {
@@ -26703,26 +26803,35 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         clearFunctionKeyConversionSource()
         cancelCandidateTranslationIfPreEditMutates()
         val committed = currentInputConnection.commitText(p0, p1)
-        if (committed) composingTextArbiter.markCanonicalFinished()
+        if (committed) {
+            editorMutationRevision.advance()
+            composingTextArbiter.markCanonicalFinished()
+        }
         return committed
     }
 
     override fun commitCompletion(p0: CompletionInfo?): Boolean {
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
-        return currentInputConnection.commitCompletion(p0)
+        val committed = currentInputConnection.commitCompletion(p0)
+        if (committed) editorMutationRevision.advance()
+        return committed
     }
 
     override fun commitCorrection(p0: CorrectionInfo?): Boolean {
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
-        return currentInputConnection.commitCorrection(p0)
+        val committed = currentInputConnection.commitCorrection(p0)
+        if (committed) editorMutationRevision.advance()
+        return committed
     }
 
     override fun setSelection(p0: Int, p1: Int): Boolean {
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
-        return currentInputConnection.setSelection(p0, p1)
+        val changed = currentInputConnection.setSelection(p0, p1)
+        if (changed) editorMutationRevision.advance()
+        return changed
     }
 
     override fun performEditorAction(p0: Int): Boolean {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImeGlassRenderPolicy.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImeGlassRenderPolicy.kt
@@ -1,0 +1,62 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+/**
+ * Rendering modes for the normal IME surface.
+ *
+ * The system blur is deliberately limited to the Android releases where this IME's
+ * translucent-window path is known to be stable.  The opaque fallback keeps the glass-like
+ * key surfaces while ensuring that an editor frame can never be sampled through the IME root.
+ */
+internal enum class ImeGlassRenderMode {
+    SYSTEM_BLUR,
+    OPAQUE_BACKDROP,
+    NO_BLUR,
+}
+
+internal data class ImeGlassRenderDecision(
+    val mode: ImeGlassRenderMode,
+    val windowBlurRadius: Int,
+)
+
+internal object ImeGlassRenderPolicy {
+    const val SYSTEM_BLUR_MIN_API = 31
+    const val SYSTEM_BLUR_MAX_API = 36
+    const val SYSTEM_BLUR_RADIUS = 50
+
+    fun resolve(
+        sdkInt: Int,
+        glassEnabled: Boolean,
+        floatingMode: Boolean,
+        physicalKeyboardEnabled: Boolean,
+        hardwareKeyboardConnected: Boolean,
+        crossWindowBlurEnabled: Boolean,
+    ): ImeGlassRenderDecision {
+        if (
+            !glassEnabled ||
+            floatingMode ||
+            physicalKeyboardEnabled ||
+            hardwareKeyboardConnected
+        ) {
+            return ImeGlassRenderDecision(
+                mode = ImeGlassRenderMode.NO_BLUR,
+                windowBlurRadius = 0,
+            )
+        }
+
+        val canUseSystemBlur =
+            sdkInt in SYSTEM_BLUR_MIN_API..SYSTEM_BLUR_MAX_API &&
+                crossWindowBlurEnabled
+
+        return if (canUseSystemBlur) {
+            ImeGlassRenderDecision(
+                mode = ImeGlassRenderMode.SYSTEM_BLUR,
+                windowBlurRadius = SYSTEM_BLUR_RADIUS,
+            )
+        } else {
+            ImeGlassRenderDecision(
+                mode = ImeGlassRenderMode.OPAQUE_BACKDROP,
+                windowBlurRadius = 0,
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/candidate/CandidateQueryPolicy.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/candidate/CandidateQueryPolicy.kt
@@ -26,6 +26,7 @@ data class CandidateRequestToken internal constructor(
     val input: String,
     val mode: CandidateQueryMode,
     val backend: ConversionBackend,
+    val editorMutationRevision: Long = 0L,
 )
 
 /** Rejects an older result even when it was produced for the same input string in another tab. */
@@ -35,7 +36,7 @@ class CandidateRequestTracker {
     private var current: CandidateRequestToken? = null
 
     @Synchronized
-    fun restart(backend: ConversionBackend) {
+    fun restart(backend: ConversionBackend, editorMutationRevision: Long = 0L) {
         sessionId += 1
         revision = 0
         current = CandidateRequestToken(
@@ -44,6 +45,7 @@ class CandidateRequestTracker {
             input = "",
             mode = CandidateQueryMode.NO_TAB_DEFAULT,
             backend = backend,
+            editorMutationRevision = editorMutationRevision,
         )
     }
 
@@ -52,6 +54,7 @@ class CandidateRequestTracker {
         input: String,
         mode: CandidateQueryMode,
         backend: ConversionBackend,
+        editorMutationRevision: Long = 0L,
     ): CandidateRequestToken {
         revision += 1
         return CandidateRequestToken(
@@ -60,6 +63,7 @@ class CandidateRequestTracker {
             input = input,
             mode = mode,
             backend = backend,
+            editorMutationRevision = editorMutationRevision,
         ).also { current = it }
     }
 

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/EditorMutationRevisionTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/EditorMutationRevisionTest.kt
@@ -1,0 +1,34 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class EditorMutationRevisionTest {
+
+    @Test
+    fun advanceInvalidatesEarlierAsyncWork() {
+        val revision = EditorMutationRevision()
+        val beforeDelete = revision.current()
+
+        revision.advance()
+
+        assertFalse(revision.isCurrent(beforeDelete))
+        assertTrue(revision.isCurrent(revision.current()))
+    }
+
+    @Test
+    fun retypingTheSameTextStillGetsANewRevision() {
+        val revision = EditorMutationRevision()
+        val firstInput = revision.current()
+
+        revision.advance()
+        val afterDelete = revision.current()
+        revision.advance()
+
+        assertNotEquals(firstInput, afterDelete)
+        assertNotEquals(afterDelete, revision.current())
+        assertFalse(revision.isCurrent(firstInput))
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImeGlassRenderPolicyTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/ImeGlassRenderPolicyTest.kt
@@ -1,0 +1,77 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ImeGlassRenderPolicyTest {
+
+    @Test
+    fun supportedBlurWindowUsesSystemBlur() {
+        val decision = resolve(sdkInt = 36, blurEnabled = true)
+
+        assertEquals(ImeGlassRenderMode.SYSTEM_BLUR, decision.mode)
+        assertEquals(ImeGlassRenderPolicy.SYSTEM_BLUR_RADIUS, decision.windowBlurRadius)
+    }
+
+    @Test
+    fun android17UsesOpaqueBackdrop() {
+        val decision = resolve(sdkInt = 37, blurEnabled = true)
+
+        assertEquals(ImeGlassRenderMode.OPAQUE_BACKDROP, decision.mode)
+        assertEquals(0, decision.windowBlurRadius)
+    }
+
+    @Test
+    fun unavailableBlurUsesOpaqueBackdrop() {
+        val decision = resolve(sdkInt = 36, blurEnabled = false)
+
+        assertEquals(ImeGlassRenderMode.OPAQUE_BACKDROP, decision.mode)
+        assertEquals(0, decision.windowBlurRadius)
+    }
+
+    @Test
+    fun unsupportedOrNonNormalModesNeverUseTransparentSystemBlur() {
+        assertEquals(
+            ImeGlassRenderMode.OPAQUE_BACKDROP,
+            resolve(sdkInt = 30, blurEnabled = true).mode,
+        )
+        assertEquals(
+            ImeGlassRenderMode.NO_BLUR,
+            resolve(sdkInt = 36, blurEnabled = true, floatingMode = true).mode,
+        )
+        assertEquals(
+            ImeGlassRenderMode.NO_BLUR,
+            resolve(sdkInt = 36, blurEnabled = true, physicalKeyboardEnabled = true).mode,
+        )
+        assertEquals(
+            ImeGlassRenderMode.NO_BLUR,
+            resolve(sdkInt = 36, blurEnabled = true, hardwareKeyboardConnected = true).mode,
+        )
+    }
+
+    @Test
+    fun disabledGlassUsesNoBlur() {
+        val decision = resolve(sdkInt = 36, blurEnabled = true, glassEnabled = false)
+
+        assertEquals(ImeGlassRenderMode.NO_BLUR, decision.mode)
+        assertEquals(0, decision.windowBlurRadius)
+    }
+
+    private fun resolve(
+        sdkInt: Int,
+        blurEnabled: Boolean,
+        glassEnabled: Boolean = true,
+        floatingMode: Boolean = false,
+        physicalKeyboardEnabled: Boolean = false,
+        hardwareKeyboardConnected: Boolean = false,
+    ): ImeGlassRenderDecision {
+        return ImeGlassRenderPolicy.resolve(
+            sdkInt = sdkInt,
+            glassEnabled = glassEnabled,
+            floatingMode = floatingMode,
+            physicalKeyboardEnabled = physicalKeyboardEnabled,
+            hardwareKeyboardConnected = hardwareKeyboardConnected,
+            crossWindowBlurEnabled = blurEnabled,
+        )
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/candidate/CandidateQueryPolicyTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/candidate/CandidateQueryPolicyTest.kt
@@ -92,4 +92,30 @@ class CandidateQueryPolicyTest {
 
         assertFalse(tracker.isCurrent(old))
     }
+
+    @Test
+    fun sameInputFromAnEarlierEditorMutationIsRejected() {
+        val tracker = CandidateRequestTracker()
+        tracker.restart(
+            backend = ConversionBackend.LEGACY,
+            editorMutationRevision = 4L,
+        )
+        val beforeDelete = tracker.begin(
+            input = "test",
+            mode = CandidateQueryMode.NO_TAB_DEFAULT,
+            backend = ConversionBackend.LEGACY,
+            editorMutationRevision = 4L,
+        )
+        val afterDeleteAndRetype = tracker.begin(
+            input = "test",
+            mode = CandidateQueryMode.NO_TAB_DEFAULT,
+            backend = ConversionBackend.LEGACY,
+            editorMutationRevision = 6L,
+        )
+
+        assertFalse(tracker.isCurrent(beforeDelete))
+        assertTrue(tracker.isCurrent(afterDeleteAndRetype))
+        assertEquals(4L, beforeDelete.editorMutationRevision)
+        assertEquals(6L, afterDeleteAndRetype.editorMutationRevision)
+    }
 }


### PR DESCRIPTION
## 日本語

### 概要

[#979](https://github.com/KazumaProject/JapaneseKeyboard/issues/979) の、Liquid Glass を有効にした状態で文字を削除すると入力欄がちらつく問題を修正します。

### 原因

- Liquid Glass は IME のルートを半透明にし、Window の背景ぼかしで背後のエディタを再合成していました。
- クロスウィンドウぼかしの利用可否を確認していなかったため、Android 17 などで削除中に古いエディタフレームが一時的に表示される余地がありました。
- 候補取得や遅延確定処理が入力文字列だけで判定しており、削除後に同じ文字列を再入力した場合、古い非同期結果を適用できました。

### 修正内容

- クロスウィンドウぼかしが利用できる対応環境だけでシステムぼかしを使用する描画ポリシーを追加しました。
- Android 17 以降、またはぼかしが利用できない環境では不透明な背景へフォールバックし、背後のエディタフレームをサンプリングしないようにしました。キー表面の Liquid Glass 表現は維持します。
- WindowManager のぼかし状態変更を監視し、IME ウィンドウの描画を更新するようにしました。
- 編集世代を候補リクエストと遅延確定処理に伝播し、削除・確定・選択変更後の古い非同期結果を破棄するようにしました。
- Liquid Glass 有効時の TenKey/QWERTY 連続削除に対する実機回帰テストを追加しました。

### 検証

- :app:testFullStandardDebugUnitTest 成功
- Pixel 6 / Android 17 実機で Liquid Glass の連続削除回帰テスト成功
- :app:lintFullStandardDebug 成功
- git diff --check 成功

## English

### Summary

Fixes the input-field flicker that occurs while deleting text with Liquid Glass enabled, reported in [#979](https://github.com/KazumaProject/JapaneseKeyboard/issues/979).

### Root cause

- Liquid Glass made the IME root translucent and used Window background blur to re-composite the editor behind it.
- The implementation did not check whether cross-window blur was available, leaving Android 17 and other unsupported or unavailable paths able to show a transient older editor frame during deletion.
- Candidate queries and delayed finalization were validated by input text alone, so stale asynchronous work could be applied after deleting and re-entering the same text.

### Changes

- Added a rendering policy that enables system blur only when cross-window blur is supported and currently enabled.
- Added an opaque-backdrop fallback on Android 17+ and whenever cross-window blur is unavailable, preventing the IME from sampling the editor frame behind it while preserving the glass-like key surfaces.
- Observed WindowManager cross-window blur state changes and updated the IME window dynamically.
- Added editor mutation revisions to candidate requests and delayed finalization so stale asynchronous results are discarded after deletion, commits, or selection changes.
- Added a physical-device regression test covering repeated deletion with Liquid Glass enabled on both TenKey and QWERTY layouts.

### Validation

- :app:testFullStandardDebugUnitTest passed
- Liquid Glass repeated-delete regression test passed on a Pixel 6 running Android 17
- :app:lintFullStandardDebug passed
- git diff --check passed

Closes #979