### PR TITLE
物理キーボードの変換範囲変更時に範囲外文字列を保持 / Preserve out-of-range text when narrowing physical-keyboard conversion

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/PhysicalCandidateCompositionInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/PhysicalCandidateCompositionInstrumentedTest.kt
@@ -1,0 +1,280 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.ComponentName
+import android.view.accessibility.AccessibilityNodeInfo
+import android.os.ParcelFileDescriptor
+import android.os.SystemClock
+import android.view.InputDevice
+import android.view.KeyEvent
+import android.view.inputmethod.BaseInputConnection
+import android.text.style.BackgroundColorSpan
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.BeforeClass
+import org.junit.AfterClass
+import org.junit.runner.RunWith
+
+/** Sends real hardware-device KeyEvents through the selected IME to a standard EditText. */
+@RunWith(AndroidJUnit4::class)
+class PhysicalCandidateCompositionInstrumentedTest {
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val automation get() = instrumentation.uiAutomation
+    private lateinit var host: ActivityScenario<FastInputHostActivity>
+    private var keyboardId = 0
+
+    @Test fun cursorTailSurvivesPreviewCancelAndCommit() = withKeyboard {
+        type("ashitaha")
+        awaitText("あしたは")
+        key(KeyEvent.KEYCODE_DPAD_LEFT)
+        key(KeyEvent.KEYCODE_SPACE)
+        await { selectedPrefixWithTail("は") }
+        assertTrue(text().endsWith("は"))
+        key(KeyEvent.KEYCODE_ESCAPE)
+        awaitText("あしたは")
+        key(KeyEvent.KEYCODE_DPAD_LEFT)
+        key(KeyEvent.KEYCODE_SPACE)
+        await { selectedPrefixWithTail("は") }
+        val preview = text()
+        key(KeyEvent.KEYCODE_ENTER)
+        // Remaining reading may be automatically converted, but must not disappear.
+        await { text().length >= preview.length && text().startsWith(preview.dropLast(1)) }
+    }
+
+    @Test fun typingAfterPartialCandidateCommitsTailBeforeNewRomaji() = withKeyboard {
+        selectPartialCandidate()
+        val preview = text()
+        type("a")
+        awaitText(preview + "あ")
+        host.onActivity {
+            assertEquals(preview.length, BaseInputConnection.getComposingSpanStart(it.editText.text))
+        }
+    }
+
+    @Test fun typingAfterPartialCandidateCommitsTailBeforeNewKana() = withKeyboard(kana = true) {
+        // JIS: 3=あ, D=し, Q=た, F=は. Move は outside the conversion query.
+        listOf(KeyEvent.KEYCODE_3, KeyEvent.KEYCODE_D, KeyEvent.KEYCODE_Q, KeyEvent.KEYCODE_F).forEach { key(it) }
+        awaitText("あしたは")
+        key(KeyEvent.KEYCODE_DPAD_LEFT)
+        key(KeyEvent.KEYCODE_SPACE)
+        await { selectedPrefixWithTail("は") }
+        val preview = text()
+        key(KeyEvent.KEYCODE_3)
+        awaitText(preview + "あ")
+    }
+
+    @Test fun narrowedCandidateCanBeCancelledWithoutLosingSource() = withKeyboard {
+        selectPartialCandidate()
+        key(KeyEvent.KEYCODE_ESCAPE)
+        awaitText("あしたはれるといいですねはれた")
+        key(KeyEvent.KEYCODE_DEL)
+        awaitText("あしたはれるといいですねはれ")
+    }
+
+    @Test fun bunsetsuWidthChangesPreserveReadingOnCancel() = withKeyboard(bunsetsu = true) {
+        type("ashitaharerutoiidesunehareta")
+        awaitText("あしたはれるといいですねはれた")
+        key(KeyEvent.KEYCODE_SPACE)
+        SystemClock.sleep(800)
+        key(KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.META_SHIFT_ON)
+        key(KeyEvent.KEYCODE_DPAD_RIGHT, KeyEvent.META_SHIFT_ON)
+        key(KeyEvent.KEYCODE_ESCAPE)
+        awaitText("あしたはれるといいですねはれた")
+    }
+
+    @Test fun clickingPartialCandidateKeepsRemainderForNextCommit() = withKeyboard {
+        selectPartialCandidate()
+        val preview = text()
+        var selected = ""
+        host.onActivity { activity ->
+            val value = activity.editText.text
+            val span = value.getSpans(0, value.length, BackgroundColorSpan::class.java)
+                .first { value.getSpanStart(it) == 0 && value.getSpanEnd(it) in 1 until value.length }
+            selected = value.substring(0, value.getSpanEnd(span))
+        }
+        val node = automation.windows.asSequence().mapNotNull { it.root }
+            .flatMap { it.findAccessibilityNodeInfosByText(selected).asSequence() }
+            .first { it.text?.toString() == selected }
+        var clickable: AccessibilityNodeInfo? = node
+        while (clickable != null && !clickable.isClickable) clickable = clickable.parent
+        assertTrue(clickable?.performAction(AccessibilityNodeInfo.ACTION_CLICK) == true)
+        SystemClock.sleep(500)
+        key(KeyEvent.KEYCODE_ESCAPE)
+        awaitText(preview)
+        key(KeyEvent.KEYCODE_ENTER)
+        awaitText(preview)
+        host.onActivity { assertEquals(-1, BaseInputConnection.getComposingSpanStart(it.editText.text)) }
+    }
+
+    @Test fun editorRestartDoesNotRevivePendingRemainder() = withKeyboard {
+        selectPartialCandidate()
+        key(KeyEvent.KEYCODE_ENTER)
+        host.onActivity { it.restartEditorInput(true) }
+        SystemClock.sleep(500)
+        type("a")
+        awaitText("あ")
+        SystemClock.sleep(500)
+        assertEquals("あ", text())
+    }
+
+    @Test fun typingImmediatelyAfterPartialEnterDoesNotDropKeyOrReading() = withKeyboard {
+        selectPartialCandidate()
+        val preview = text()
+        key(KeyEvent.KEYCODE_ENTER, settleMillis = 0)
+        key(KeyEvent.KEYCODE_A)
+        awaitText(preview + "あ")
+    }
+
+    private fun selectPartialCandidate() {
+        type("ashitaharerutoiidesunehareta")
+        awaitText("あしたはれるといいですねはれた")
+        key(KeyEvent.KEYCODE_SPACE)
+        repeat(100) {
+            if (selectedPrefixWithTail("はれた")) return
+            key(KeyEvent.KEYCODE_DPAD_DOWN)
+        }
+        fail("No partial candidate found: ${text()}")
+    }
+
+    private fun selectedPrefixWithTail(tail: String): Boolean {
+        var selected = false
+        host.onActivity { activity ->
+            val text = activity.editText.text
+            selected = text.toString().endsWith(tail) &&
+                text.getSpans(0, text.length, BackgroundColorSpan::class.java).any {
+                    text.getSpanStart(it) == 0 && text.getSpanEnd(it) in 1 until text.length
+                }
+        }
+        return selected
+    }
+
+    private fun type(romaji: String) = romaji.forEach { key(KeyEvent.KEYCODE_A + (it - 'a')) }
+
+    private fun key(code: Int, meta: Int = 0, settleMillis: Long = 160) {
+        val time = SystemClock.uptimeMillis()
+        fun inject(keyCode: Int, action: Int, metaState: Int) {
+            assertTrue(automation.injectInputEvent(KeyEvent(
+                time, SystemClock.uptimeMillis(), action, keyCode, 0, metaState, keyboardId,
+                0, 0, InputDevice.SOURCE_KEYBOARD
+            ), true))
+        }
+        val shifted = meta and KeyEvent.META_SHIFT_ON != 0
+        if (shifted) inject(KeyEvent.KEYCODE_SHIFT_LEFT, KeyEvent.ACTION_DOWN, meta)
+        inject(code, KeyEvent.ACTION_DOWN, meta)
+        inject(code, KeyEvent.ACTION_UP, meta)
+        if (shifted) inject(KeyEvent.KEYCODE_SHIFT_LEFT, KeyEvent.ACTION_UP, 0)
+        SystemClock.sleep(settleMillis)
+    }
+
+    private fun text(): String {
+        var value = ""
+        host.onActivity { value = it.editText.text.toString() }
+        return value
+    }
+
+    private fun awaitText(expected: String) = await { text() == expected }
+
+    private fun await(condition: () -> Boolean) {
+        val end = SystemClock.uptimeMillis() + 10000
+        while (SystemClock.uptimeMillis() < end) {
+            if (condition()) return
+            SystemClock.sleep(50)
+        }
+        fail("Timed out; editor=[${text()}]")
+    }
+
+    companion object {
+        private lateinit var originalIme: String
+        private lateinit var targetIme: String
+        private lateinit var originalShowWithHardware: String
+        private var wasEnabled = false
+
+        private fun shell(command: String): String = ParcelFileDescriptor.AutoCloseInputStream(
+            InstrumentationRegistry.getInstrumentation().uiAutomation.executeShellCommand(command)
+        ).bufferedReader().use { it.readText().trim() }
+
+        private fun sameIme(first: String, second: String): Boolean =
+            ComponentName.unflattenFromString(first) == ComponentName.unflattenFromString(second)
+
+        @JvmStatic @BeforeClass fun selectIme() {
+            val context = InstrumentationRegistry.getInstrumentation().targetContext
+            targetIme = "${context.packageName}/com.kazumaproject.markdownhelperkeyboard.ime_service.IMEService"
+            originalIme = shell("settings get secure default_input_method")
+            originalShowWithHardware = shell("settings get secure show_ime_with_hard_keyboard")
+            wasEnabled = shell("ime list -s").lines().any { sameIme(it, targetIme) }
+            shell("settings put secure show_ime_with_hard_keyboard 1")
+            shell("ime enable $targetIme")
+            shell("ime set $targetIme")
+        }
+
+        @JvmStatic @AfterClass fun restoreIme() {
+            if (originalIme.isNotEmpty() && originalIme != "null") shell("ime set $originalIme")
+            if (!wasEnabled && !sameIme(originalIme, targetIme)) shell("ime disable $targetIme")
+            if (originalShowWithHardware == "null") {
+                shell("settings delete secure show_ime_with_hard_keyboard")
+            } else {
+                shell("settings put secure show_ime_with_hard_keyboard $originalShowWithHardware")
+            }
+        }
+    }
+
+    private fun withKeyboard(kana: Boolean = false, bunsetsu: Boolean = false, block: () -> Unit) {
+        keyboardId = InputDevice.getDeviceIds().toList().mapNotNull(InputDevice::getDevice)
+            .firstOrNull { !it.isVirtual && it.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC }
+            ?.id ?: error("A physical or emulator hardware keyboard is required")
+        automation.serviceInfo = automation.serviceInfo.apply {
+            flags = flags or AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS
+        }
+        val context = instrumentation.targetContext
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        val values = mapOf<String, Any>(
+            "conversion_bunsetsu_separation_preference" to true,
+            "conversion_bunsetsu_cursor_move_preference" to bunsetsu,
+            "physical_keyboard_input_mode_preference" to if (kana) "kana" else "romaji",
+            "live_conversion_preference" to false,
+            "sumire_keymap_guide_japanese" to false,
+            "sumire_keymap_guide_modes_migrated" to true,
+        )
+        val previous = values.keys.associateWith { prefs.all[it] }
+        try {
+            prefs.edit().apply {
+                values.forEach { (key, value) ->
+                    when (value) { is Boolean -> putBoolean(key, value); is String -> putString(key, value) }
+                }
+            }.commit()
+            host = ActivityScenario.launch(FastInputHostActivity::class.java)
+            host.onActivity { it.restartEditorInput(true) }
+            // Cold dictionary/romaji initialization may outlive Activity creation.
+            // Prove that a key reaches Japanese composition before testing conversion.
+            val readyBy = SystemClock.uptimeMillis() + 30000
+            var ready = false
+            var observed = ""
+            while (!ready && SystemClock.uptimeMillis() < readyBy) {
+                SystemClock.sleep(500)
+                key(KeyEvent.KEYCODE_KANA)
+                key(if (kana) KeyEvent.KEYCODE_3 else KeyEvent.KEYCODE_A)
+                observed = text()
+                ready = observed == "あ"
+                host.onActivity { it.restartEditorInput(true) }
+            }
+            assertTrue("Japanese hardware input did not initialize: [$observed]", ready)
+            SystemClock.sleep(500)
+            block()
+        } finally {
+            if (::host.isInitialized) host.close()
+            prefs.edit().apply {
+                previous.forEach { (key, value) ->
+                    when (value) {
+                        is Boolean -> putBoolean(key, value)
+                        is String -> putString(key, value)
+                        null -> remove(key)
+                    }
+                }
+            }.commit()
+        }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -106,6 +106,7 @@ import com.kazumaproject.android.flexbox.FlexboxLayoutManager
 import com.kazumaproject.android.flexbox.JustifyContent
 import com.kazumaproject.core.data.clicked_symbol.SymbolMode
 import com.kazumaproject.core.data.clipboard.ClipboardItem
+import com.kazumaproject.core.data.floating_candidate.CandidateInputRange
 import com.kazumaproject.core.data.floating_candidate.CandidateItem
 import com.kazumaproject.core.data.popup.FlickPopupViewStyleSet
 import com.kazumaproject.core.data.popup.PopupViewStyle
@@ -139,6 +140,8 @@ import com.kazumaproject.core.domain.listener.KeyTouchCancelReason
 import com.kazumaproject.core.domain.listener.LongPressListener
 import com.kazumaproject.core.domain.listener.QWERTYKeyListener
 import com.kazumaproject.core.domain.listener.QwertyKeyTouchCancelListener
+import com.kazumaproject.core.domain.physical_keyboard.FloatingCandidateComposition
+import com.kazumaproject.core.domain.physical_keyboard.FloatingCandidateCompositionResolver
 import com.kazumaproject.core.domain.physical_keyboard.FloatingCandidateTailResolver
 import com.kazumaproject.core.domain.physical_keyboard.KanaDakutenComposer
 import com.kazumaproject.core.domain.physical_keyboard.PhysicalKanaMapper
@@ -455,6 +458,19 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         val focusedIndex: Int = 0,
         val splitPatterns: List<List<Int>> = emptyList(),
         val activeSplitPatternIndex: Int = 0
+    )
+
+    /**
+     * The immutable source and the currently queried prefix for physical-keyboard conversion.
+     *
+     * CandidateItem.length is a range in the source reading, not a length of the displayed
+     * candidate. Keeping both values prevents a shorter preview from becoming the next source
+     * for InputConnection.setComposingText().
+     */
+    private data class PhysicalCandidateCompositionSession(
+        val sourceText: String,
+        val queryText: String,
+        val generation: Long,
     )
 
     private sealed class BunsetsuDisplayedSelection {
@@ -1513,6 +1529,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private val _inputString = MutableStateFlow("")
     private val inputString = _inputString.asStateFlow()
     private var stringInTail = AtomicReference("")
+    private var physicalCandidateCompositionSession: PhysicalCandidateCompositionSession? = null
+    private var physicalCandidateCompositionGeneration: Long = 0L
     private var functionKeyConversionSource: String? = null
     private var suppressedSelectionCleanupCount = 0
     private var preservePreEditOnNextSelectionUpdate: String? = null
@@ -2373,6 +2391,33 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 suggestion.sourceId?.let(::executeTextMacro)
                 return@suggestionClick
             }
+
+            if (isPhysicalFloatingCandidatePathActive()) {
+                val composition = resolvePhysicalCandidateComposition(
+                    suggestion = suggestion,
+                    insertString = inputString.value,
+                    reason = "click"
+                ) ?: return@suggestionClick
+                val committedText = commitPhysicalCandidateComposition(composition)
+
+                updateSuggestionsForFloatingCandidate(emptyList())
+                listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
+                currentHighlightIndex = RecyclerView.NO_POSITION
+                if (composition.tail.isNotEmpty()) {
+                    beginPhysicalCandidateCompositionSession(composition.tail)
+                    scope.launch {
+                        delay(64)
+                        floatingCandidateNextItem(insertString = composition.tail)
+                    }
+                } else {
+                    if (committedText.isNotBlank()) {
+                        rememberZeroQueryKeyAfterCommit(committedText)
+                    }
+                    consumePendingZeroQueryAfterCommit()
+                }
+                return@suggestionClick
+            }
+
             val tail = FloatingCandidateTailResolver.resolveTail(
                 originalInput = inputString.value,
                 selectedCandidateLength = suggestion.length.toInt()
@@ -5027,6 +5072,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             inlineAutofillController?.clear()
         }
+        clearPhysicalCandidateCompositionSession("finish input")
         super.onFinishInput()
     }
 
@@ -5034,6 +5080,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             inlineAutofillController?.clear()
         }
+        clearPhysicalCandidateCompositionSession("finish input view")
         flickInputPreviewCoordinator.cancel(restore = false)
         gemmaMediaPanelController?.onInputViewHidden()
         gemmaHandwritingController?.onInputViewHidden()
@@ -5102,6 +5149,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
         pendingGemmaPickedImagePath = null
         clearZeroQueryAllState(refresh = false)
+        clearPhysicalCandidateCompositionSession("destroy")
         stopAllOngoingKeyLongPresses()
         disableKeyboardLayoutEditMode(updateSurface = false)
         collapseShortcutEntryExpansion()
@@ -6862,6 +6910,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun cancelFloatingCandidateConversion(insertString: String) {
+        clearPhysicalCandidateCompositionSession("conversion cancelled")
         preservePreEditOnNextSelectionUpdate = insertString
         isHenkan.set(false)
         henkanPressedWithBunsetsuDetect = false
@@ -6911,6 +6960,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     isHenkan.set(true)
                     Timber.d("KEYCODE_SPACE is pressed: $normalizedInsertString $stringInTail")
+                    beginPhysicalCandidateCompositionSession(normalizedInsertString)
                     _inputString.update { normalizedInsertString }
 
                     if (shouldUseBunsetsuCursorMoveSession()) {
@@ -7393,11 +7443,247 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
     }
 
+    private fun isPhysicalFloatingCandidatePathActive(): Boolean {
+        return physicalKeyboardEnable.replayCache.firstOrNull() == true &&
+                !isBunsetsuCursorMoveSessionActive()
+    }
+
+    private fun clearPhysicalCandidateCompositionSession(reason: String) {
+        physicalCandidateCompositionSession?.let {
+            Timber.d(
+                "clearPhysicalCandidateCompositionSession: generation=%d reason=%s",
+                it.generation,
+                reason
+            )
+        }
+        physicalCandidateCompositionSession = null
+    }
+
+    private fun beginPhysicalCandidateCompositionSession(input: String) {
+        if (!isPhysicalFloatingCandidatePathActive() || input.isEmpty()) return
+
+        val current = physicalCandidateCompositionSession
+        val session = when {
+            current == null -> {
+                PhysicalCandidateCompositionSession(
+                    sourceText = input,
+                    queryText = input,
+                    generation = ++physicalCandidateCompositionGeneration,
+                )
+            }
+
+            current.sourceText == input -> current.copy(queryText = input)
+
+            current.sourceText.startsWith(input) && current.queryText.startsWith(input) ->
+                current.copy(queryText = input)
+
+            else -> {
+                PhysicalCandidateCompositionSession(
+                    sourceText = input,
+                    queryText = input,
+                    generation = ++physicalCandidateCompositionGeneration,
+                )
+            }
+        }
+        physicalCandidateCompositionSession = session
+        Timber.d(
+            "beginPhysicalCandidateCompositionSession: generation=%d sourceLength=%d queryLength=%d",
+            session.generation,
+            session.sourceText.length,
+            session.queryText.length
+        )
+    }
+
+    private fun ensurePhysicalCandidateCompositionSession(
+        insertString: String
+    ): PhysicalCandidateCompositionSession? {
+        if (!isPhysicalFloatingCandidatePathActive() || insertString.isEmpty()) return null
+
+        val current = physicalCandidateCompositionSession
+        val currentTail = stringInTail.get()
+        val sourceText = when {
+            current != null &&
+                    current.sourceText.startsWith(insertString) &&
+                    current.queryText.startsWith(insertString) -> current.sourceText
+
+            currentTail.isNotEmpty() && !insertString.endsWith(currentTail) ->
+                insertString + currentTail
+
+            else -> insertString
+        }
+        val session = if (
+            current != null &&
+            current.sourceText == sourceText &&
+            sourceText.startsWith(insertString)
+        ) {
+            current.copy(queryText = insertString)
+        } else {
+            PhysicalCandidateCompositionSession(
+                sourceText = sourceText,
+                queryText = insertString,
+                generation = ++physicalCandidateCompositionGeneration,
+            )
+        }
+        physicalCandidateCompositionSession = session
+        return session
+    }
+
+    private fun resolvePhysicalCandidateComposition(
+        suggestion: CandidateItem,
+        insertString: String,
+        reason: String,
+    ): FloatingCandidateComposition? {
+        val session = ensurePhysicalCandidateCompositionSession(insertString) ?: return null
+        val candidateLength = suggestion.length.toInt()
+        if (
+            candidateLength < 0 ||
+            candidateLength > session.queryText.length ||
+            !session.sourceText.startsWith(session.queryText)
+        ) {
+            Timber.e(
+                "Invalid physical candidate range: reason=%s generation=%d candidateLength=%d " +
+                        "sourceLength=%d queryLength=%d",
+                reason,
+                session.generation,
+                candidateLength,
+                session.sourceText.length,
+                session.queryText.length
+            )
+            return null
+        }
+
+        val composition = FloatingCandidateCompositionResolver.resolve(
+            originalInput = session.sourceText,
+            replacementText = suggestion.formulaFallbackText ?: suggestion.word,
+            inputRange = CandidateInputRange(start = 0, endExclusive = candidateLength),
+        ) ?: run {
+            Timber.e(
+                "Could not resolve physical candidate composition: reason=%s generation=%d",
+                reason,
+                session.generation
+            )
+            return null
+        }
+        stringInTail.set(composition.tail)
+        Timber.d(
+            "resolvePhysicalCandidateComposition: reason=%s generation=%d candidateLength=%d " +
+                    "sourceLength=%d queryLength=%d replacementLength=%d tailLength=%d",
+            reason,
+            session.generation,
+            candidateLength,
+            session.sourceText.length,
+            session.queryText.length,
+            (suggestion.formulaFallbackText ?: suggestion.word).length,
+            composition.tail.length
+        )
+        return composition
+    }
+
+    private fun setPhysicalCandidateComposingText(
+        composition: FloatingCandidateComposition,
+    ) {
+        val spannableString = SpannableString(composition.text)
+        val spanFlag = Spannable.SPAN_EXCLUSIVE_EXCLUSIVE or Spannable.SPAN_COMPOSING
+        val selectedStart = composition.selectedTextStart.coerceIn(0, spannableString.length)
+        val selectedEnd = composition.selectedTextEndExclusive.coerceIn(
+            selectedStart,
+            spannableString.length
+        )
+        if (selectedStart < selectedEnd) {
+            spannableString.setSpan(
+                BackgroundColorSpan(
+                    if (customComposingTextPreference == true) {
+                        inputCompositionAfterBackgroundColor ?: getColor(
+                            com.kazumaproject.core.R.color.blue
+                        )
+                    } else {
+                        getColor(com.kazumaproject.core.R.color.blue)
+                    }
+                ),
+                selectedStart,
+                selectedEnd,
+                spanFlag
+            )
+            if (customComposingTextPreference == true) {
+                inputCompositionTextColor?.let { color ->
+                    spannableString.setSpan(
+                        ForegroundColorSpan(color),
+                        selectedStart,
+                        selectedEnd,
+                        spanFlag
+                    )
+                }
+            }
+        }
+        if (spannableString.isNotEmpty()) {
+            spannableString.setSpan(
+                UnderlineSpan(),
+                0,
+                spannableString.length,
+                spanFlag
+            )
+        }
+        setComposingText(spannableString, 1)
+    }
+
+    private fun commitPhysicalCandidateComposition(
+        composition: FloatingCandidateComposition,
+    ): String {
+        val committedText = composition.text.substring(0, composition.selectedTextEndExclusive)
+        val tail = composition.tail
+        beginBatchEdit()
+        try {
+            // setComposingText() replaces the entire active composing region. End that region
+            // before committing only the selected prefix, then explicitly recompose the tail.
+            setComposingText("", 0)
+            finishComposingText()
+            if (committedText.isNotEmpty()) {
+                commitText(committedText, 1)
+            }
+            stringInTail.set("")
+            _inputString.update { tail }
+            if (tail.isNotEmpty()) {
+                val spannableString = SpannableString(tail)
+                setComposingTextAfterEdit(
+                    inputString = tail,
+                    spannableString = spannableString,
+                    backgroundColor = if (customComposingTextPreference == true) {
+                        inputCompositionAfterBackgroundColor
+                            ?: getColor(com.kazumaproject.core.R.color.blue)
+                    } else {
+                        getColor(com.kazumaproject.core.R.color.blue)
+                    },
+                    textColor = if (customComposingTextPreference == true) {
+                        inputCompositionTextColor
+                    } else {
+                        null
+                    }
+                )
+            }
+        } finally {
+            endBatchEdit()
+        }
+        clearPhysicalCandidateCompositionSession("candidate committed")
+        return committedText
+    }
+
     private fun displayComposingTextInHardwareKeyboardConnected(
         insertString: String
     ) {
         val selectedSuggestion = listAdapter.currentList.getOrNull(currentHighlightIndex) ?: return
         if (selectedSuggestion.candidateType == CANDIDATE_TYPE_TEXT_MACRO) return
+        if (isPhysicalFloatingCandidatePathActive()) {
+            val composition = resolvePhysicalCandidateComposition(
+                suggestion = selectedSuggestion,
+                insertString = insertString,
+                reason = "preview"
+            ) ?: return
+            setPhysicalCandidateComposingText(composition)
+            return
+        }
+
+        // Bunsetsu cursor-move conversion has its own source/range bookkeeping. Keep its
+        // existing composing behavior when this shared navigation method is reached.
         val tail = FloatingCandidateTailResolver.resolveTail(
             originalInput = insertString,
             selectedCandidateLength = selectedSuggestion.length.toInt()
@@ -7433,6 +7719,32 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 selectedSuggestion.sourceId?.let(::executeTextMacro)
                 return
             }
+
+            if (isPhysicalFloatingCandidatePathActive()) {
+                val composition = resolvePhysicalCandidateComposition(
+                    suggestion = selectedSuggestion,
+                    insertString = inputString.value,
+                    reason = "enter"
+                ) ?: return
+                val committedText = commitPhysicalCandidateComposition(composition)
+                updateSuggestionsForFloatingCandidate(emptyList())
+                listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
+                currentHighlightIndex = RecyclerView.NO_POSITION
+                if (composition.tail.isNotEmpty()) {
+                    beginPhysicalCandidateCompositionSession(composition.tail)
+                    scope.launch {
+                        delay(64)
+                        floatingCandidateNextItem(insertString = composition.tail)
+                    }
+                } else {
+                    if (committedText.isNotBlank()) {
+                        rememberZeroQueryKeyAfterCommit(committedText)
+                    }
+                    consumePendingZeroQueryAfterCommit()
+                }
+                return
+            }
+
             val subString = stringInTail.get()
             val commitWord = selectedSuggestion.formulaFallbackText ?: selectedSuggestion.word
             if (subString.isNotEmpty()) {
@@ -15660,6 +15972,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     isHenkan.set(false)
                     henkanPressedWithBunsetsuDetect = false
                 } else {
+                    clearPhysicalCandidateCompositionSession("physical keyboard disabled")
                     requestCursorUpdates(0)
                     floatingCandidateWindow?.dismiss()
                     floatingDockWindow?.dismiss()
@@ -22258,6 +22571,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private fun resetAllFlags() {
         Timber.d("onUpdate resetAllFlags called")
+        clearPhysicalCandidateCompositionSession("reset all flags")
         clearZeroQueryAllState(refresh = false)
         customKeyboardRenderJob?.cancel()
         customKeyboardRenderJob = null
@@ -22318,6 +22632,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun clearDirectCommitCompositionState(reason: String) {
+        clearPhysicalCandidateCompositionSession(reason)
         clearZeroQueryAllState(refresh = false)
         clearFunctionKeyConversionSource()
         qwertyGlideInputCoordinator?.cancelPending()
@@ -22409,6 +22724,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun resetFlagsSuggestionClick() {
+        clearPhysicalCandidateCompositionSession("suggestion clicked")
         isHenkan.set(false)
         henkanPressedWithBunsetsuDetect = false
         suggestionClickNum = 0
@@ -22439,6 +22755,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun resetFlagsEnterKey() {
+        clearPhysicalCandidateCompositionSession("enter key")
         isHenkan.set(false)
         henkanPressedWithBunsetsuDetect = false
         suggestionClickNum = 0
@@ -22455,6 +22772,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun resetFlagsEnterKeyNotHenkan() {
+        clearPhysicalCandidateCompositionSession("enter key without conversion")
         isHenkan.set(false)
         henkanPressedWithBunsetsuDetect = false
         suggestionClickNum = 0
@@ -22473,6 +22791,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun resetFlagsKeySpace() {
+        clearPhysicalCandidateCompositionSession("space key")
         onDeleteLongPressUp.set(false)
         _dakutenPressed.value = false
         isContinuousTapInputEnabled.set(false)
@@ -22481,6 +22800,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun resetFlagsDeleteKey() {
+        clearPhysicalCandidateCompositionSession("delete key")
         conversionLearningSession.cancel()
         suggestionClickNum = 0
         _dakutenPressed.value = false
@@ -26694,7 +27014,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         flickInputPreviewCoordinator.cancel(restore = true)
         clearFunctionKeyConversionSource()
         cancelCandidateTranslationIfPreEditMutates()
-        return composingTextArbiter.finishCanonical()
+        val finished = composingTextArbiter.finishCanonical()
+        clearPhysicalCandidateCompositionSession("finish composing text")
+        return finished
     }
 
     override fun commitText(p0: CharSequence?, p1: Int): Boolean {
@@ -26703,7 +27025,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         clearFunctionKeyConversionSource()
         cancelCandidateTranslationIfPreEditMutates()
         val committed = currentInputConnection.commitText(p0, p1)
-        if (committed) composingTextArbiter.markCanonicalFinished()
+        if (committed) {
+            composingTextArbiter.markCanonicalFinished()
+            clearPhysicalCandidateCompositionSession("commit text")
+        }
         return committed
     }
 

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -106,7 +106,6 @@ import com.kazumaproject.android.flexbox.FlexboxLayoutManager
 import com.kazumaproject.android.flexbox.JustifyContent
 import com.kazumaproject.core.data.clicked_symbol.SymbolMode
 import com.kazumaproject.core.data.clipboard.ClipboardItem
-import com.kazumaproject.core.data.floating_candidate.CandidateInputRange
 import com.kazumaproject.core.data.floating_candidate.CandidateItem
 import com.kazumaproject.core.data.popup.FlickPopupViewStyleSet
 import com.kazumaproject.core.data.popup.PopupViewStyle
@@ -141,7 +140,8 @@ import com.kazumaproject.core.domain.listener.LongPressListener
 import com.kazumaproject.core.domain.listener.QWERTYKeyListener
 import com.kazumaproject.core.domain.listener.QwertyKeyTouchCancelListener
 import com.kazumaproject.core.domain.physical_keyboard.FloatingCandidateComposition
-import com.kazumaproject.core.domain.physical_keyboard.FloatingCandidateCompositionResolver
+import com.kazumaproject.core.domain.physical_keyboard.PhysicalCandidateCompositionSession
+import com.kazumaproject.core.domain.physical_keyboard.PhysicalCandidateCommit
 import com.kazumaproject.core.domain.physical_keyboard.FloatingCandidateTailResolver
 import com.kazumaproject.core.domain.physical_keyboard.KanaDakutenComposer
 import com.kazumaproject.core.domain.physical_keyboard.PhysicalKanaMapper
@@ -459,19 +459,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         val focusedIndex: Int = 0,
         val splitPatterns: List<List<Int>> = emptyList(),
         val activeSplitPatternIndex: Int = 0
-    )
-
-    /**
-     * The immutable source and the currently queried prefix for physical-keyboard conversion.
-     *
-     * CandidateItem.length is a range in the source reading, not a length of the displayed
-     * candidate. Keeping both values prevents a shorter preview from becoming the next source
-     * for InputConnection.setComposingText().
-     */
-    private data class PhysicalCandidateCompositionSession(
-        val sourceText: String,
-        val queryText: String,
-        val generation: Long,
     )
 
     private sealed class BunsetsuDisplayedSelection {
@@ -1419,10 +1406,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private suspend fun updateFloatingCandidatesOnMain(
         candidates: List<CandidateItem>,
         insertString: String,
+        token: CandidateRequestToken?,
         highlightedAbsoluteIndex: Int? = null
     ) {
         withContext(Dispatchers.Main.immediate) {
-            if (!shouldApplyCandidateResult(insertString)) return@withContext
+            if (!shouldApplyCandidateResult(insertString, token)) return@withContext
             updateSuggestionsForFloatingCandidate(
                 suggestions = candidates,
                 highlightedAbsoluteIndex = highlightedAbsoluteIndex
@@ -1553,6 +1541,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var stringInTail = AtomicReference("")
     private var physicalCandidateCompositionSession: PhysicalCandidateCompositionSession? = null
     private var physicalCandidateCompositionGeneration: Long = 0L
+    private var pendingPhysicalCandidatePreviewGeneration: Long? = null
     private var functionKeyConversionSource: String? = null
     private var suppressedSelectionCleanupCount = 0
     private var preservePreEditOnNextSelectionUpdate: String? = null
@@ -2416,29 +2405,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 return@suggestionClick
             }
 
-            if (isPhysicalFloatingCandidatePathActive()) {
-                val composition = resolvePhysicalCandidateComposition(
-                    suggestion = suggestion,
-                    insertString = inputString.value,
-                    reason = "click"
-                ) ?: return@suggestionClick
-                val committedText = commitPhysicalCandidateComposition(composition)
-
-                updateSuggestionsForFloatingCandidate(emptyList())
-                listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
-                currentHighlightIndex = RecyclerView.NO_POSITION
-                if (composition.tail.isNotEmpty()) {
-                    beginPhysicalCandidateCompositionSession(composition.tail)
-                    scope.launch {
-                        delay(64)
-                        floatingCandidateNextItem(insertString = composition.tail)
-                    }
-                } else {
-                    if (committedText.isNotBlank()) {
-                        rememberZeroQueryKeyAfterCommit(committedText)
-                    }
-                    consumePendingZeroQueryAfterCommit()
-                }
+            if (isPhysicalFloatingCandidatePathActive() && inputString.value.isNotEmpty()) {
+                commitPhysicalCandidate(suggestion, commitAll = false)
                 return@suggestionClick
             }
 
@@ -6843,7 +6811,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             PhysicalKeyboardShortcutAction.CANCEL -> {
                 if (isBunsetsuCursorMoveSessionActive()) {
-                    restoreRawInputFromBunsetsuSession()
+                    clearPhysicalCandidateCompositionSession("bunsetsu shortcut cancelled")
+                    exitBunsetsuCursorMoveSessionToRawInput()
                 } else if (isHenkan.get()) {
                     cancelFloatingCandidateConversion(insertString)
                 }
@@ -6990,12 +6959,17 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             return super.onKeyDown(keyCode, event)
         }
         if (isBunsetsuCursorMoveSessionActive()) {
-            restoreRawInputFromBunsetsuSession()
+            clearPhysicalCandidateCompositionSession("bunsetsu conversion cancelled")
+            exitBunsetsuCursorMoveSessionToRawInput()
             listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
             currentHighlightIndex = RecyclerView.NO_POSITION
             return true
         }
 
+        if (isPhysicalFloatingCandidatePathActive() && physicalCandidateCompositionSession != null) {
+            cancelFloatingCandidateConversion(insertString)
+            return true
+        }
         deleteStringCommon(insertString)
         resetFlagsDeleteKey()
         event?.let { e ->
@@ -7005,8 +6979,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun cancelFloatingCandidateConversion(insertString: String) {
+        val restoredInput = physicalCandidateCompositionSession?.sourceText ?: insertString
         clearPhysicalCandidateCompositionSession("conversion cancelled")
-        preservePreEditOnNextSelectionUpdate = insertString
+        preservePreEditOnNextSelectionUpdate = restoredInput
+        _inputString.update { restoredInput }
         isHenkan.set(false)
         henkanPressedWithBunsetsuDetect = false
         stringInTail.set("")
@@ -7017,9 +6993,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         suggestionAdapter?.updateHighlightPosition(RecyclerView.NO_POSITION)
         setSuggestionAdaptersOnMain(emptyList())
         updateSuggestionsForFloatingCandidate(emptyList())
-        val spannableString = SpannableString(insertString)
+        val spannableString = SpannableString(restoredInput)
         setComposingTextAfterEdit(
-            inputString = insertString,
+            inputString = restoredInput,
             spannableString = spannableString,
             backgroundColor = if (customComposingTextPreference == true) {
                 inputCompositionAfterBackgroundColor
@@ -7055,7 +7031,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
                     isHenkan.set(true)
                     Timber.d("KEYCODE_SPACE is pressed: $normalizedInsertString $stringInTail")
-                    beginPhysicalCandidateCompositionSession(normalizedInsertString)
                     _inputString.update { normalizedInsertString }
 
                     if (shouldUseBunsetsuCursorMoveSession()) {
@@ -7065,10 +7040,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                                 mainView = mainView
                             )
                             if (!activated) {
+                                beginPhysicalCandidateCompositionSession(normalizedInsertString)
                                 floatingCandidateNextItem(normalizedInsertString)
                             }
                         }
                     } else {
+                        beginPhysicalCandidateCompositionSession(normalizedInsertString)
                         floatingCandidateNextItem(normalizedInsertString)
                     }
                 } else {
@@ -7204,6 +7181,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         keyCode: Int, event: KeyEvent?, insertString: String
     ): Boolean {
         event?.let { e ->
+            // A real Shift+arrow sends a separate Shift event before the arrow. It must
+            // not implicitly commit text or tear down the bunsetsu session.
+            if (KeyEvent.isModifierKey(keyCode)) return super.onKeyDown(keyCode, e)
             scope.launch {
                 _physicalKeyboardEnable.emit(true)
             }
@@ -7226,6 +7206,43 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             if (hasPhysicalTextShortcutModifier(e)) {
                 return super.onKeyDown(keyCode, e)
+            }
+
+            if (isHenkan.get() && isPhysicalFloatingCandidatePathActive()) {
+                val suggestion = listAdapter.getHighlightedItem()
+                // The editor must not report the intermediate, composition-free selection
+                // between committing the old text and composing the first new character.
+                beginBatchEdit()
+                try {
+                    if (suggestion == null) {
+                        // Enter followed immediately by typing can arrive before the next
+                        // candidate list. Commit the remaining reading, never drop the key.
+                        val session = ensurePhysicalCandidateCompositionSession(inputString.value)
+                            ?: return true
+                        applyPhysicalCandidateCommit(PhysicalCandidateCommit(session.sourceText, ""), true)
+                    } else if (suggestion.candidateType == CANDIDATE_TYPE_TEXT_MACRO) {
+                        suggestion.sourceId?.let(::executeTextMacro)
+                    } else if (!commitPhysicalCandidate(suggestion, commitAll = true)) {
+                        return true
+                    }
+                    romajiConverter?.clear()
+                    val newInput = if (physicalKeyboardInputMode == PhysicalKeyboardInputMode.KANA) {
+                        PhysicalKanaMapper.resolve(keyCode, e.isShiftPressed)?.let {
+                            KanaDakutenComposer.append("", it)
+                        }
+                    } else {
+                        handlePhysicalRomajiOrUnicodeKey(keyCode, e)?.first
+                    }
+                    newInput?.let { text ->
+                        if (!dispatchDirectTextIfNeeded(text)) {
+                            _inputString.update { text }
+                            applyRawComposingFallback(text)
+                        }
+                    }
+                } finally {
+                    endBatchEdit()
+                }
+                return true
             }
 
             if (isHenkan.get()) {
@@ -7475,6 +7492,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun floatingCandidateNextItem(insertString: String) {
+        if (isPhysicalFloatingCandidatePathActive()) {
+            navigatePhysicalCandidate(insertString, 1)
+            return
+        }
         Timber.d("floatingCandidateNextItem called. Current highlight: $currentHighlightIndex ${stringInTail.get()}")
         if (listAdapter.currentList.isEmpty()) return
 
@@ -7514,6 +7535,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun floatingCandidatePreviousItem(insertString: String) {
+        if (isPhysicalFloatingCandidatePathActive()) {
+            navigatePhysicalCandidate(insertString, -1)
+            return
+        }
         if (listAdapter.currentList.isEmpty()) return
         val suggestionCount = listAdapter.currentList.size.coerceAtMost(PAGE_SIZE)
         if (suggestionCount == 0) return
@@ -7538,6 +7563,24 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
     }
 
+    private fun navigatePhysicalCandidate(insertString: String, delta: Int) {
+        val session = ensurePhysicalCandidateCompositionSession(insertString) ?: return
+        if (fullSuggestionsList.isEmpty()) {
+            pendingPhysicalCandidatePreviewGeneration = session.generation
+            requestCandidateRefresh(CandidateShowFlag.Updating, insertString)
+            return
+        }
+        val current = if (currentHighlightIndex == RecyclerView.NO_POSITION) -1 else
+            currentPage * PAGE_SIZE + currentHighlightIndex
+        val next = if (current == -1) {
+            if (delta > 0) 0 else fullSuggestionsList.lastIndex
+        } else Math.floorMod(current + delta, fullSuggestionsList.size)
+        currentPage = next / PAGE_SIZE
+        currentHighlightIndex = next % PAGE_SIZE
+        pendingPhysicalCandidatePreviewGeneration = session.generation
+        displayCurrentPage()
+    }
+
     private fun isPhysicalFloatingCandidatePathActive(): Boolean {
         return physicalKeyboardEnable.replayCache.firstOrNull() == true &&
                 !isBunsetsuCursorMoveSessionActive()
@@ -7551,76 +7594,33 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 reason
             )
         }
+        // A candidate preview's suffix may overlap queryText. Once the session is gone,
+        // the legacy fields must describe disjoint reading ranges again.
+        physicalCandidateCompositionSession?.let { stringInTail.set(it.trailingText) }
         physicalCandidateCompositionSession = null
+        pendingPhysicalCandidatePreviewGeneration = null
     }
 
     private fun beginPhysicalCandidateCompositionSession(input: String) {
-        if (!isPhysicalFloatingCandidatePathActive() || input.isEmpty()) return
-
-        val current = physicalCandidateCompositionSession
-        val session = when {
-            current == null -> {
-                PhysicalCandidateCompositionSession(
-                    sourceText = input,
-                    queryText = input,
-                    generation = ++physicalCandidateCompositionGeneration,
-                )
-            }
-
-            current.sourceText == input -> current.copy(queryText = input)
-
-            current.sourceText.startsWith(input) && current.queryText.startsWith(input) ->
-                current.copy(queryText = input)
-
-            else -> {
-                PhysicalCandidateCompositionSession(
-                    sourceText = input,
-                    queryText = input,
-                    generation = ++physicalCandidateCompositionGeneration,
-                )
-            }
-        }
-        physicalCandidateCompositionSession = session
-        Timber.d(
-            "beginPhysicalCandidateCompositionSession: generation=%d sourceLength=%d queryLength=%d",
-            session.generation,
-            session.sourceText.length,
-            session.queryText.length
-        )
+        ensurePhysicalCandidateCompositionSession(input)
     }
 
     private fun ensurePhysicalCandidateCompositionSession(
         insertString: String
     ): PhysicalCandidateCompositionSession? {
         if (!isPhysicalFloatingCandidatePathActive() || insertString.isEmpty()) return null
-
         val current = physicalCandidateCompositionSession
-        val currentTail = stringInTail.get()
-        val sourceText = when {
-            current != null &&
-                    current.sourceText.startsWith(insertString) &&
-                    current.queryText.startsWith(insertString) -> current.sourceText
-
-            currentTail.isNotEmpty() && !insertString.endsWith(currentTail) ->
-                insertString + currentTail
-
-            else -> insertString
+        if (current != null) {
+            // A preview may change stringInTail, but it never changes the session's reading.
+            // Reject callbacks belonging to a previous input instead of reviving their text.
+            return current.takeIf { it.queryText == insertString && inputString.value == insertString }
         }
-        val session = if (
-            current != null &&
-            current.sourceText == sourceText &&
-            sourceText.startsWith(insertString)
-        ) {
-            current.copy(queryText = insertString)
-        } else {
-            PhysicalCandidateCompositionSession(
-                sourceText = sourceText,
-                queryText = insertString,
-                generation = ++physicalCandidateCompositionGeneration,
-            )
-        }
-        physicalCandidateCompositionSession = session
-        return session
+        if (inputString.value != insertString) return null
+        return PhysicalCandidateCompositionSession(
+            queryText = insertString,
+            trailingText = stringInTail.get(),
+            generation = ++physicalCandidateCompositionGeneration,
+        ).also { physicalCandidateCompositionSession = it }
     }
 
     private fun resolvePhysicalCandidateComposition(
@@ -7629,49 +7629,48 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         reason: String,
     ): FloatingCandidateComposition? {
         val session = ensurePhysicalCandidateCompositionSession(insertString) ?: return null
-        val candidateLength = suggestion.length.toInt()
-        if (
-            candidateLength < 0 ||
-            candidateLength > session.queryText.length ||
-            !session.sourceText.startsWith(session.queryText)
-        ) {
-            Timber.e(
-                "Invalid physical candidate range: reason=%s generation=%d candidateLength=%d " +
-                        "sourceLength=%d queryLength=%d",
-                reason,
-                session.generation,
-                candidateLength,
-                session.sourceText.length,
-                session.queryText.length
-            )
-            return null
-        }
-
-        val composition = FloatingCandidateCompositionResolver.resolve(
-            originalInput = session.sourceText,
-            replacementText = suggestion.formulaFallbackText ?: suggestion.word,
-            inputRange = CandidateInputRange(start = 0, endExclusive = candidateLength),
+        val composition = session.resolve(
+            suggestion.formulaFallbackText ?: suggestion.word,
+            suggestion.length.toInt(),
         ) ?: run {
-            Timber.e(
-                "Could not resolve physical candidate composition: reason=%s generation=%d",
-                reason,
-                session.generation
-            )
+            Timber.e("Invalid physical candidate range: reason=%s generation=%d", reason, session.generation)
             return null
         }
+        // Keep the legacy field for existing rendering, but never use it as the session source.
         stringInTail.set(composition.tail)
-        Timber.d(
-            "resolvePhysicalCandidateComposition: reason=%s generation=%d candidateLength=%d " +
-                    "sourceLength=%d queryLength=%d replacementLength=%d tailLength=%d",
-            reason,
-            session.generation,
-            candidateLength,
-            session.sourceText.length,
-            session.queryText.length,
-            (suggestion.formulaFallbackText ?: suggestion.word).length,
-            composition.tail.length
-        )
         return composition
+    }
+
+    private fun commitPhysicalCandidate(suggestion: CandidateItem, commitAll: Boolean): Boolean {
+        val composition = resolvePhysicalCandidateComposition(
+            suggestion, inputString.value, if (commitAll) "typing" else "commit"
+        ) ?: return false
+        val session = physicalCandidateCompositionSession ?: return false
+        val result = session.commit(composition, commitAll)
+        applyPhysicalCandidateCommit(result, commitAll)
+        return true
+    }
+
+    private fun applyPhysicalCandidateCommit(result: PhysicalCandidateCommit, commitAll: Boolean) {
+        commitPhysicalCandidateComposition(result)
+        updateSuggestionsForFloatingCandidate(emptyList())
+        listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
+        currentHighlightIndex = RecyclerView.NO_POSITION
+        if (result.remainingReading.isNotEmpty()) {
+            isHenkan.set(true)
+            beginPhysicalCandidateCompositionSession(result.remainingReading)
+            pendingPhysicalCandidatePreviewGeneration = physicalCandidateCompositionSession?.generation
+            // Request explicitly: StateFlow may conflate the preceding edit, or the reading
+            // may be unchanged. The list commit callback will preview the matching result.
+            requestCandidateRefresh(CandidateShowFlag.Updating, result.remainingReading)
+        } else {
+            isHenkan.set(false)
+            henkanPressedWithBunsetsuDetect = false
+            if (!commitAll) {
+                if (result.committedText.isNotBlank()) rememberZeroQueryKeyAfterCommit(result.committedText)
+                consumePendingZeroQueryAfterCommit()
+            }
+        }
     }
 
     private fun setPhysicalCandidateComposingText(
@@ -7721,20 +7720,15 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         setComposingText(spannableString, 1)
     }
 
-    private fun commitPhysicalCandidateComposition(
-        composition: FloatingCandidateComposition,
-    ): String {
-        val committedText = composition.text.substring(0, composition.selectedTextEndExclusive)
-        val tail = composition.tail
+    private fun commitPhysicalCandidateComposition(result: PhysicalCandidateCommit) {
+        val committedText = result.committedText
+        val tail = result.remainingReading
         beginBatchEdit()
         try {
-            // setComposingText() replaces the entire active composing region. End that region
-            // before committing only the selected prefix, then explicitly recompose the tail.
-            setComposingText("", 0)
-            finishComposingText()
-            if (committedText.isNotEmpty()) {
-                commitText(committedText, 1)
-            }
+            // commitText replaces the current composing region and finishes it itself.
+            // An additional finishComposingText can flush selection notifications before
+            // the tail is restored (notably in Sora's nested composing batch).
+            commitText(committedText, 1)
             stringInTail.set("")
             _inputString.update { tail }
             if (tail.isNotEmpty()) {
@@ -7759,7 +7753,6 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             endBatchEdit()
         }
         clearPhysicalCandidateCompositionSession("candidate committed")
-        return committedText
     }
 
     private fun displayComposingTextInHardwareKeyboardConnected(
@@ -7816,27 +7809,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             }
 
             if (isPhysicalFloatingCandidatePathActive()) {
-                val composition = resolvePhysicalCandidateComposition(
-                    suggestion = selectedSuggestion,
-                    insertString = inputString.value,
-                    reason = "enter"
-                ) ?: return
-                val committedText = commitPhysicalCandidateComposition(composition)
-                updateSuggestionsForFloatingCandidate(emptyList())
-                listAdapter.updateHighlightPosition(RecyclerView.NO_POSITION)
-                currentHighlightIndex = RecyclerView.NO_POSITION
-                if (composition.tail.isNotEmpty()) {
-                    beginPhysicalCandidateCompositionSession(composition.tail)
-                    scope.launch {
-                        delay(64)
-                        floatingCandidateNextItem(insertString = composition.tail)
-                    }
-                } else {
-                    if (committedText.isNotBlank()) {
-                        rememberZeroQueryKeyAfterCommit(committedText)
-                    }
-                    consumePendingZeroQueryAfterCommit()
-                }
+                commitPhysicalCandidate(selectedSuggestion, commitAll = false)
                 return
             }
 
@@ -9314,7 +9287,21 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             val pagerLabel = "▶ (${currentPage + 1}/$totalPages)"
             itemsToShow.add(CandidateItem(word = pagerLabel, length = (1).toUByte()))
         }
+        val physicalSession = physicalCandidateCompositionSession
+        val requestedPage = currentPage
         listAdapter.submitList(itemsToShow) {
+            if (physicalSession != null && (
+                    physicalCandidateCompositionSession?.generation != physicalSession.generation ||
+                        inputString.value != physicalSession.queryText || currentPage != requestedPage
+                    )) return@submitList
+            if (physicalSession != null &&
+                pendingPhysicalCandidatePreviewGeneration == physicalSession.generation &&
+                isPhysicalFloatingCandidatePathActive()
+            ) {
+                if (currentHighlightIndex == RecyclerView.NO_POSITION) currentHighlightIndex = 0
+                pendingPhysicalCandidatePreviewGeneration = null
+                displayComposingTextInHardwareKeyboardConnected(physicalSession.queryText)
+            }
             listAdapter.updateHighlightPosition(currentHighlightIndex)
             Timber.d("floatingCandidateNextItem (after update): ${listAdapter.getHighlightedItem()} [$itemsToShow]")
         }
@@ -16888,7 +16875,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     candidates = displayedCandidates.map {
                         it.toFloatingCandidateItem()
                     },
-                    insertString = insertString
+                    insertString = insertString,
+                    token = token,
                 )
             }
         } else {
@@ -17877,6 +17865,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun processInputString(
         string: String, mainView: MainLayoutBinding,
     ) {
+        physicalCandidateCompositionSession?.let { session ->
+            if (session.queryText != string) {
+                clearPhysicalCandidateCompositionSession("reading edited")
+            }
+        }
         defaultInputFinalizeJob?.cancel()
         defaultInputFinalizeJob = null
         if (string.isNotEmpty()) {
@@ -23925,7 +23918,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     candidates = displayedCandidates.map {
                         it.toFloatingCandidateItem()
                     },
-                    insertString = insertString
+                    insertString = insertString,
+                    token = token,
                 )
             }
         } else {
@@ -24002,7 +23996,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                     candidates = displayedCandidates.map {
                         it.toFloatingCandidateItem()
                     },
-                    insertString = insertString
+                    insertString = insertString,
+                    token = token,
                 )
             }
         } else {
@@ -27211,6 +27206,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         val maxPage = (fullSuggestionsList.size - 1) / PAGE_SIZE
         currentPage = if (currentPage >= maxPage) 0 else currentPage + 1
         currentHighlightIndex = 0
+        if (isPhysicalFloatingCandidatePathActive()) {
+            pendingPhysicalCandidatePreviewGeneration = physicalCandidateCompositionSession?.generation
+        }
         displayCurrentPage()
     }
 
@@ -27219,6 +27217,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         if (currentPage > 0) {
             currentPage--
             currentHighlightIndex = 0
+            if (isPhysicalFloatingCandidatePathActive()) {
+                pendingPhysicalCandidatePreviewGeneration = physicalCandidateCompositionSession?.generation
+            }
             displayCurrentPage()
         }
     }

--- a/core/src/main/java/com/kazumaproject/core/data/floating_candidate/CandidateInputRange.kt
+++ b/core/src/main/java/com/kazumaproject/core/data/floating_candidate/CandidateInputRange.kt
@@ -1,0 +1,16 @@
+package com.kazumaproject.core.data.floating_candidate
+
+/**
+ * A half-open UTF-16 range in a composing input string.
+ *
+ * The range describes source text, not the length of the candidate output. Conversion can
+ * change the number of UTF-16 code units between the reading and its displayed text.
+ */
+data class CandidateInputRange(
+    val start: Int,
+    val endExclusive: Int,
+) {
+    fun isValidFor(input: String): Boolean {
+        return start >= 0 && start <= endExclusive && endExclusive <= input.length
+    }
+}

--- a/core/src/main/java/com/kazumaproject/core/domain/physical_keyboard/FloatingCandidateCompositionResolver.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/physical_keyboard/FloatingCandidateCompositionResolver.kt
@@ -1,0 +1,38 @@
+package com.kazumaproject.core.domain.physical_keyboard
+
+import com.kazumaproject.core.data.floating_candidate.CandidateInputRange
+
+data class FloatingCandidateComposition(
+    val text: String,
+    val selectedTextStart: Int,
+    val selectedTextEndExclusive: Int,
+    val tail: String,
+)
+
+/**
+ * Rebuilds the complete composing text after replacing a source range with a candidate.
+ *
+ * This is deliberately independent from Android's InputConnection. Callers must provide the
+ * source range explicitly; inferring a range from the candidate output would be incorrect when
+ * conversion changes the text length.
+ */
+object FloatingCandidateCompositionResolver {
+    fun resolve(
+        originalInput: String,
+        replacementText: String,
+        inputRange: CandidateInputRange,
+    ): FloatingCandidateComposition? {
+        if (!inputRange.isValidFor(originalInput)) return null
+
+        val prefix = originalInput.substring(0, inputRange.start)
+        val tail = originalInput.substring(inputRange.endExclusive)
+        val selectedTextStart = prefix.length
+        val selectedTextEndExclusive = selectedTextStart + replacementText.length
+        return FloatingCandidateComposition(
+            text = prefix + replacementText + tail,
+            selectedTextStart = selectedTextStart,
+            selectedTextEndExclusive = selectedTextEndExclusive,
+            tail = tail,
+        )
+    }
+}

--- a/core/src/main/java/com/kazumaproject/core/domain/physical_keyboard/PhysicalCandidateCompositionSession.kt
+++ b/core/src/main/java/com/kazumaproject/core/domain/physical_keyboard/PhysicalCandidateCompositionSession.kt
@@ -1,0 +1,32 @@
+package com.kazumaproject.core.domain.physical_keyboard
+
+import com.kazumaproject.core.data.floating_candidate.CandidateInputRange
+
+/** Source reading is never inferred from a rendered candidate or from overlapping suffixes. */
+data class PhysicalCandidateCompositionSession(
+    val queryText: String,
+    val trailingText: String,
+    val generation: Long,
+) {
+    val sourceText: String get() = queryText + trailingText
+
+    fun resolve(replacement: String, readingLength: Int): FloatingCandidateComposition? {
+        if (readingLength !in 1..queryText.length) return null
+        return FloatingCandidateCompositionResolver.resolve(
+            sourceText, replacement, CandidateInputRange(0, readingLength)
+        )
+    }
+
+    fun commit(composition: FloatingCandidateComposition, commitAll: Boolean): PhysicalCandidateCommit {
+        return if (commitAll) {
+            PhysicalCandidateCommit(composition.text, "")
+        } else {
+            PhysicalCandidateCommit(
+                composition.text.substring(0, composition.selectedTextEndExclusive),
+                composition.tail,
+            )
+        }
+    }
+}
+
+data class PhysicalCandidateCommit(val committedText: String, val remainingReading: String)

--- a/core/src/test/java/com/kazumaproject/core/domain/physical_keyboard/FloatingCandidateCompositionResolverTest.kt
+++ b/core/src/test/java/com/kazumaproject/core/domain/physical_keyboard/FloatingCandidateCompositionResolverTest.kt
@@ -1,0 +1,65 @@
+package com.kazumaproject.core.domain.physical_keyboard
+
+import com.kazumaproject.core.data.floating_candidate.CandidateInputRange
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class FloatingCandidateCompositionResolverTest {
+    @Test
+    fun resolve_replacesPrefix_andPreservesFollowingInput() {
+        val result = FloatingCandidateCompositionResolver.resolve(
+            originalInput = "あいたじかんでＩＴぱすぽ－とのべんきょうをする",
+            replacementText = "空いた時間で",
+            inputRange = CandidateInputRange(0, 7),
+        )
+
+        requireNotNull(result)
+        assertEquals(
+            "空いた時間でＩＴぱすぽ－とのべんきょうをする",
+            result.text,
+        )
+        assertEquals("ＩＴぱすぽ－とのべんきょうをする", result.tail)
+        assertEquals(0, result.selectedTextStart)
+        assertEquals("空いた時間で".length, result.selectedTextEndExclusive)
+    }
+
+    @Test
+    fun resolve_replacesNonPrefixRange_withoutDroppingEitherSide() {
+        val result = FloatingCandidateCompositionResolver.resolve(
+            originalInput = "ここでは",
+            replacementText = "でわ",
+            inputRange = CandidateInputRange(2, 3),
+        )
+
+        requireNotNull(result)
+        assertEquals("ここでわは", result.text)
+        assertEquals("は", result.tail)
+        assertEquals(2, result.selectedTextStart)
+        assertEquals(4, result.selectedTextEndExclusive)
+    }
+
+    @Test
+    fun resolve_usesUtf16SourceOffsets_notOutputLength() {
+        val result = FloatingCandidateCompositionResolver.resolve(
+            originalInput = "😀かな",
+            replacementText = "絵",
+            inputRange = CandidateInputRange(2, 3),
+        )
+
+        requireNotNull(result)
+        assertEquals("😀絵な", result.text)
+        assertEquals("な", result.tail)
+    }
+
+    @Test
+    fun resolve_returnsNull_forInvalidRange_withoutCreatingShortText() {
+        assertNull(
+            FloatingCandidateCompositionResolver.resolve(
+                originalInput = "ここでは",
+                replacementText = "此処",
+                inputRange = CandidateInputRange(0, 100),
+            )
+        )
+    }
+}

--- a/core/src/test/java/com/kazumaproject/core/domain/physical_keyboard/PhysicalCandidateCompositionSessionTest.kt
+++ b/core/src/test/java/com/kazumaproject/core/domain/physical_keyboard/PhysicalCandidateCompositionSessionTest.kt
@@ -1,0 +1,61 @@
+package com.kazumaproject.core.domain.physical_keyboard
+
+import org.junit.Assert.*
+import org.junit.Test
+
+class PhysicalCandidateCompositionSessionTest {
+    @Test fun cursorTailIsPartOfSourceBeforeFirstPreview() {
+        val session = PhysicalCandidateCompositionSession("あした", "は", 1)
+        assertEquals("明日は", session.resolve("明日", 3)!!.text)
+        assertEquals("あしたは", session.sourceText)
+    }
+
+    @Test fun repeatedSuffixIsNotMistakenForAlreadyIncludedTail() {
+        val session = PhysicalCandidateCompositionSession("ここ", "こ", 1)
+        assertEquals("此処こ", session.resolve("此処", 2)!!.text)
+    }
+
+    @Test fun shorteningThenExpandingCandidateKeepsOriginalReading() {
+        val session = PhysicalCandidateCompositionSession("あしたはれるといいですね", "はれた", 1)
+        assertEquals("明日はれるといいですねはれた", session.resolve("明日", 3)!!.text)
+        val expanded = session.resolve("明日晴れると良いですね", session.queryText.length)!!
+        assertEquals("明日晴れると良いですねはれた", expanded.text)
+        assertEquals("はれた", expanded.tail)
+        assertEquals("あしたはれるといいですねはれた", session.sourceText)
+    }
+
+    @Test fun enterCommitsOnlySelectedReading() {
+        val session = PhysicalCandidateCompositionSession("あしたはれる", "", 1)
+        val result = session.commit(session.resolve("明日", 3)!!, false)
+        assertEquals("明日", result.committedText)
+        assertEquals("はれる", result.remainingReading)
+        val next = PhysicalCandidateCompositionSession(result.remainingReading, "", 2)
+        assertEquals("晴れる", next.commit(next.resolve("晴れる", 3)!!, false).committedText)
+    }
+
+    @Test fun typingCommitsCandidateAndAllRemainingReading() {
+        val session = PhysicalCandidateCompositionSession("あしたはれる", "かな", 1)
+        val result = session.commit(session.resolve("明日", 3)!!, true)
+        assertEquals("明日はれるかな", result.committedText)
+        assertEquals("", result.remainingReading)
+    }
+
+    @Test fun previewNeverReplacesReadingUsedToCancel() {
+        val session = PhysicalCandidateCompositionSession("あした", "は", 1)
+        session.resolve("明日", 3)
+        session.resolve("足", 2)
+        assertEquals("あしたは", session.sourceText)
+    }
+
+    @Test fun candidateCannotConsumeUnqueriedTail() {
+        val session = PhysicalCandidateCompositionSession("あした", "は", 1)
+        assertNull(session.resolve("明日は", 4))
+        assertNull(session.resolve("", 0))
+        assertNull(session.resolve("明日", -1))
+    }
+
+    @Test fun sourceOffsetsAreUtf16() {
+        val session = PhysicalCandidateCompositionSession("😀かな", "！", 1)
+        assertEquals("絵かな！", session.resolve("絵", 2)!!.text)
+    }
+}

--- a/docs/reviews/pr984-physical-conversion.md
+++ b/docs/reviews/pr984-physical-conversion.md
@@ -1,0 +1,88 @@
+# PR #984: physical keyboard conversion review
+
+## Scope and implementation
+
+The changed conversion behaviour is limited to physical-keyboard input. Ordinary
+software-keyboard candidate generation and commit routing are unchanged.
+
+- Store the queried reading and the disjoint cursor tail as an immutable session.
+  Build each preview from that source and a UTF-16 reading range, not the candidate's
+  display length or a suffix-overlap heuristic.
+- Enter and candidate clicks commit only the selected reading and recompose the rest.
+  Typing commits the selected candidate plus the remaining reading before composing
+  the new character. Commit and initial new-character composition share a batch.
+- `commitText` finishes the composing region itself; do not clear the region and
+  redundantly call `finishComposingText` before restoring the tail. Sora's composing
+  batch can otherwise flush a stale selection update between those operations.
+- If typing arrives before the next candidate list, commit the remaining raw reading
+  and process the key. Candidate previews wait for list submission rather than a
+  fixed delay, and check the session generation. Candidate request tokens are checked
+  again after dispatch to the main thread.
+- Restore the complete reading on cancellation, reset physical bunsetsu conversion
+  flags, and ignore standalone modifier keys as text input.
+
+## Baseline reproduction
+
+Baseline: `5d1f95d24` (original PR merged with `dev` at
+`d84ff2c0b91339c9f96081706c9c946fee7b73a2`). Using the same hardware-key tests:
+
+| Operation | Baseline result |
+| --- | --- |
+| Type あしたは, move left, Space | 明日; trailing は is lost |
+| Select a partial candidate from あしたはれるといいですねはれた, then type a | あしたあ; remaining reading is lost |
+
+Both are assertion failures in the added Android tests, not assumptions inferred
+only from source inspection.
+
+## Reproduction commands
+
+Use a dedicated Android 35+ emulator with hardware keyboard enabled and set
+`ANDROID_HOME` and `ANDROID_SERIAL`. Do not share it with another UI test.
+
+```sh
+./gradlew :core:testDebugUnitTest :app:testLiteStandardDebugUnitTest :gojuon_keyboard:testDebugUnitTest :app:assembleLiteStandardDebug :app:assembleLiteStandardDebugAndroidTest :app:assembleFullStandardDebug --max-workers=2
+adb install -r app/build/outputs/apk/liteStandard/debug/app-lite-standard-debug.apk
+adb install -r app/build/outputs/apk/androidTest/liteStandard/debug/app-lite-standard-debug-androidTest.apk
+adb shell am instrument -w -r -e class com.kazumaproject.markdownhelperkeyboard.PhysicalCandidateCompositionInstrumentedTest com.kazumaproject.markdownhelperkeyboard.lite.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+The independent Sora 0.24.6 host and its commands are in
+[`tools/physical_candidate_sora_probe`](../../tools/physical_candidate_sora_probe/README.md).
+It enables composing IME input when a hardware keyboard is present; Sora's default
+hardware-keyboard setting instead advertises `TYPE_NULL` and exercises direct input.
+The probe is not part of the product dependency graph.
+
+## Validation record
+
+Verified on 2026-09-08 against the final implementation, using a dedicated Android
+35 arm64 emulator and its built-in `qwerty2` hardware-keyboard route:
+
+| Check | Result |
+| --- | --- |
+| core unit tests | 40 passed |
+| app Lite unit tests | 1,448 passed; 4 existing skips; 0 failures |
+| gojuon unit tests | 1 passed |
+| Standard EditText hardware-key instrumentation | 8 passed |
+| Sora 0.24.6 hardware-key instrumentation | 3 passed |
+| Lite debug APK and AndroidTest APK | Built successfully |
+| Full debug APK, including pinned native submodules | Built successfully |
+| Whitespace and conflict review | Clean |
+
+The EditText cases include actual Shift down/up events, rapid Enter followed by a
+character, kana and romaji input, cancellation, candidate clicks and editor restart.
+Sora covers partial Enter/remaining-reading commit, implicit commit/new input and
+cursor-tail cancellation. Its standalone test dependency is not shipped in the IME.
+
+An intermediate run of the existing glide timing benchmark exceeded its threshold
+under concurrent builds. The unchanged benchmark and the complete final suite passed
+with `--max-workers=2`. Early UI runs affected by a shared emulator or incomplete IME
+binding are not treated as product verification; the final runs use a dedicated
+emulator and explicit Japanese-input readiness checks.
+
+Re-review found no remaining merge-blocking defects in the verified paths. The PR
+includes `dev` at the SHA above and preserves its editor-mutation revision tracking.
+The actual PR merge is intentionally left to the maintainer.
+
+Physical Japanese 109A hardware and Android 16/HyperOS were not available. Emulator
+results must not be represented as a physical-device test. Full builds use the
+repository's pinned native submodules.

--- a/tools/physical_candidate_sora_probe/.gitignore
+++ b/tools/physical_candidate_sora_probe/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/.gradle/
+/local.properties

--- a/tools/physical_candidate_sora_probe/README.md
+++ b/tools/physical_candidate_sora_probe/README.md
@@ -1,0 +1,30 @@
+# Physical candidate conversion: Sora Editor probe
+
+Standalone Android test host for Sora Editor **0.24.6**. This project is deliberately
+not included in the product build: Sora's Kotlin runtime does not alter the IME's
+dependencies. Use an Android 35+ emulator with hardware keyboard enabled, or a device
+with an alphabetic physical keyboard. Tests exercise Sumire Lite's real IME connection.
+
+The host enables IME composition with `setDisableSoftKbdIfHardKbdAvailable(false)`.
+Sora otherwise advertises `TYPE_NULL` with a hardware keyboard, which tests a different
+(direct input) path. `disallowSuggestions` remains false.
+
+From the repository root, with `ANDROID_HOME` and `ANDROID_SERIAL` set:
+
+```sh
+./gradlew :app:assembleLiteStandardDebug
+./gradlew -p tools/physical_candidate_sora_probe assembleDebug assembleDebugAndroidTest
+adb install -r app/build/outputs/apk/liteStandard/debug/app-lite-standard-debug.apk
+adb install -r tools/physical_candidate_sora_probe/build/outputs/apk/debug/PR984SoraProbe-debug.apk
+adb install -r tools/physical_candidate_sora_probe/build/outputs/apk/androidTest/debug/PR984SoraProbe-debug-androidTest.apk
+adb shell am instrument -w -r dev.pr984.soraprobe.test/androidx.test.runner.AndroidJUnitRunner
+```
+
+Use Japanese romaji input, bunsetsu separation enabled, bunsetsu cursor movement disabled,
+and live conversion disabled. The tests select the Lite IME and restore the previously
+selected IME. Run on a dedicated test device: do not run another UI test concurrently.
+
+Checks cover a cursor-separated trailing reading, partial Enter/continuation, and
+implicit commit followed by another typed character. The main app's
+`PhysicalCandidateCompositionInstrumentedTest` additionally tests kana input, clicks,
+bunsetsu width changes and editor restart against standard `EditText`.

--- a/tools/physical_candidate_sora_probe/build.gradle
+++ b/tools/physical_candidate_sora_probe/build.gradle
@@ -1,0 +1,13 @@
+plugins { id 'com.android.application' version '8.10.1' }
+android {
+ namespace 'dev.pr984.soraprobe'
+ compileSdk 36
+ defaultConfig { applicationId 'dev.pr984.soraprobe'; minSdk 24; targetSdk 35; versionCode 1; versionName '1'; testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner' }
+ compileOptions { sourceCompatibility JavaVersion.VERSION_17; targetCompatibility JavaVersion.VERSION_17 }
+}
+dependencies {
+ implementation 'io.github.rosemoe:editor:0.24.6'
+ androidTestImplementation 'androidx.test:runner:1.6.2'
+ androidTestImplementation 'androidx.test:core:1.6.1'
+ androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+}

--- a/tools/physical_candidate_sora_probe/gradle.properties
+++ b/tools/physical_candidate_sora_probe/gradle.properties
@@ -1,0 +1,2 @@
+android.useAndroidX=true
+org.gradle.jvmargs=-Xmx1024m

--- a/tools/physical_candidate_sora_probe/settings.gradle
+++ b/tools/physical_candidate_sora_probe/settings.gradle
@@ -1,0 +1,3 @@
+pluginManagement { repositories { google(); mavenCentral(); gradlePluginPortal() } }
+dependencyResolutionManagement { repositories { google(); mavenCentral() } }
+rootProject.name = "PR984SoraProbe"

--- a/tools/physical_candidate_sora_probe/src/androidTest/java/dev/pr984/soraprobe/SoraPhysicalTest.java
+++ b/tools/physical_candidate_sora_probe/src/androidTest/java/dev/pr984/soraprobe/SoraPhysicalTest.java
@@ -1,0 +1,91 @@
+package dev.pr984.soraprobe;
+import android.app.Instrumentation;
+import android.os.ParcelFileDescriptor;
+import android.os.SystemClock;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.platform.app.InstrumentationRegistry;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import org.junit.Test;
+import org.junit.BeforeClass;
+import org.junit.AfterClass;
+import org.junit.runner.RunWith;
+import static org.junit.Assert.*;
+import java.util.function.BooleanSupplier;
+@RunWith(AndroidJUnit4.class)
+public class SoraPhysicalTest {
+ private static final Instrumentation inst = InstrumentationRegistry.getInstrumentation();
+ private ActivityScenario<HostActivity> host;
+ private int device;
+ private static String shell(String command) throws Exception {
+  try(java.io.InputStream in = new ParcelFileDescriptor.AutoCloseInputStream(inst.getUiAutomation().executeShellCommand(command))) {
+   return new String(in.readAllBytes()).trim();
+  }
+ }
+ private static String previous;
+ private static String showWithHardware;
+ @BeforeClass public static void connectIme() throws Exception {
+  previous=shell("settings get secure default_input_method");
+  showWithHardware=shell("settings get secure show_ime_with_hard_keyboard");
+  String ime="com.kazumaproject.markdownhelperkeyboard.lite/com.kazumaproject.markdownhelperkeyboard.ime_service.IMEService";
+  shell("settings put secure show_ime_with_hard_keyboard 1");
+  shell("ime enable "+ime); shell("ime set "+ime);
+ }
+ @AfterClass public static void restoreIme() throws Exception {
+  shell("ime set "+previous);
+  shell(showWithHardware.equals("null") ? "settings delete secure show_ime_with_hard_keyboard" : "settings put secure show_ime_with_hard_keyboard "+showWithHardware);
+ }
+ private void fixture(Runnable action) throws Exception {
+  device=-1;
+  for(int id: InputDevice.getDeviceIds()) {
+   InputDevice d=InputDevice.getDevice(id);
+   if(d!=null && !d.isVirtual() && d.getKeyboardType()==InputDevice.KEYBOARD_TYPE_ALPHABETIC) device=id;
+  }
+  assertTrue(device>=0);
+  try {
+   host=ActivityScenario.launch(HostActivity.class);
+   long readyBy = SystemClock.uptimeMillis() + 30000;
+   boolean ready = false;
+   String observed = "";
+   while (!ready && SystemClock.uptimeMillis() < readyBy) {
+    SystemClock.sleep(500);
+    key(KeyEvent.KEYCODE_KANA);
+    key(KeyEvent.KEYCODE_A);
+    observed = text();
+    ready = observed.equals("あ");
+    host.onActivity(a -> {
+     a.editor.setText("");
+     a.editor.restartInput();
+     ((android.view.inputmethod.InputMethodManager)a.getSystemService(android.content.Context.INPUT_METHOD_SERVICE)).showSoftInput(a.editor, android.view.inputmethod.InputMethodManager.SHOW_FORCED);
+    });
+   }
+   assertTrue("Japanese IME did not initialize: ["+observed+"]", ready);
+   SystemClock.sleep(500);
+   action.run();
+  } finally {
+   if(host!=null) host.close();
+  }
+ }
+ private String text() { String[] s={""}; host.onActivity(a->s[0]=a.editor.getText().toString()); return s[0]; }
+ private void await(BooleanSupplier check) { long end=SystemClock.uptimeMillis()+10000; while(SystemClock.uptimeMillis()<end) { if(check.getAsBoolean()) return; SystemClock.sleep(50); } fail("Editor: "+text()); }
+ private void key(int code) {
+  long time=SystemClock.uptimeMillis();
+  for(int action:new int[]{KeyEvent.ACTION_DOWN,KeyEvent.ACTION_UP}) assertTrue(inst.getUiAutomation().injectInputEvent(new KeyEvent(time,SystemClock.uptimeMillis(),action,code,0,0,device,0,0,InputDevice.SOURCE_KEYBOARD),true));
+  SystemClock.sleep(160);
+ }
+ private void type(String s) { for(char c:s.toCharArray()) key(KeyEvent.KEYCODE_A+c-'a'); }
+ private void partial() {
+  type("ashitaharerutoiidesunehareta");
+  await(()->text().equals("あしたはれるといいですねはれた"));
+  key(KeyEvent.KEYCODE_SPACE);
+  for(int i=0;i<40;i++) {
+   if(text().equals("明日はれるといいですねはれた")) return;
+   key(KeyEvent.KEYCODE_DPAD_DOWN);
+  }
+  fail("No partial candidate: "+text());
+ }
+ @Test public void narrowedTypingPreservesAllText() throws Exception { fixture(()->{partial();String preview=text();type("a");await(()->text().equals(preview+"あ"));}); }
+ @Test public void cursorTailAndCancelPreserveAllText() throws Exception { fixture(()->{type("ashitaha");await(()->text().equals("あしたは"));key(KeyEvent.KEYCODE_DPAD_LEFT);key(KeyEvent.KEYCODE_SPACE);await(()->text().equals("明日は"));key(KeyEvent.KEYCODE_ESCAPE);await(()->text().equals("あしたは"));}); }
+ @Test public void partialEnterKeepsRemainder() throws Exception { fixture(()->{partial();String preview=text();key(KeyEvent.KEYCODE_ENTER);SystemClock.sleep(700);key(KeyEvent.KEYCODE_ESCAPE);await(()->text().equals(preview));key(KeyEvent.KEYCODE_ENTER);await(()->text().equals(preview));}); }
+}

--- a/tools/physical_candidate_sora_probe/src/main/AndroidManifest.xml
+++ b/tools/physical_candidate_sora_probe/src/main/AndroidManifest.xml
@@ -1,0 +1,1 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"><application android:theme="@android:style/Theme.Material.Light.NoActionBar" android:label="PR984 Sora probe"><activity android:name=".HostActivity" android:exported="true" android:windowSoftInputMode="stateAlwaysVisible|adjustResize" /></application></manifest>

--- a/tools/physical_candidate_sora_probe/src/main/java/dev/pr984/soraprobe/HostActivity.java
+++ b/tools/physical_candidate_sora_probe/src/main/java/dev/pr984/soraprobe/HostActivity.java
@@ -1,0 +1,20 @@
+package dev.pr984.soraprobe;
+import android.app.Activity;
+import android.os.Bundle;
+import android.view.inputmethod.InputMethodManager;
+import io.github.rosemoe.sora.widget.CodeEditor;
+public class HostActivity extends Activity {
+ public CodeEditor editor;
+ @Override public void onCreate(Bundle state) {
+  super.onCreate(state);
+  editor = new CodeEditor(this);
+  editor.getProps().disallowSuggestions = false;
+  editor.setDisableSoftKbdIfHardKbdAvailable(false);
+  setContentView(editor);
+  editor.requestFocus();
+ }
+ @Override public void onWindowFocusChanged(boolean focused) {
+  super.onWindowFocusChanged(focused);
+  if(focused) editor.post(() -> { editor.requestFocus(); ((InputMethodManager)getSystemService(INPUT_METHOD_SERVICE)).showSoftInput(editor, InputMethodManager.SHOW_FORCED); });
+ }
+}


### PR DESCRIPTION
## 概要

Fixes #974. 物理キーボードで変換範囲を狭めた際に、範囲外の後続文字列が消える問題を修正します。改善後の再レビューと回帰テストを実施しました。

## 修正内容

- 物理入力専用のセッションで検索対象の読みとカーソル右側の読みを保持し、候補の表示長や文字列の重なりから元の全文を推測しないようにしました。
- 候補表示・切替・ページ移動では、範囲外の読みを含めて composing text を再構成します。
- Enter・候補クリックでは選択部分だけ確定し、残りを未確定入力として維持します。
- 文字入力による暗黙確定では、選択候補と残りの読みをすべて確定してから、新しい文字を入力します。確定と最初の文字の表示を同じバッチにまとめ、選択位置通知による欠落を防ぎます。
- `commitText()` が composing region を終了するため、冗長な `finishComposingText()` を取り除きました。Soraの部分確定で後続が失われる経路も確認・修正しています。
- 次の候補一覧が未到着でも、部分確定直後の文字キーを落としません。固定時間の待機をやめ、一覧反映時にセッション世代と入力内容を確認します。候補リクエストもメインスレッドで再照合します。
- キャンセル時に全文を復元し、物理文節変換のフラグを解除します。Shiftなど修飾キー単独では変換を確定・解除しません。
- 最新 `dev` を取り込み、`commitText()` の競合では既存の編集リビジョン更新を保持しました。

ソフトウェアキーボードの入力・変換仕様は変更していません。Sora検証用プロジェクトは独立しており、製品の依存関係には含まれません。

## 検証

修正前PR＋devの `5d1f95d24` に同じテストを適用し、以下を再現しました。

- 「あしたは」→左キー→Spaceで「は」が消え、「明日」になる。
- 長い読みの短い候補を選んでから `a` を入力すると、残りの読みが消えて「あしたあ」になる。

改善後の結果:

- `:core:testDebugUnitTest`: 40件成功
- `:app:testLiteStandardDebugUnitTest`: 1,448件成功、既存の4件スキップ、失敗なし
- `:gojuon_keyboard:testDebugUnitTest`: 1件成功
- 標準EditTextの物理キー操作テスト: 8件成功（実際のShift押下・解放、かな/ローマ字、部分確定直後の連続入力、候補クリック、キャンセル、入力欄再接続を含む）
- Sora Editor 0.24.6の物理キー操作テスト: 3件成功
- Lite Debug APK / AndroidTest APK / Full Debug APK: ビルド成功
- `git diff --check`: 成功

Android 35 arm64の専用エミュレーター（built-in `qwerty2`）で検証しました。Soraは物理キーボード接続中もIMEによる未確定入力を許可する設定で検証しています。109A実機とAndroid 16/HyperOSは未検証です。

再レビューで、検証した経路にマージを妨げる指摘は残っていません。詳細と再実行手順は [検証記録](https://github.com/KazumaProject/JapaneseKeyboard/blob/684d641f1c1c8ab289d482854207f07026e120fb/docs/reviews/pr984-physical-conversion.md) を参照してください。

## English

Preserve the complete source reading across physical-keyboard candidate previews, partial commits, cancellation and continued typing. Enter/click commits only the selected reading; typing commits the candidate plus its remaining reading before starting new composition. Remove redundant composing-region teardown, wait for candidate-list submission instead of fixed delays, validate request/session ownership, and ignore standalone modifier keys as text input.

Regression tests reproduce both reviewed text-loss cases before the fix. The final implementation passes 8 real-IME EditText cases, 3 Sora 0.24.6 cases, unit tests and Lite/Full debug builds. Testing used a dedicated Android 35 emulator, not a physical 109A device.
