### PR TITLE
スミレ入力βのキー間タッチ判定を改善 / Fix touch detection between Sumire beta keys

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -168,6 +168,7 @@ import com.kazumaproject.custom_keyboard.data.KeyboardLayoutUsageMode
 import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
 import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts.DeleteKeyFlickSettings
 import com.kazumaproject.custom_keyboard.view.FlickKeyboardView
+import com.kazumaproject.custom_keyboard.view.KeyHitTestMode
 import com.kazumaproject.gojuon_keyboard.GojuonKeyboardView
 import com.kazumaproject.data.clicked_symbol.ClickedSymbol
 import com.kazumaproject.data.emoji.Emoji
@@ -8687,7 +8688,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             layoutType = layoutType,
             inputMode = customKeyboardMode.name
         )
-        flickView.setKeyboard(createSumireKeyboardLayout())
+        flickView.setKeyboard(createSumireKeyboardLayout(), KeyHitTestMode.NEAREST_KEY)
     }
 
     private fun setNumberLayoutTo(flickView: FlickKeyboardView) {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateHeightPreviewUtils.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/CandidateHeightPreviewUtils.kt
@@ -29,6 +29,7 @@ import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
 import com.kazumaproject.custom_keyboard.data.KeyboardLayout
 import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
 import com.kazumaproject.custom_keyboard.view.FlickKeyboardView
+import com.kazumaproject.custom_keyboard.view.KeyHitTestMode
 import com.kazumaproject.gojuon_keyboard.GojuonKeyboardView
 import com.kazumaproject.markdownhelperkeyboard.ime_service.resolveInitialCustomKeyboardSelection
 import com.kazumaproject.markdownhelperkeyboard.ime_service.state.KeyboardType
@@ -294,7 +295,7 @@ private fun renderNonCustomKeyboardPreviewType(
                     layoutType = layoutType,
                     inputMode = inputMode.name
                 )
-                views.flick.setKeyboard(layout)
+                views.flick.setKeyboard(layout, KeyHitTestMode.NEAREST_KEY)
             }
         }
 

--- a/custom_keyboard/build.gradle
+++ b/custom_keyboard/build.gradle
@@ -30,6 +30,8 @@ android {
     }
 
     testOptions {
+        // Keep the device test window free of Android's deprecated-target warning dialog.
+        targetSdk = 36
         unitTests.includeAndroidResources = true
     }
 }

--- a/custom_keyboard/src/androidTest/AndroidManifest.xml
+++ b/custom_keyboard/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="com.kazumaproject.custom_keyboard.view.SumireNearestKeyTestActivity"
+            android:exported="false"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
+    </application>
+</manifest>

--- a/custom_keyboard/src/androidTest/java/com/kazumaproject/custom_keyboard/view/SumireNearestKeyInstrumentedTest.kt
+++ b/custom_keyboard/src/androidTest/java/com/kazumaproject/custom_keyboard/view/SumireNearestKeyInstrumentedTest.kt
@@ -1,0 +1,149 @@
+package com.kazumaproject.custom_keyboard.view
+
+import android.app.Activity
+import android.content.Intent
+import android.graphics.Rect
+import android.os.Bundle
+import android.os.SystemClock
+import android.view.Gravity
+import android.view.InputDevice
+import android.view.MotionEvent
+import android.widget.FrameLayout
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kazumaproject.custom_keyboard.data.FlickDirection
+import com.kazumaproject.custom_keyboard.data.KeyAction
+import com.kazumaproject.custom_keyboard.data.KeyItem
+import com.kazumaproject.custom_keyboard.data.KeyboardInputMode
+import com.kazumaproject.custom_keyboard.data.KeyboardLayout
+import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
+
+/** Test-only window: exercises production Sumire views without replacing the user's IME. */
+class SumireNearestKeyTestActivity : Activity() {
+    lateinit var keyboard: FlickKeyboardView
+    private lateinit var root: FrameLayout
+    private lateinit var definition: KeyboardLayout
+    val actions = CopyOnWriteArrayList<KeyAction>()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        root = FrameLayout(this)
+        setContentView(root)
+        window.addFlags(android.view.WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+    }
+
+    fun configure(scale: Int, floating: Boolean) {
+        root.removeAllViews()
+        actions.clear()
+        definition = KeyboardDefaultLayouts.createFinalLayout(
+            KeyboardInputMode.HIRAGANA, emptyMap(), "toggle", "default"
+        )
+        keyboard = FlickKeyboardView(this).apply {
+            applyKeySizing(scale, scale, 100, 14f, 14f)
+            setKeyboard(definition, KeyHitTestMode.NEAREST_KEY)
+            setOnKeyboardActionListener(object : FlickKeyboardView.OnKeyboardActionListener {
+                override fun onPress(action: KeyAction) = Unit
+                override fun onAction(action: KeyAction, isFlick: Boolean) { actions += action }
+                override fun onActionLongPress(action: KeyAction) = Unit
+                override fun onActionUpAfterLongPress(action: KeyAction) = Unit
+                override fun onFlickDirectionChanged(direction: FlickDirection) = Unit
+                override fun onFlickActionLongPress(action: KeyAction) = Unit
+                override fun onFlickActionUpAfterLongPress(action: KeyAction, isFlick: Boolean) = Unit
+            })
+        }
+        val width = if (floating) (resources.displayMetrics.widthPixels * 0.75f).toInt() else -1
+        root.addView(keyboard, FrameLayout.LayoutParams(width, if (floating) 600 else 800).apply {
+            gravity = if (floating) Gravity.CENTER else Gravity.BOTTOM
+        })
+    }
+
+    fun keyBounds(label: String): Rect {
+        val index = definition.items.indexOfFirst { it is KeyItem && it.keyData.label == label }
+        check(index >= 0) { "Missing Sumire key $label" }
+        val key = keyboard.getChildAt(index)
+        val origin = IntArray(2).also(key::getLocationOnScreen)
+        return Rect(origin[0], origin[1], origin[0] + key.width, origin[1] + key.height)
+    }
+}
+
+@RunWith(AndroidJUnit4::class)
+class SumireNearestKeyInstrumentedTest {
+    @Test fun realSumireLayout_acceptsGapTapsAtBothSizesAndWindowPositions() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val activity = instrumentation.startActivitySync(Intent(
+            instrumentation.context, SumireNearestKeyTestActivity::class.java
+        ).addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)) as SumireNearestKeyTestActivity
+        var count = 0
+        try {
+            for (floating in listOf(false, true)) for (scale in listOf(100, 0)) {
+                instrumentation.runOnMainSync { activity.configure(scale, floating) }
+                instrumentation.waitForIdleSync()
+                val deadline = SystemClock.uptimeMillis() + 3000
+                var ready = false
+                while (!ready && SystemClock.uptimeMillis() < deadline) {
+                    instrumentation.runOnMainSync {
+                        ready = activity.hasWindowFocus() && activity.keyboard.width > 0 &&
+                            activity.keyboard.getChildAt(0).width > 0
+                    }
+                    if (!ready) SystemClock.sleep(25)
+                }
+                assertTrue("Test window must be focused and laid out; unlock the device first", ready)
+                lateinit var a: Rect
+                lateinit var ka: Rect
+                lateinit var ta: Rect
+                instrumentation.runOnMainSync {
+                    a = activity.keyBounds("あ")
+                    ka = activity.keyBounds("か")
+                    ta = activity.keyBounds("た")
+                }
+                assertTrue("Expected horizontal gap: a=$a ka=$ka", a.right < ka.left)
+                assertTrue("Expected vertical gap: a=$a ta=$ta", a.bottom < ta.top)
+                val midX = (a.exactCenterX() + ka.exactCenterX()) / 2f
+                val midY = (a.exactCenterY() + ta.exactCenterY()) / 2f
+                val points = listOf(
+                    Triple(a.exactCenterX(), a.exactCenterY(), "あ"),
+                    Triple(ka.exactCenterX(), ka.exactCenterY(), "か"),
+                    Triple(midX - 1, a.exactCenterY(), "あ"),
+                    Triple(midX + 1, a.exactCenterY(), "か"),
+                    Triple(a.exactCenterX(), midY - 1, "あ"),
+                    Triple(a.exactCenterX(), midY + 1, "た"),
+                    Triple(midX - 1, midY - 1, "あ"),
+                    Triple(midX + 1, midY + 1, "な")
+                )
+                assertTrue(midX >= a.right && midX < ka.left)
+                assertTrue(midY >= a.bottom && midY < ta.top)
+                val screenshot = instrumentation.uiAutomation.takeScreenshot()
+                val output = File(instrumentation.context.getExternalFilesDir(null),
+                    "sumire-nearest-$scale-$floating.png")
+                output.outputStream().use {
+                    screenshot.compress(android.graphics.Bitmap.CompressFormat.PNG, 100, it)
+                }
+                screenshot.recycle()
+                for ((x, y, expected) in points) repeat(3) {
+                    activity.actions.clear()
+                    val down = SystemClock.uptimeMillis()
+                    for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_UP)) {
+                        val event = MotionEvent.obtain(down, SystemClock.uptimeMillis(), action, x, y, 0)
+                        event.source = InputDevice.SOURCE_TOUCHSCREEN
+                        try { assertTrue(instrumentation.uiAutomation.injectInputEvent(event, true)) }
+                        finally { event.recycle() }
+                        if (action == MotionEvent.ACTION_DOWN) SystemClock.sleep(40)
+                    }
+                    instrumentation.waitForIdleSync()
+                    assertEquals("scale=$scale floating=$floating ($x,$y)",
+                        listOf(KeyAction.Text(expected)), activity.actions.toList())
+                    count++
+                }
+            }
+            println("SUMIRE_NEAREST_KEY_RESULT taps=$count failures=0")
+        } finally {
+            instrumentation.runOnMainSync { activity.finish() }
+        }
+    }
+}

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardView.kt
@@ -192,6 +192,7 @@ class FlickKeyboardView @JvmOverloads constructor(
     private val canonicalGuideLabels =
         IdentityHashMap<AutoSizeButton, AutoSizeButton.FlickGuideLabels>()
     private var currentLayout: KeyboardLayout? = null
+    private var keyHitTestMode = KeyHitTestMode.KEY_BOUNDS
     private var controllerRebindPending = false
     private var keyboardRenderRevision: Int = 0
     private var renderedKeyboardRenderRevision: Int = -1
@@ -574,8 +575,15 @@ class FlickKeyboardView @JvmOverloads constructor(
         return ContextCompat.getDrawable(context, drawableResId)
     }
 
+    /** Nearest-key input is opt-in; omitting the mode restores legacy bounds-only behavior. */
+    @JvmOverloads
     @SuppressLint("ClickableViewAccessibility")
-    fun setKeyboard(layout: KeyboardLayout) {
+    fun setKeyboard(layout: KeyboardLayout, hitTestMode: KeyHitTestMode = KeyHitTestMode.KEY_BOUNDS) {
+        if (keyHitTestMode != hitTestMode) {
+            cancelTrackedTouchState()
+            doubleTapActionDispatcher.cancel()
+        }
+        keyHitTestMode = hitTestMode
         setKeyboard(layout, forceRebuild = false)
     }
 
@@ -2837,7 +2845,9 @@ class FlickKeyboardView @JvmOverloads constructor(
     private data class MotionTarget(
         val view: View,
         val displayOriginX: Float,
-        val displayOriginY: Float
+        val displayOriginY: Float,
+        val localOffsetX: Float = 0f,
+        val localOffsetY: Float = 0f
     )
 
     private val motionTargets = mutableMapOf<Int, MotionTarget>()
@@ -2882,6 +2892,9 @@ class FlickKeyboardView @JvmOverloads constructor(
     }
 
     private fun findTargetView(displayX: Float, displayY: Float): MotionTarget? {
+        if (keyHitTestMode == KeyHitTestMode.NEAREST_KEY) {
+            return findNearestKeyTarget(displayX, displayY)
+        }
         val location = IntArray(2)
         for (i in 0 until childCount) {
             val child = getChildAt(i)
@@ -2903,6 +2916,55 @@ class FlickKeyboardView @JvmOverloads constructor(
         }
 
         return null
+    }
+
+    /**
+     * Sumire treats the entire keyboard surface as key input, independently of visual margins.
+     * Read current screen bounds at DOWN (also POINTER_DOWN), never cached layout geometry.
+     * Custom layouts keep the legacy bounds-only path, including their intentional empty cells.
+     */
+    private fun findNearestKeyTarget(displayX: Float, displayY: Float): MotionTarget? {
+        if (!displayX.isFinite() || !displayY.isFinite() || visibility != View.VISIBLE || !isEnabled) {
+            return null
+        }
+        val location = IntArray(2)
+        getLocationOnScreen(location)
+        if (displayX < location[0] || displayX >= location[0] + width ||
+            displayY < location[1] || displayY >= location[1] + height
+        ) return null
+
+        var nearest: MotionTarget? = null
+        var nearestDistance = Float.POSITIVE_INFINITY
+        for (info in keyInfos) {
+            val key = info.view
+            if (key.visibility != View.VISIBLE || !key.isEnabled || key.width <= 0 || key.height <= 0) {
+                continue
+            }
+            key.getLocationOnScreen(location)
+            val left = location[0].toFloat()
+            val top = location[1].toFloat()
+            if (displayX >= left && displayX < left + key.width &&
+                displayY >= top && displayY < top + key.height
+            ) return MotionTarget(key, left, top)
+
+            val dx = displayX - (left + key.width / 2f)
+            val dy = displayY - (top + key.height / 2f)
+            val distance = dx * dx + dy * dy
+            // Strict comparison deliberately preserves layout order for equal distances.
+            if (distance < nearestDistance) {
+                nearestDistance = distance
+                val localX = displayX - left
+                val localY = displayY - top
+                nearest = MotionTarget(
+                    view = key,
+                    displayOriginX = left,
+                    displayOriginY = top,
+                    localOffsetX = localX.coerceIn(0f, key.width - 1f) - localX,
+                    localOffsetY = localY.coerceIn(0f, key.height - 1f) - localY
+                )
+            }
+        }
+        return nearest
     }
 
     private fun MotionEvent.displayX(pointerIndex: Int): Float {
@@ -2939,9 +3001,11 @@ class FlickKeyboardView @JvmOverloads constructor(
             displayY,
             source.metaState
         )
+        // A fixed local translation admits a margin-origin touch without changing raw screen
+        // coordinates or movement deltas. Re-clamping MOVE would distort/cancel flick gestures.
         childEvent.offsetLocation(
-            -target.displayOriginX,
-            -target.displayOriginY
+            -target.displayOriginX + target.localOffsetX,
+            -target.displayOriginY + target.localOffsetY
         )
         target.view.dispatchTouchEvent(childEvent)
         childEvent.recycle()

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/KeyHitTestMode.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/view/KeyHitTestMode.kt
@@ -1,0 +1,7 @@
+package com.kazumaproject.custom_keyboard.view
+
+/** Input surface policy; custom layouts retain their intentional untouchable gaps by default. */
+enum class KeyHitTestMode {
+    KEY_BOUNDS,
+    NEAREST_KEY
+}

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardViewNearestKeyTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/view/FlickKeyboardViewNearestKeyTest.kt
@@ -1,0 +1,315 @@
+package com.kazumaproject.custom_keyboard.view
+
+import android.app.Activity
+import android.content.Context
+import android.os.Looper
+import android.view.ContextThemeWrapper
+import android.view.MotionEvent
+import android.view.View
+import androidx.test.core.app.ApplicationProvider
+import com.kazumaproject.custom_keyboard.data.FlickAction
+import com.kazumaproject.custom_keyboard.data.FlickDirection
+import com.kazumaproject.custom_keyboard.data.GridPlacement
+import com.kazumaproject.custom_keyboard.data.KeyAction
+import com.kazumaproject.custom_keyboard.data.KeyData
+import com.kazumaproject.custom_keyboard.data.KeyItem
+import com.kazumaproject.custom_keyboard.data.KeyType
+import com.kazumaproject.custom_keyboard.data.KeyboardLayout
+import com.kazumaproject.custom_keyboard.data.SpacerItem
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import java.util.concurrent.TimeUnit
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [28, 35])
+class FlickKeyboardViewNearestKeyTest {
+    private val actions = mutableListOf<KeyAction>()
+    private val longs = mutableListOf<KeyAction>()
+    private val releases = mutableListOf<KeyAction>()
+    private val listener = object : FlickKeyboardView.OnKeyboardActionListener {
+        override fun onPress(action: KeyAction) = Unit
+        override fun onAction(action: KeyAction, isFlick: Boolean) { actions += action }
+        override fun onActionLongPress(action: KeyAction) { longs += action }
+        override fun onActionUpAfterLongPress(action: KeyAction) { releases += action }
+        override fun onFlickDirectionChanged(direction: FlickDirection) = Unit
+        override fun onFlickActionLongPress(action: KeyAction) { longs += action }
+        override fun onFlickActionUpAfterLongPress(action: KeyAction, isFlick: Boolean) { releases += action }
+    }
+
+    @Test fun gapsAndIntersections_selectNearestCenter_atNormalAndSmallSizes() {
+        for (size in listOf(100, 0)) {
+            val view = keyboard()
+            view.applyKeySizing(size, size, 100, 14f, 14f)
+            layout(view)
+            val a = view.getChildAt(0)
+            val b = view.getChildAt(1)
+            val c = view.getChildAt(2)
+            val gapX = (a.right + b.left) / 2f
+            val gapY = (a.bottom + c.top) / 2f
+            assertTrue(a.right < b.left && a.bottom < c.top)
+            for ((x, y, expected) in listOf(
+                Triple(gapX - 1, a.cy(), "a"), Triple(gapX + 1, a.cy(), "b"),
+                Triple(a.cx(), gapY - 1, "a"), Triple(a.cx(), gapY + 1, "c"),
+                Triple(gapX - 1, gapY - 1, "a"), Triple(gapX + 1, gapY + 1, "d")
+            )) {
+                actions.clear()
+                tap(view, x, y)
+                assertEquals("size=$size point=($x,$y)", listOf(KeyAction.Text(expected)), actions)
+            }
+        }
+    }
+
+    @Test fun insideKeyWinsEvenWhenAnotherCenterIsCloser_andTieUsesLayoutOrder() {
+        val view = keyboard()
+        view.getChildAt(0).layout(10, 10, 300, 110)
+        view.getChildAt(1).layout(310, 10, 330, 110)
+        view.getChildAt(2).visibility = View.INVISIBLE
+        view.getChildAt(3).visibility = View.INVISIBLE
+        tap(view, 299f, 60f)
+        assertEquals(listOf(KeyAction.Text("a")), actions)
+        view.getChildAt(0).layout(10, 10, 110, 110)
+        view.getChildAt(1).layout(130, 10, 230, 110)
+        actions.clear()
+        tap(view, 120f, 60f)
+        assertEquals(listOf(KeyAction.Text("a")), actions)
+    }
+
+    @Test fun disabledInvisibleAndZeroSizedKeys_areNeverFallbackTargets() {
+        val view = keyboard()
+        view.getChildAt(0).isEnabled = false
+        view.getChildAt(1).visibility = View.INVISIBLE
+        view.getChildAt(2).layout(0, 0, 0, 0)
+        tap(view, 1f, 1f)
+        assertEquals(listOf(KeyAction.Text("d")), actions)
+        actions.clear()
+        view.getChildAt(3).visibility = View.GONE
+        tap(view, 1f, 1f)
+        assertTrue(actions.isEmpty())
+    }
+
+    @Test fun outsideKeyboardDoesNotSelectAnyKey() {
+        val view = keyboard()
+        for ((x, y) in listOf(-0.5f to 100f, 600f to 100f, 100f to -1f, 100f to 400f)) {
+            tap(view, x, y)
+        }
+        assertTrue(actions.isEmpty())
+    }
+
+    @Test fun switchingToDefaultPolicyCancelsGesture_evenWhenViewsAreReused() {
+        val view = keyboard()
+        val first = view.getChildAt(0)
+        event(view, MotionEvent.ACTION_DOWN, 1f, 1f)
+        view.setKeyboard(keys())
+        assertSame(first, view.getChildAt(0))
+        event(view, MotionEvent.ACTION_UP, 1f, 1f)
+        tap(view, 1f, 1f)
+        assertTrue(actions.isEmpty())
+        tap(view, first.cx(), first.cy())
+        assertEquals(listOf(KeyAction.Text("a")), actions)
+    }
+
+    @Test fun cancelAndLayoutReplacement_doNotCommitOrLeavePressedKeys() {
+        val view = keyboard()
+        event(view, MotionEvent.ACTION_DOWN, 1f, 1f)
+        assertTrue(view.getChildAt(0).isPressed)
+        event(view, MotionEvent.ACTION_CANCEL, 1f, 1f)
+        assertFalse(view.getChildAt(0).isPressed)
+        event(view, MotionEvent.ACTION_DOWN, 1f, 1f)
+        val replacement = keys().keys.map { it.copy(action = KeyAction.Text("replacement")) }
+        view.setKeyboard(KeyboardLayout(replacement, emptyMap(), 2, 2), KeyHitTestMode.NEAREST_KEY)
+        layout(view)
+        event(view, MotionEvent.ACTION_UP, 1f, 1f)
+        shadowOf(Looper.getMainLooper()).idleFor(1500, TimeUnit.MILLISECONDS)
+        assertTrue(actions.isEmpty())
+        assertTrue(longs.isEmpty())
+        assertFalse(view.getChildAt(0).isPressed)
+    }
+
+    @Test fun farOutsideVisualKey_smallMoveStillClicksFunctionalKey() {
+        val view = keyboard()
+        val data = keys().keys.mapIndexed { i, key ->
+            if (i == 0) key.copy(action = KeyAction.Paste, isSpecialKey = true) else key
+        }
+        view.setKeyboard(KeyboardLayout(data, emptyMap(), 2, 2), KeyHitTestMode.NEAREST_KEY)
+        layout(view)
+        view.getChildAt(0).layout(100, 100, 180, 180)
+        for (i in 1..3) view.getChildAt(i).isEnabled = false
+        // A start more than the cancellation slop outside the visual key must remain valid.
+        event(view, MotionEvent.ACTION_DOWN, 1f, 120f)
+        event(view, MotionEvent.ACTION_MOVE, 2f, 120f)
+        event(view, MotionEvent.ACTION_UP, 2f, 120f)
+        assertEquals(listOf(KeyAction.Paste), actions)
+    }
+
+    @Test fun localCorrectionIsConstant_andRawScreenCoordinatesArePreserved() {
+        val view = keyboard()
+        val key = view.getChildAt(0)
+        key.layout(100, 100, 180, 180)
+        for (i in 1..3) view.getChildAt(i).isEnabled = false
+        val samples = mutableListOf<List<Float>>()
+        key.setOnTouchListener { _, e -> samples += listOf(e.x, e.y, e.rawX, e.rawY); true }
+        event(view, MotionEvent.ACTION_DOWN, 1f, 120f)
+        event(view, MotionEvent.ACTION_MOVE, 31f, 140f)
+        event(view, MotionEvent.ACTION_UP, 41f, 145f)
+        assertEquals(3, samples.size)
+        assertTrue(samples[0][0] >= 0 && samples[0][0] < key.width)
+        assertEquals(30f, samples[1][0] - samples[0][0], 0f)
+        assertEquals(20f, samples[1][1] - samples[0][1], 0f)
+        val origin = IntArray(2).also(view::getLocationOnScreen)
+        assertEquals(listOf(1f, 31f, 41f).map { it + origin[0] }, samples.map { it[2] })
+        assertEquals(listOf(120f, 140f, 145f).map { it + origin[1] }, samples.map { it[3] })
+    }
+
+    @Test fun longPressFromMargin_withSmallMove_firesOnceWithoutTap() {
+        val view = keyboard()
+        view.setLongPressTimeout(200L)
+        event(view, MotionEvent.ACTION_DOWN, 1f, 1f)
+        event(view, MotionEvent.ACTION_MOVE, 2f, 2f)
+        shadowOf(Looper.getMainLooper()).idleFor(210, TimeUnit.MILLISECONDS)
+        assertEquals(listOf(KeyAction.Text("a")), longs)
+        event(view, MotionEvent.ACTION_UP, 2f, 2f)
+        shadowOf(Looper.getMainLooper()).idleFor(500, TimeUnit.MILLISECONDS)
+        assertEquals(listOf(KeyAction.Text("a")), releases)
+        assertTrue(actions.isEmpty())
+        assertFalse(view.getChildAt(0).isPressed)
+    }
+
+    @Test fun spacerIsNotAKey_andDefaultPolicyKeepsTheEmptyCellUntouchable() {
+        val view = keyboard()
+        val data = keys().keys.first()
+        val layout = KeyboardLayout(listOf(data), emptyMap(), 2, 1,
+            items = listOf(KeyItem("a", data, GridPlacement(0, 0)),
+                SpacerItem("space", GridPlacement(0, 2))))
+        view.setKeyboard(layout, KeyHitTestMode.NEAREST_KEY)
+        layout(view)
+        tap(view, 450f, 100f)
+        assertEquals(listOf(KeyAction.Text("a")), actions)
+        actions.clear()
+        view.setKeyboard(layout)
+        tap(view, 450f, 100f)
+        assertTrue(actions.isEmpty())
+    }
+
+    @Test fun layoutResizeAndScreenOffset_useFreshBounds_withoutLosingPolicy() {
+        val view = keyboard()
+        view.applyKeySizing(0, 0, 100, 14f, 14f)
+        layout(view)
+        view.offsetLeftAndRight(37)
+        view.offsetTopAndBottom(83)
+        val a = view.getChildAt(0)
+        val b = view.getChildAt(1)
+        tap(view, (a.right + b.left) / 2f + 1f, a.cy())
+        assertEquals(listOf(KeyAction.Text("b")), actions)
+        actions.clear()
+        view.measure(View.MeasureSpec.makeMeasureSpec(400, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(300, View.MeasureSpec.EXACTLY))
+        view.layout(37, 83, 437, 383)
+        tap(view, (a.right + b.left) / 2f - 1f, a.cy())
+        assertEquals(listOf(KeyAction.Text("a")), actions)
+    }
+
+    @Test fun movingWindowOriginAfterDown_doesNotShiftChildGestureCoordinates() {
+        val view = keyboard()
+        val key = view.getChildAt(0)
+        val received = mutableListOf<Pair<Float, Float>>()
+        key.setOnTouchListener { _, e -> received += e.x to e.y; true }
+        event(view, MotionEvent.ACTION_DOWN, 1f, 1f)
+        view.offsetTopAndBottom(80)
+        event(view, MotionEvent.ACTION_MOVE, 2f, -78f)
+        event(view, MotionEvent.ACTION_UP, 2f, -78f)
+        assertEquals(3, received.size)
+        assertEquals(1f, received[1].first - received[0].first, 0f)
+        assertEquals(1f, received[1].second - received[0].second, 0f)
+    }
+
+    @Test fun secondFingerCommitsFirstOnce_andUsesItsOwnNearestTarget() {
+        val view = keyboard()
+        fun multi(action: Int, points: List<Pair<Float, Float>>) {
+            val origin = IntArray(2).also(view::getLocationOnScreen)
+            val properties = points.indices.map { i -> MotionEvent.PointerProperties().apply {
+                id = if (i == 0) 7 else 11
+                toolType = MotionEvent.TOOL_TYPE_FINGER
+            } }.toTypedArray()
+            val coords = points.map { (px, py) -> MotionEvent.PointerCoords().apply {
+                x = px + origin[0]; y = py + origin[1]; pressure = 1f; size = 1f
+            } }.toTypedArray()
+            val e = MotionEvent.obtain(100, 120, action, points.size, properties, coords,
+                0, 0, 1f, 1f, 0, 0, android.view.InputDevice.SOURCE_TOUCHSCREEN, 0)
+            e.offsetLocation(-origin[0].toFloat(), -origin[1].toFloat())
+            view.onTouchEvent(e)
+            e.recycle()
+        }
+        multi(MotionEvent.ACTION_DOWN, listOf(1f to 1f))
+        multi(MotionEvent.ACTION_POINTER_DOWN or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT),
+            listOf(1f to 1f, 599f to 1f))
+        assertEquals(listOf(KeyAction.Text("a")), actions)
+        multi(MotionEvent.ACTION_POINTER_UP or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT),
+            listOf(1f to 1f, 599f to 1f))
+        multi(MotionEvent.ACTION_UP, listOf(1f to 1f))
+        assertEquals(listOf(KeyAction.Text("a"), KeyAction.Text("b")), actions)
+        assertFalse(view.getChildAt(0).isPressed)
+        assertFalse(view.getChildAt(1).isPressed)
+    }
+
+    @Test fun standardFlickFromGap_keepsOriginalKeyAndRealMovement() {
+        val view = keyboard()
+        val data = keys().keys.map { it.copy(keyType = KeyType.STANDARD_FLICK) }
+        val maps = data.associate { it.label to listOf(mapOf(
+            FlickDirection.TAP to FlickAction.Input(it.label),
+            FlickDirection.UP_RIGHT_FAR to FlickAction.Input(it.label + "-right")
+        )) }
+        view.setKeyboard(KeyboardLayout(data, maps, 2, 2), KeyHitTestMode.NEAREST_KEY)
+        layout(view)
+        val a = view.getChildAt(0)
+        val b = view.getChildAt(1)
+        val startX = (a.right + b.left) / 2f - 1f
+        event(view, MotionEvent.ACTION_DOWN, startX, a.cy())
+        event(view, MotionEvent.ACTION_MOVE, startX + 100f, a.cy())
+        event(view, MotionEvent.ACTION_UP, startX + 100f, a.cy())
+        assertEquals(listOf(KeyAction.Text("a-right")), actions)
+    }
+
+    private fun keyboard() = FlickKeyboardView(ContextThemeWrapper(
+        ApplicationProvider.getApplicationContext<Context>(),
+        com.google.android.material.R.style.Theme_Material3_DayNight_NoActionBar
+    )).apply {
+        Robolectric.buildActivity(Activity::class.java).setup().get().setContentView(this)
+        setOnKeyboardActionListener(listener)
+        setKeyboard(keys(), KeyHitTestMode.NEAREST_KEY)
+        layout(this)
+    }
+
+    private fun keys() = KeyboardLayout(
+        keys = listOf("a", "b", "c", "d").mapIndexed { i, label ->
+            KeyData(label = label, row = i / 2, column = i % 2,
+                isFlickable = false, action = KeyAction.Text(label), keyId = label, keyType = KeyType.NORMAL)
+        }, flickKeyMaps = emptyMap(), columnCount = 2, rowCount = 2
+    )
+
+    private fun layout(view: FlickKeyboardView) {
+        view.measure(View.MeasureSpec.makeMeasureSpec(600, View.MeasureSpec.EXACTLY),
+            View.MeasureSpec.makeMeasureSpec(400, View.MeasureSpec.EXACTLY))
+        view.layout(0, 0, 600, 400)
+    }
+    private fun View.cx() = (left + right) / 2f
+    private fun View.cy() = (top + bottom) / 2f
+    private fun event(view: FlickKeyboardView, action: Int, x: Float, y: Float) {
+        val origin = IntArray(2).also(view::getLocationOnScreen)
+        val e = MotionEvent.obtain(100, 120, action, x + origin[0], y + origin[1], 0)
+        e.offsetLocation(-origin[0].toFloat(), -origin[1].toFloat())
+        view.onTouchEvent(e)
+        e.recycle()
+    }
+    private fun tap(view: FlickKeyboardView, x: Float, y: Float) {
+        event(view, MotionEvent.ACTION_DOWN, x, y)
+        event(view, MotionEvent.ACTION_UP, x, y)
+    }
+}


### PR DESCRIPTION
## 日本語

スミレ入力βでキーを小さくすると、表示キーの間のマージンから押し始めたタッチが認識されませんでした。このPRでは見た目を維持し、キー矩形内を優先したうえで、矩形外のタッチを中心が最も近いキーへ割り当てます。

### 変更内容

- 判定方式をレイアウト設定時の明示的な指定にし、スミレのIME表示と設定プレビューだけで有効化。通常・フローティングのスミレ設定経路で共通に使用します。既定値は従来の矩形内判定で、カスタム配列の意図的な空白や「キー外で貼り付けない」動作を維持します。TenKey・QWERTYの製品コードは変更していません。
- キーボードView内に限り、表示中・有効・正のサイズを持つ実キーを対象に選択。同距離はレイアウト順で確定し、スペーサー自体やView外は選択しません。押下時の現在の画面上の位置を使うため、サイズ・配置変更後に古い範囲を参照しません。
- 隙間から選んだキーには、ジェスチャー全体で一定の子View座標補正を適用。微小なMOVEでキャンセルされる問題を防ぎ、画面座標とフリック移動量は維持します。押下後に対象キーを選び直しません。
- 判定方式の切り替え時は進行中の入力をキャンセル。既存の1引数呼び出しを維持し、カスタム配列への切り替えで最近傍判定が残らないようにしています。

### 検証・レビュー

- 再現テストは実装前に失敗することを確認。最終版の `:custom_keyboard:testDebugUnitTest` は **225件成功**。新規14シナリオをAPI 28/35で実行した28件を含みます。
- 隙間・交差点、矩形内優先、同距離、異なるキーサイズ、非表示／無効／ゼロサイズ、スペーサー、View外、長押し、フリック、微小移動、複数指、CANCEL、配列置換、判定方式解除、表示位置変更を検証。
- Pixel 6 / Android 17で新規instrumentation testが成功。実際のスミレ日本語配列をテスト用Activityに表示し、通常／縮小サイズ × 下部全幅／中央の縮小配置 × 8座標 × 各3回、**計96タップで期待するアクションを確認**しました。通常のIMEサービス全体ではなく、製品のView・配列・イベント転送を端末上で検証したものです。ユーザーのIME選択・キーボード設定は変更していません。
- `:app:compileFullStandardDebugKotlin` 成功、`git diff --check` 成功。
- 差分を自己レビューし、対象限定、現在座標の参照、座標補正の一定性、指ごとの状態、キャンセル、呼び出し互換性を確認しました。未解決の指摘はありません。
- テストAPKのみtarget SDKを36に設定し、実機測定を妨げる旧target SDKの警告ダイアログを防止。製品アプリのtarget SDKは変更していません。

## English

Shrinking Sumire beta keys left visual margins where a touch could start without selecting a key. This change preserves the appearance, prioritizes touches inside a key rectangle, and otherwise selects the key with the nearest center.

### Changes

- Opt in through the layout-setting API only for Sumire IME surfaces and its settings preview. Existing callers default to bounds-only behavior, including custom layouts with intentional gaps. TenKey and QWERTY production code is unchanged.
- Restrict fallback to the keyboard View and visible, enabled, positive-sized real keys. Break distance ties in layout order; never select spacers themselves or points outside the keyboard. Read live screen bounds at each pointer down rather than caching geometry across layout changes.
- Apply a constant child-local translation throughout gestures that start in a margin. This prevents tiny moves from canceling those touches while preserving raw screen coordinates and flick deltas. Keep the initial target for the gesture.
- Cancel active input when the policy changes, retain the one-argument API, and restore bounds-only behavior when switching back to custom layouts.

### Validation and review

- Confirmed regression tests fail before implementation. **225 custom_keyboard unit tests pass**, including 14 new scenarios on API 28 and 35 (28 executions).
- Coverage includes gaps, intersections, direct-hit priority, ties, unequal sizes, excluded keys, spacers, surface boundaries, long press, flicks, small moves, multiple pointers, cancellation, layout replacement, policy reset, resizing, and screen-origin changes.
- The new instrumentation test passes on Pixel 6 / Android 17: **96 injected taps** over normal/shrunken keys and bottom/full-width versus centered/narrower placements. It renders the production Japanese Sumire layout and View in a test Activity; this is device-level View/dispatch validation, not an end-to-end IME-service test. The user's IME selection and keyboard settings remain unchanged.
- `:app:compileFullStandardDebugKotlin` and `git diff --check` pass.
- Completed a self-review of scope isolation, live geometry, constant coordinate correction, pointer state, cancellation, and API compatibility; no unresolved findings.
- Set target SDK 36 for the test APK only to avoid the deprecated-target dialog during device tests. Production target SDK is unchanged.

### Reproduction

With an unlocked Android device attached:

```sh
./gradlew :custom_keyboard:testDebugUnitTest \
  :custom_keyboard:connectedDebugAndroidTest \
  :app:compileFullStandardDebugKotlin \
  -Pandroid.testInstrumentationRunnerArguments.class=com.kazumaproject.custom_keyboard.view.SumireNearestKeyInstrumentedTest \
  -Pkotlin.compiler.execution.strategy=in-process
```

Base: `dev`; implemented in a separate worktree created from `dev`. Gboard investigation artifacts are not included.
