### PR TITLE
カスタムトグルの待機時間を反映 / Honor custom keyboard toggle timeout

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -1819,6 +1819,90 @@ class FastInputMatrixInstrumentedTest {
     }
 
     @Test
+    fun customToggleWaitPreferenceOnPhysicalDevice() {
+        runPhysicalDeviceSession("custom-toggle-timeout") { session ->
+            val dao = EntryPointAccessors.fromApplication(
+                session.context.applicationContext, KanaKanjiEngineEntryPoint::class.java,
+            ).keyboardLayoutDao()
+            val fixtureIds = mutableListOf<Long>()
+            var host: ActivityScenario<FastInputHostActivity>? = null
+            try {
+                for (direct in listOf(false, true)) {
+                    val stableId = "toggle-timeout-qa-$direct-${System.currentTimeMillis()}"
+                    val layoutId = runBlocking {
+                        dao.insertFullKeyboardLayout(
+                            layout = CustomKeyboardLayout(
+                                name = "Toggle timeout QA", columnCount = 1, rowCount = 1,
+                                stableId = stableId, sortOrder = dao.getMaxSortOrder() + 1,
+                                isDirectMode = direct,
+                            ),
+                            keys = listOf(KeyDefinition(
+                                ownerLayoutId = 0, label = "TOGGLE-QA", row = 0, column = 0,
+                                keyType = KeyType.PETAL_FLICK, keyIdentifier = stableId,
+                                textInputBehavior = com.kazumaproject.custom_keyboard.data.KeyTextInputBehavior.TOGGLE.dbValue,
+                            )),
+                            flicksMap = mapOf(stableId to
+                                com.kazumaproject.custom_keyboard.data.PETAL_TOGGLE_DIRECTIONS
+                                    .take(2).zip(listOf("あ", "お")).map { (direction, text) ->
+                                        com.kazumaproject.markdownhelperkeyboard.custom_keyboard.data.FlickMapping(
+                                            ownerKeyId = 0, flickDirection = direction,
+                                            actionType = "INPUT_TEXT", actionValue = text,
+                                        )
+                                    }),
+                            circularFlicksMap = emptyMap(), twoStepFlicksMap = emptyMap(),
+                            longPressFlicksMap = emptyMap(), twoStepLongPressFlicksMap = emptyMap(),
+                        )
+                    }
+                    fixtureIds += layoutId
+                    check(session.preferences.edit()
+                        .putString("keyboard_order_preference", """["CUSTOM","TENKEY","SUMIRE","QWERTY","ROMAJI"]""")
+                        .putBoolean("save_last_used_keyboard", false)
+                        .putBoolean("remember_last_custom_keyboard_preference", true)
+                        .putString("last_used_custom_keyboard_stable_id", stableId)
+                        .putBoolean("keyboard_floating_preference", false)
+                        .putBoolean("live_conversion_preference", false)
+                        .putBoolean("custom_keyboard_suggestion_preference", false)
+                        .putInt("candidate_view_height_dp_preference", 110)
+                        .putInt("candidate_view_empty_height_dp_preference", 110)
+                        .commit())
+                    val scenario = host ?: launchHost(session.context).also { host = it }
+                    // Re-entering the editor mirrors returning from the settings screen.
+                    for ((timeout, interval) in listOf(1000 to 500L, 200 to 500L, 1000 to 500L, 200 to 50L)) {
+                        check(session.preferences.edit()
+                            .putInt("time_same_pronounce_typing_preference", timeout).commit())
+                        restartInput(scenario)
+                        SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                        val root = findVisibleNodeById("custom_layout_default")
+                            ?: throw SetupException("Custom keyboard missing")
+                        val key = findDescendant(root) {
+                            it.isVisibleToUser && (it.text?.toString() == "TOGGLE-QA" ||
+                                it.contentDescription?.toString() == "TOGGLE-QA")
+                        } ?: throw SetupException("Toggle key missing")
+                        assertTrue(injectTapPairAtDownInterval(key.screenRect().center, interval))
+                        val expected = if (interval < timeout) "お" else "ああ"
+                        assertEquals("direct=$direct timeout=$timeout interval=$interval",
+                            expected, awaitEditorText(scenario) { it == expected })
+                        instrumentation.waitForIdleSync()
+                        SystemClock.sleep(250)
+                        assertEquals("Text changed after settling", expected, readText(scenario))
+                        scenario.onActivity {
+                            val composingStart = android.view.inputmethod.BaseInputConnection
+                                .getComposingSpanStart(it.editText.text)
+                            assertEquals("Unexpected composition mode for direct=$direct",
+                                !direct, composingStart >= 0)
+                        }
+                        saveScreenshot(session, "direct-$direct-timeout-$timeout-interval-$interval")
+                        sendProgress("CUSTOM_TOGGLE_OK direct=$direct timeout=$timeout interval=$interval text=$expected\n")
+                    }
+                }
+            } finally {
+                host?.close()
+                runBlocking { fixtureIds.forEach { dao.deleteLayout(it) } }
+            }
+        }
+    }
+
+    @Test
     fun customKeyboardAcceptsInputOnPhysicalDevice() {
         runPhysicalDeviceSession("custom-input") { session ->
             var scenario: ActivityScenario<FastInputHostActivity>? = null

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputState.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputState.kt
@@ -10,11 +10,14 @@ internal class CustomToggleInputState {
     private var values: List<String> = emptyList()
     private var index = -1
     private var lastEmittedText: String? = null
+    private var lastInputTimeMillis: Long? = null
 
     fun next(
         keyIdentity: String,
         values: List<String>,
         outputValues: List<String> = values,
+        nowMillis: Long,
+        timeoutMillis: Long,
     ): Mutation? {
         if (values.isEmpty() || values.size != outputValues.size) {
             reset()
@@ -24,7 +27,11 @@ internal class CustomToggleInputState {
             reset()
             return Mutation.Append(outputValues.first())
         }
+        val elapsedMillis = lastInputTimeMillis?.let { nowMillis - it }
+        val expired = elapsedMillis == null || elapsedMillis < 0 || elapsedMillis >= timeoutMillis
+        lastInputTimeMillis = nowMillis
         if (
+            expired ||
             this.keyIdentity != keyIdentity ||
             this.values != values ||
             index !in values.indices ||
@@ -48,5 +55,6 @@ internal class CustomToggleInputState {
         values = emptyList()
         index = -1
         lastEmittedText = null
+        lastInputTimeMillis = null
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -14084,6 +14084,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 keyIdentity = keyIdentity,
                 values = canonicalValues,
                 outputValues = emittedValues,
+                nowMillis = SystemClock.elapsedRealtime(),
+                timeoutMillis = delayTime?.toLong() ?: DEFAULT_DELAY_MS,
             )
         ) {
             null -> return

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleComposingInputTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleComposingInputTest.kt
@@ -8,8 +8,10 @@ import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
 import org.robolectric.util.ReflectionHelpers
 import org.robolectric.util.ReflectionHelpers.ClassParameter
+import java.time.Duration
 
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
@@ -56,5 +58,43 @@ class CustomToggleComposingInputTest {
         ReflectionHelpers.callInstanceMethod<Unit>(service, "resetCustomToggleState")
         tap("key", listOf("あ", "お"))
         assertEquals("ああ", text())
+    }
+
+    @Test fun configuredTimeout_preservesPreviousComposingCharacter() {
+        ReflectionHelpers.setField(service, "delayTime", 200)
+        tap("key", listOf("あ", "お"))
+        ShadowSystemClock.advanceBy(Duration.ofMillis(199))
+        tap("key", listOf("あ", "お"))
+        assertEquals("お", text())
+        ShadowSystemClock.advanceBy(Duration.ofMillis(200))
+        tap("key", listOf("あ", "お"))
+        assertEquals("おあ", text())
+        ShadowSystemClock.advanceBy(Duration.ofMillis(201))
+        tap("key", listOf("あ", "お"))
+        assertEquals("おああ", text())
+    }
+
+    @Test fun missingPreference_usesOneSecondTimeout() {
+        ReflectionHelpers.setField(service, "delayTime", null)
+        tap("key", listOf("あ", "お"))
+        ShadowSystemClock.advanceBy(Duration.ofMillis(999))
+        tap("key", listOf("あ", "お"))
+        assertEquals("お", text())
+        ShadowSystemClock.advanceBy(Duration.ofMillis(1000))
+        tap("key", listOf("あ", "お"))
+        assertEquals("おあ", text())
+    }
+
+    @Test fun updatedPreference_changesDeadlineForNextTap() {
+        ReflectionHelpers.setField(service, "delayTime", 1000)
+        tap("key", listOf("あ", "お"))
+        ReflectionHelpers.setField(service, "delayTime", 200)
+        ShadowSystemClock.advanceBy(Duration.ofMillis(200))
+        tap("key", listOf("あ", "お"))
+        assertEquals("ああ", text())
+        ReflectionHelpers.setField(service, "delayTime", 1000)
+        ShadowSystemClock.advanceBy(Duration.ofMillis(700))
+        tap("key", listOf("あ", "お"))
+        assertEquals("あお", text())
     }
 }

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleDirectInputTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleDirectInputTest.kt
@@ -1,0 +1,80 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import android.text.Selection
+import android.text.SpannableStringBuilder
+import android.view.View
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.ExtractedText
+import android.view.inputmethod.ExtractedTextRequest
+import androidx.test.core.app.ApplicationProvider
+import com.kazumaproject.markdownhelperkeyboard.databinding.MainLayoutBinding
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.doReturn
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.spy
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowSystemClock
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+import java.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class CustomToggleDirectInputTest {
+    private class Editor : BaseInputConnection(View(ApplicationProvider.getApplicationContext()), true) {
+        private val content = SpannableStringBuilder()
+        init { Selection.setSelection(content, 0) }
+        override fun getEditable() = content
+        override fun beginBatchEdit() = true
+        override fun endBatchEdit() = true
+        override fun getExtractedText(request: ExtractedTextRequest?, flags: Int) = ExtractedText().apply {
+            text = content.toString()
+            startOffset = 0
+            selectionStart = Selection.getSelectionStart(content)
+            selectionEnd = Selection.getSelectionEnd(content)
+        }
+    }
+
+    private val editor = Editor()
+    private val service = spy(IMEService()).also {
+        doReturn(editor).`when`(it).getCurrentInputConnection()
+        ReflectionHelpers.setField(it, "isCustomLayoutDirectMode", true)
+        ReflectionHelpers.setField(it, "delayTime", 200)
+    }
+    private val binding = mock(MainLayoutBinding::class.java)
+
+    private fun tap() {
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "handleCustomToggleText",
+            ClassParameter.from(String::class.java, "key"),
+            ClassParameter.from(List::class.java, listOf("a", "b")),
+            ClassParameter.from(List::class.java, listOf("a", "b")),
+            ClassParameter.from(MainLayoutBinding::class.java, binding))
+    }
+
+    @Test fun configuredTimeout_preservesPreviouslyCommittedCharacter() {
+        tap()
+        ShadowSystemClock.advanceBy(Duration.ofMillis(199))
+        tap()
+        assertEquals("b", editor.editable.toString())
+        ShadowSystemClock.advanceBy(Duration.ofMillis(200))
+        tap()
+        assertEquals("ba", editor.editable.toString())
+        ShadowSystemClock.advanceBy(Duration.ofMillis(201))
+        tap()
+        assertEquals("baa", editor.editable.toString())
+    }
+
+    @Test fun movedCursor_startsNewSequenceEvenWithinTimeout() {
+        tap()
+        Selection.setSelection(editor.editable, 0)
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "invalidateCustomToggleStateForSelection",
+            ClassParameter.from(Int::class.javaPrimitiveType, 0),
+            ClassParameter.from(Int::class.javaPrimitiveType, 0))
+        tap()
+        assertEquals("aa", editor.editable.toString())
+        assertEquals(1, Selection.getSelectionStart(editor.editable))
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputStateTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputStateTest.kt
@@ -6,41 +6,50 @@ import org.junit.Test
 class CustomToggleInputStateTest {
     private val state = CustomToggleInputState()
 
+    private fun next(
+        key: String,
+        values: List<String>,
+        outputs: List<String> = values,
+        now: Long = 0,
+        timeout: Long = 1000,
+    ) =
+        state.next(key, values, outputs, nowMillis = now, timeoutMillis = timeout)
+
     @Test
     fun sameKey_cyclesInConfiguredOrder() {
         val values = listOf("あ", "い", "う")
 
-        assertEquals(CustomToggleInputState.Mutation.Append("あ"), state.next("key", values))
-        assertEquals(CustomToggleInputState.Mutation.Replace("あ", "い"), state.next("key", values))
-        assertEquals(CustomToggleInputState.Mutation.Replace("い", "う"), state.next("key", values))
-        assertEquals(CustomToggleInputState.Mutation.Replace("う", "あ"), state.next("key", values))
+        assertEquals(CustomToggleInputState.Mutation.Append("あ"), next("key", values))
+        assertEquals(CustomToggleInputState.Mutation.Replace("あ", "い"), next("key", values))
+        assertEquals(CustomToggleInputState.Mutation.Replace("い", "う"), next("key", values))
+        assertEquals(CustomToggleInputState.Mutation.Replace("う", "あ"), next("key", values))
     }
 
     @Test
     fun anotherKey_startsANewSequence() {
-        state.next("first", listOf("a", "b"))
-        state.next("first", listOf("a", "b"))
+        next("first", listOf("a", "b"))
+        next("first", listOf("a", "b"))
 
         assertEquals(
             CustomToggleInputState.Mutation.Append("x"),
-            state.next("second", listOf("x", "y"))
+            next("second", listOf("x", "y"))
         )
     }
 
     @Test
     fun singleValue_alwaysAppends() {
-        assertEquals(CustomToggleInputState.Mutation.Append("a"), state.next("key", listOf("a")))
-        assertEquals(CustomToggleInputState.Mutation.Append("a"), state.next("key", listOf("a")))
+        assertEquals(CustomToggleInputState.Mutation.Append("a"), next("key", listOf("a")))
+        assertEquals(CustomToggleInputState.Mutation.Append("a"), next("key", listOf("a")))
     }
 
     @Test
     fun reset_startsSequenceAgain() {
         val values = listOf("a", "b")
-        state.next("key", values)
-        state.next("key", values)
+        next("key", values)
+        next("key", values)
         state.reset()
 
-        assertEquals(CustomToggleInputState.Mutation.Append("a"), state.next("key", values))
+        assertEquals(CustomToggleInputState.Mutation.Append("a"), next("key", values))
     }
 
     @Test
@@ -49,15 +58,45 @@ class CustomToggleInputStateTest {
 
         assertEquals(
             CustomToggleInputState.Mutation.Append("A"),
-            state.next("key", values, listOf("A", "B", "C"))
+            next("key", values, listOf("A", "B", "C"))
         )
         assertEquals(
             CustomToggleInputState.Mutation.Replace("A", "b"),
-            state.next("key", values, listOf("a", "b", "c"))
+            next("key", values, listOf("a", "b", "c"))
         )
         assertEquals(
             CustomToggleInputState.Mutation.Replace("b", "C"),
-            state.next("key", values, listOf("A", "B", "C"))
+            next("key", values, listOf("A", "B", "C"))
         )
+    }
+
+    @Test fun timeoutBoundary_startsNewSequence() {
+        for (elapsed in listOf(999L, 1000L, 1001L)) {
+            state.reset()
+            next("key", listOf("a", "b"), now = 100)
+            val expected = if (elapsed < 1000) CustomToggleInputState.Mutation.Replace("a", "b")
+                else CustomToggleInputState.Mutation.Append("a")
+            assertEquals(expected, next("key", listOf("a", "b"), now = 100 + elapsed))
+        }
+    }
+
+    @Test fun everyTap_renewsDeadlineAcrossMultipleCycles() {
+        val values = listOf("a", "b")
+        next("key", values)
+        for (i in 1..6) {
+            val previous = values[(i - 1) % 2]
+            assertEquals(CustomToggleInputState.Mutation.Replace(previous, values[i % 2]),
+                next("key", values, now = i * 900L))
+        }
+        assertEquals(CustomToggleInputState.Mutation.Append("a"), next("key", values, now = 6400))
+    }
+
+    @Test fun changedTimeout_isUsedOnNextTap() {
+        val values = listOf("a", "b")
+        next("key", values, timeout = 1000)
+        assertEquals(CustomToggleInputState.Mutation.Append("a"),
+            next("key", values, now = 200, timeout = 200))
+        assertEquals(CustomToggleInputState.Mutation.Replace("a", "b"),
+            next("key", values, now = 900, timeout = 1000))
     }
 }


### PR DESCRIPTION
## 日本語

カスタムキーボードの出力設定「トグル」で、待機時間を過ぎても同じキーが直前の文字を置換し続ける不具合を修正します。例えば待機時間200msで「あ→お」のキーを入力すると、最後の入力から200ms未満なら「お」に切り替わり、200ms以上なら前の文字を残して「あ」を追加します。

### 変更内容
- `CustomToggleInputState` に最後の入力時刻を記録し、入力ごとに待機時間を判定・更新します。
- `IMEService` から単調増加時計 `SystemClock.elapsedRealtime()` と既存の待機時間設定を渡します。未設定時は1,000msです。
- 変換前入力と直接入力の両方に適用し、リセット時は時刻も消去します。時間切れによる変換前文字列全体の確定処理は追加しません。

### 検証・レビュー
- 関連テスト22件成功：時間境界の直前・一致・経過後、複数周の連打、設定変更、既定値、直接入力・変換前入力、カーソル移動、大小文字変換、既存の編集画面検証・DB移行。
- `:app:assembleLiteStandardDebug` 成功。
- 差分をセルフレビューし、時間判定・状態リセット・既存の文字置換保護を確認。`git diff --check` 成功。
- Pixel 6（Android 17）で実機テスト成功。既存の設定保存先を更新して入力欄に戻り、実際のカスタムキーへタッチイベントを送信。変換前入力・直接入力の各4ケース（計8ケース）と、描画安定後の文字列・変換中スパンを検証しました。テスト用レイアウトを削除し、設定と元のIMEを復元済みです。

## English

Fix custom keyboard toggle output continuing to replace the previous character after the configured wait time. With a 200ms timeout and an `あ → お` sequence, tapping within 200ms of the last tap cycles to `お`; tapping at or after 200ms preserves the previous character and appends `あ`.

### Changes
- Track the last input timestamp in `CustomToggleInputState`, checking and renewing the timeout on each tap.
- Pass the monotonic `SystemClock.elapsedRealtime()` timestamp and existing wait-time preference from `IMEService`, retaining the 1,000ms fallback.
- Apply the same timeout to composing and direct input, and clear the timestamp on reset. Expiration does not commit the entire composition.

### Validation and review
- All 22 related tests passed, covering timeout boundaries, repeated cycles, changed settings, the default timeout, composing/direct input, cursor movement, case conversion, existing editor validation and database migration.
- `:app:assembleLiteStandardDebug` passed.
- Self-reviewed timeout handling, reset behavior and existing replacement safeguards; `git diff --check` passed.
- Physical-device instrumentation passed on Pixel 6 (Android 17). The test updates the existing preference store, re-enters the editor, and injects touch events into the real custom key. All 8 cases passed (4 each for composing/direct input), including settled text and composing-span checks. Temporary layouts were deleted; original preferences and IME selection were restored.

### Verification command
```sh
./gradlew :app:testLiteStandardDebugUnitTest \
  --tests '*CustomToggle*' \
  --tests '*CustomKeyboardShiftStateTest' \
  --tests '*KeyEditorToggleValidationTest' \
  --tests '*ToggleInputMigrationTest' \
  :app:assembleLiteStandardDebug
```


### 実機結果 / Physical-device results

Both composing and direct input / 変換前入力・直接入力の両方:

| 待機時間 / Timeout | 入力間隔 / Tap interval | 結果 / Result |
| --- | --- | --- |
| 1,000ms | 500ms | お（トグル / cycle） |
| 200ms に変更 / changed to 200ms | 500ms | ああ（追加 / append） |
| 1,000ms に戻す / restored to 1,000ms | 500ms | お（トグル / cycle） |
| 200ms | 50ms | お（トグル / cycle） |

Device regression: `FastInputMatrixInstrumentedTest#customToggleWaitPreferenceOnPhysicalDevice` — `OK (1 test)`, 8 input cases.
