### PR TITLE
フリック専用入力の背景色が待機後に変わる不具合を修正 / Fix timed background changes in flick-only input

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -65,6 +65,68 @@ class FastInputMatrixInstrumentedTest {
         get() = instrumentation.uiAutomation
 
     @Test
+    fun flickOnlyBackgroundDoesNotChangeAfterToggleTimeoutOnPhysicalDevice() {
+        runPhysicalDeviceSession("flick-background-timeout") { session ->
+            val scenario = launchHost(session.context)
+            try {
+                rotateAndVerify(TestOrientation.PORTRAIT)
+                for (keyboard in listOf(TestKeyboard.TENKEY, TestKeyboard.SUMIRE)) {
+                    for (custom in listOf(false, true)) {
+                        for (flickOnly in listOf(false, true)) {
+                            applyCasePreferences(session.preferences, previewTestCase(keyboard))
+                            check(session.preferences.edit()
+                                .putBoolean("flick_input_only_preference", flickOnly)
+                                .putBoolean("flick_editor_preview_preference", true)
+                                .putBoolean("theme_custom_input_color_enable", custom)
+                                .putInt("theme_custom_pre_edit_bg_color", 0x44112233)
+                                .putInt("time_same_pronounce_typing_preference", 1000)
+                                .commit())
+                            restartInput(scenario)
+                            SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                            val geometry = awaitStableGeometry(keyboard, false)
+                            val before = if (custom) 0x44112233 else session.context.getColor(
+                                com.kazumaproject.core.R.color.char_in_edit_color)
+                            // Existing custom after-edit color: RGB channels multiplied by 1.2.
+                            val after = if (custom) 0x4414283D else session.context.getColor(
+                                com.kazumaproject.core.R.color.blue)
+                            val token = "$keyboard-custom-$custom-flick-$flickOnly"
+                            val down = SystemClock.uptimeMillis()
+                            assertTrue(injectSinglePointerEvent(down, MotionEvent.ACTION_DOWN, geometry.prime.center))
+                            awaitEditorText(scenario) { it.isNotEmpty() }
+                            val preview = readEditorDecoration(scenario)
+                            assertTrue("$token DOWN: $preview", preview.matches(
+                                keyboard.primeText, if (flickOnly) after else before, keyboard.primeText.length))
+                            assertTrue(injectSinglePointerEvent(down, MotionEvent.ACTION_UP, geometry.prime.center))
+                            val released = SystemClock.uptimeMillis()
+                            SystemClock.sleep(100)
+                            val immediate = readEditorDecoration(scenario)
+                            assertTrue("$token early sample missed timeout", SystemClock.uptimeMillis() - released < 1000)
+                            assertTrue("$token immediate: $immediate", immediate.matches(
+                                keyboard.primeText, if (flickOnly) after else before, keyboard.primeText.length))
+                            saveScreenshot(session, "$token-immediate")
+                            while (SystemClock.uptimeMillis() - released < 1600) {
+                                if (flickOnly) {
+                                    val sample = readEditorDecoration(scenario)
+                                    assertTrue("$token changed after ${SystemClock.uptimeMillis() - released}ms: $sample",
+                                        sample.matches(keyboard.primeText, after, keyboard.primeText.length))
+                                }
+                                SystemClock.sleep(50)
+                            }
+                            val settled = readEditorDecoration(scenario)
+                            assertTrue("$token settled: $settled", settled.matches(
+                                keyboard.primeText, after, keyboard.primeText.length))
+                            saveScreenshot(session, "$token-settled")
+                            sendProgress("BACKGROUND_VERIFIED $token immediate=$immediate settled=$settled\n")
+                        }
+                    }
+                }
+            } finally {
+                scenario.close()
+            }
+        }
+    }
+
+    @Test
     fun flickEditorPreviewFunctionalAndPerformanceOnPhysicalDevice() {
         runPhysicalDeviceSession("flick-editor-preview") { session ->
             var scenario: ActivityScenario<FastInputHostActivity>? = null
@@ -72,7 +134,7 @@ class FastInputMatrixInstrumentedTest {
                 scenario = launchHost(session.context)
                 rotateAndVerify(TestOrientation.PORTRAIT)
                 val defaultPreviewBackgroundColor = session.context.getColor(
-                    com.kazumaproject.core.R.color.char_in_edit_color
+                    com.kazumaproject.core.R.color.blue
                 )
 
                 val sumireStyles = listOf(
@@ -189,7 +251,7 @@ class FastInputMatrixInstrumentedTest {
                     assertEditorPreviewDecoration(
                         scenario = scenario,
                         expectedText = movedPreview,
-                        expectedBackgroundColor = PREVIEW_TEST_BACKGROUND_COLOR,
+                        expectedBackgroundColor = PREVIEW_TEST_AFTER_BACKGROUND_COLOR,
                         caseName = "$keyboard MOVE",
                     )
                     assertTrue(
@@ -286,7 +348,7 @@ class FastInputMatrixInstrumentedTest {
                     assertEditorPreviewDecoration(
                         scenario = scenario,
                         expectedText = "ああな",
-                        expectedBackgroundColor = PREVIEW_TEST_BACKGROUND_COLOR,
+                        expectedBackgroundColor = PREVIEW_TEST_AFTER_BACKGROUND_COLOR,
                         expectedBackgroundEnd = 2,
                         caseName = "$keyboard tail DOWN",
                     )
@@ -306,7 +368,7 @@ class FastInputMatrixInstrumentedTest {
                     assertEditorPreviewDecoration(
                         scenario = scenario,
                         expectedText = movedWithTail,
-                        expectedBackgroundColor = PREVIEW_TEST_BACKGROUND_COLOR,
+                        expectedBackgroundColor = PREVIEW_TEST_AFTER_BACKGROUND_COLOR,
                         expectedBackgroundEnd = 2,
                         caseName = "$keyboard tail MOVE",
                     )
@@ -4359,6 +4421,8 @@ class FastInputMatrixInstrumentedTest {
         private const val PREVIEW_HOLD_ASSERT_MS = 120L
         private const val PREVIEW_TEXT_POLL_MS = 4L
         private const val PREVIEW_TEST_BACKGROUND_COLOR = 0x66336699
+        // The configured composing color is brightened by 1.2 for after-edit rendering.
+        private const val PREVIEW_TEST_AFTER_BACKGROUND_COLOR = 0x663D7AB7
         private const val PREVIEW_PERFORMANCE_WARMUP_GESTURES = 30
         private const val PREVIEW_PERFORMANCE_GESTURES = 500
         private const val PREVIEW_GC_SETTLE_MS = 250L

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -18358,6 +18358,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun scheduleDefaultInputFinalize(string: String) {
+        // フリック専用入力はすでに編集後の背景で表示されており、トグル待機は不要。
+        if (isFlickOnlyMode == true) return
+
         val timeToDelay = delayTime?.toLong() ?: DEFAULT_DELAY_MS
         val mutationRevision = editorMutationRevision.current()
         defaultInputFinalizeJob = scope.launch {
@@ -23523,9 +23526,20 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         @ColorInt textColor: Int? = null,
     ): SpannableString {
         val spanFlag = Spannable.SPAN_EXCLUSIVE_EXCLUSIVE or Spannable.SPAN_COMPOSING
+        // フリック専用入力にはトグル待機がないため、最初から編集後の背景を使う。
+        val resolvedBackgroundColor = if (isFlickOnlyMode == true) {
+            if (customComposingTextPreference == true) {
+                inputCompositionAfterBackgroundColor
+                    ?: getColor(com.kazumaproject.core.R.color.blue)
+            } else {
+                getColor(com.kazumaproject.core.R.color.blue)
+            }
+        } else {
+            backgroundColor
+        }
         return spannableString.apply {
             setSpan(
-                BackgroundColorSpan(backgroundColor),
+                BackgroundColorSpan(resolvedBackgroundColor),
                 0,
                 inputLength,
                 spanFlag,

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/FlickComposingBackgroundTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/FlickComposingBackgroundTest.kt
@@ -1,0 +1,68 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import android.content.Context
+import android.text.SpannableString
+import android.text.style.BackgroundColorSpan
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.RuntimeEnvironment
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class FlickComposingBackgroundTest {
+    @Test
+    fun flickOnlyInput_doesNotScheduleToggleTimeout() {
+        val service = IMEService()
+        ReflectionHelpers.setField(service, "isFlickOnlyMode", true)
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "scheduleDefaultInputFinalize",
+            ClassParameter.from(String::class.java, "あ"))
+        assertNull(ReflectionHelpers.getField<Any?>(service, "defaultInputFinalizeJob"))
+    }
+
+    @Test
+    fun previewAndNormalInput_useAfterEditBackgroundOnlyInFlickOnlyMode() {
+        val context = RuntimeEnvironment.getApplication()
+        val service = IMEService()
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "attachBaseContext",
+            ClassParameter.from(Context::class.java, context))
+        val before = 0x44112233
+        val after = 0x77556677
+        for (custom in listOf(false, true)) {
+            for (flickOnly in listOf(false, true)) {
+                ReflectionHelpers.setField(service, "isFlickOnlyMode", flickOnly)
+                ReflectionHelpers.setField(service, "customComposingTextPreference", custom)
+                ReflectionHelpers.setField(service, "inputCompositionBackgroundColor", before)
+                ReflectionHelpers.setField(service, "inputCompositionAfterBackgroundColor", after)
+                val expected = if (flickOnly) {
+                    if (custom) after else context.getColor(com.kazumaproject.core.R.color.blue)
+                } else {
+                    if (custom) before else context.getColor(com.kazumaproject.core.R.color.char_in_edit_color)
+                }
+                val preEdit = if (custom) before else context.getColor(com.kazumaproject.core.R.color.char_in_edit_color)
+                val normal = ReflectionHelpers.callInstanceMethod<SpannableString>(service,
+                    "applyPreEditComposingSpans",
+                    ClassParameter.from(SpannableString::class.java, SpannableString("あいう")),
+                    ClassParameter.from(Int::class.javaPrimitiveType, 2),
+                    ClassParameter.from(Int::class.javaPrimitiveType, 3),
+                    ClassParameter.from(Int::class.javaPrimitiveType, preEdit),
+                    ClassParameter.from(Int::class.javaObjectType, null))
+                val preview = ReflectionHelpers.callInstanceMethod<CharSequence>(service,
+                    "createFlickPreviewComposingText",
+                    ClassParameter.from(String::class.java, "あい"),
+                    ClassParameter.from(String::class.java, "う")) as SpannableString
+                for (text in listOf(normal, preview)) {
+                    val span = text.getSpans(0, text.length, BackgroundColorSpan::class.java).single()
+                    assertEquals("custom=$custom flickOnly=$flickOnly", expected, span.backgroundColor)
+                    assertEquals(0, text.getSpanStart(span))
+                    assertEquals(2, text.getSpanEnd(span))
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 日本語

フリック専用設定でも、文字入力直後はトグル待機中の背景が表示され、待機時間が過ぎると色が変わっていました。フリック専用入力では最初から編集後の背景を使い、トグル待機ジョブを起動しないよう修正します。指を置いたとき・滑らせたときのプレビューも同じ背景を使います。

標準色と既存のカスタム色計算の両方に対応します。トグル入力の待機後の色切り替えは維持します。

### 検証・レビュー

- Pixel 6 / Android 17（API 37）、Lite Standard Debug を実機にインストールして確認。
- テンキー・すみれ × フリック専用・トグル × 標準色・カスタム色の8条件で、指を置いた際のプレビュー、入力約100ms後、1.6秒後の実際の EditText の背景 Span を検証。フリック専用では時間経過中も背景が一定、トグルでは設定した1秒後に編集後色へ切り替わることを確認。
- 実機テスト2件成功。既存のプレビュー検証（DOWN/MOVE/UP/CANCEL、プレビュー無効、カーソル後方の文字列保持、各すみれスタイル）も成功。
- 関連ユニットテスト15件成功。APK・実機テストAPKのビルド成功、git diff --check 成功。
- 背景選択、タイマー起動条件、カスタム色、Span範囲、トグル入力への影響を差分レビューし、未解決の指摘なし。
- 実機テスト終了時に設定と既定IMEを復元。調査レポート・ログ・スクリーンショットはリポジトリに追加していません。

## English

Flick-only input previously showed the toggle-waiting composing background immediately after typing, then changed color after the toggle timeout. Use the after-edit background from the start in flick-only mode and skip the toggle-finalization job. DOWN/MOVE previews use the same background.

This respects both default colors and the existing custom-color calculation, while preserving the timed background transition for toggle input.

### Validation and review

- Installed Lite Standard Debug on a physical Pixel 6 running Android 17 (API 37).
- Verified eight combinations of ten-key/Sumire, flick-only/toggle, and default/custom colors. Inspected actual EditText background spans during DOWN preview, approximately 100 ms after input, and after 1.6 seconds. Flick-only backgrounds stayed stable throughout the waiting interval; toggle backgrounds changed after the configured one-second timeout.
- Two device tests passed, including existing preview coverage for DOWN/MOVE/UP/CANCEL, preview disabled, composing-tail preservation, and Sumire styles.
- All 15 relevant unit tests passed. App/test APK builds and git diff --check passed.
- Reviewed background selection, timer scheduling, custom colors, span boundaries, and toggle behavior; no unresolved findings.
- Device preferences and the original default IME were restored. No investigation reports, logs, or screenshots were added to the repository.
