### PR TITLE
カスタムキーボードのトグル修正とかなテンプレート追加 / Fix custom keyboard toggles and add kana template

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/CustomToggleKeyboardDeviceTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/CustomToggleKeyboardDeviceTest.kt
@@ -1,0 +1,206 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Intent
+import android.graphics.Rect
+import android.os.ParcelFileDescriptor
+import android.os.SystemClock
+import android.text.style.BackgroundColorSpan
+import android.view.InputDevice
+import android.view.MotionEvent
+import android.view.accessibility.AccessibilityNodeInfo
+import android.view.inputmethod.BaseInputConnection
+import androidx.preference.PreferenceManager
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.kazumaproject.custom_keyboard.data.KeyTextInputBehavior
+import com.kazumaproject.custom_keyboard.data.copyWithKeys
+import com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts
+import com.kazumaproject.markdownhelperkeyboard.ime_service.di.AppModule
+import com.kazumaproject.markdownhelperkeyboard.custom_keyboard.ui.KeyboardEditorViewModel
+import com.kazumaproject.markdownhelperkeyboard.repository.KeyboardRepository
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Uses the real IME and editor in an isolated application, restoring the selected IME afterward.
+ * Run :app:connectedLiteStandardDebugAndroidTest with -I investigation/custom-toggle.init.gradle
+ * and -Pandroid.testInstrumentationRunnerArguments.class=com.kazumaproject.markdownhelperkeyboard.CustomToggleKeyboardDeviceTest.
+ */
+@RunWith(AndroidJUnit4::class)
+class CustomToggleKeyboardDeviceTest {
+    private val ins = InstrumentationRegistry.getInstrumentation()
+    private val automation get() = ins.uiAutomation
+    private fun shell(command: String) = ParcelFileDescriptor.AutoCloseInputStream(
+        automation.executeShellCommand(command)).bufferedReader().use { it.readText() }
+    private fun nodes(): List<AccessibilityNodeInfo> {
+        val result = mutableListOf<AccessibilityNodeInfo>()
+        fun visit(node: AccessibilityNodeInfo) {
+            result.add(node)
+            for (index in 0 until node.childCount) node.getChild(index)?.let(::visit)
+        }
+        automation.windows.forEach { it.root?.let(::visit) }
+        return result
+    }
+    private fun key(label: String): Rect {
+        val deadline = SystemClock.uptimeMillis() + 15000
+        while (SystemClock.uptimeMillis() < deadline) {
+            nodes().firstOrNull { it.packageName?.toString() == ins.targetContext.packageName &&
+                it.isVisibleToUser && it.isClickable &&
+                it.text?.toString()?.lineSequence()?.firstOrNull()?.trim() == label
+            }?.let { return Rect().also(it::getBoundsInScreen) }
+            SystemClock.sleep(100)
+        }
+        error("Missing key $label: " + nodes().joinToString { "${it.text}/${it.contentDescription}" })
+    }
+    private fun awaitStableKeyboard() {
+        var previous: Rect? = null
+        var unchanged = 0
+        val deadline = SystemClock.uptimeMillis() + 15000
+        while (SystemClock.uptimeMillis() < deadline) {
+            val bounds = key("あ")
+            unchanged = if (bounds == previous) unchanged + 1 else 0
+            if (unchanged >= 3) return
+            previous = bounds
+            SystemClock.sleep(100)
+        }
+        error("Custom keyboard geometry did not settle")
+    }
+    private fun tap(rect: Rect) {
+        val start = SystemClock.uptimeMillis()
+        for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_UP)) {
+            val event = MotionEvent.obtain(start, SystemClock.uptimeMillis(), action,
+                rect.exactCenterX(), rect.exactCenterY(), 0)
+            event.source = InputDevice.SOURCE_TOUCHSCREEN
+            check(automation.injectInputEvent(event, true))
+            event.recycle()
+            if (action == MotionEvent.ACTION_DOWN) SystemClock.sleep(25)
+        }
+        SystemClock.sleep(80)
+    }
+    private fun cell(column: Int, row: Int): Rect {
+        val a = key("あ")
+        val ka = key("か")
+        val ta = key("た")
+        return Rect(a).apply {
+            offset((column - 1) * (ka.centerX() - a.centerX()), row * (ta.centerY() - a.centerY()))
+        }
+    }
+    private fun flickUp(rect: Rect) {
+        val start = SystemClock.uptimeMillis()
+        for (action in listOf(MotionEvent.ACTION_DOWN, MotionEvent.ACTION_MOVE, MotionEvent.ACTION_UP)) {
+            val event = MotionEvent.obtain(start, SystemClock.uptimeMillis(), action,
+                rect.exactCenterX(), rect.exactCenterY() - if (action == MotionEvent.ACTION_DOWN) 0f else rect.height().toFloat(), 0)
+            event.source = InputDevice.SOURCE_TOUCHSCREEN
+            check(automation.injectInputEvent(event, true))
+            event.recycle()
+            SystemClock.sleep(30)
+        }
+        SystemClock.sleep(80)
+    }
+    private fun text(scenario: ActivityScenario<FastInputHostActivity>): String {
+        var result = ""
+        scenario.onActivity { result = it.editText.text.toString() }
+        return result
+    }
+    private fun color(scenario: ActivityScenario<FastInputHostActivity>): Int? {
+        var result: Int? = null
+        scenario.onActivity {
+            val text = it.editText.text
+            result = text.getSpans(0, text.length, BackgroundColorSpan::class.java).lastOrNull()?.backgroundColor
+        }
+        return result
+    }
+
+    @Test fun actualIme_customToggleAndOrdinaryOutputAcrossModesAndSurfaces() = runBlocking {
+        val context = ins.targetContext
+        check(context.packageName.startsWith("com.kazumaproject.customtoggletest")) {
+            "Use an isolated customtoggletest application ID"
+        }
+        val target = "${context.packageName}/com.kazumaproject.markdownhelperkeyboard.ime_service.IMEService"
+        val oldIme = shell("settings get secure default_input_method").trim()
+        val enabled = shell("ime list -s").lineSequence().any { it.trim() == target }
+        val db = AppModule.providesLearnDatabase(context)
+        val repository = KeyboardRepository(db.keyboardLayoutDao())
+        val prefs = PreferenceManager.getDefaultSharedPreferences(context)
+        automation.serviceInfo = automation.serviceInfo.apply {
+            flags = flags or AccessibilityServiceInfo.FLAG_RETRIEVE_INTERACTIVE_WINDOWS or AccessibilityServiceInfo.FLAG_REPORT_VIEW_IDS
+        }
+        val editor = KeyboardEditorViewModel(repository)
+        editor.applyTemplate(KeyboardDefaultLayouts.createToggleKanaTemplateLayout())
+        val template = editor.uiState.value.layout
+        // One ordinary kana key proves that global toggle mode cannot change normal output.
+        val layout = template.copyWithKeys(template.keys.map {
+            if (it.label == "か") it.copy(textInputBehavior = KeyTextInputBehavior.NORMAL) else it
+        })
+        var id: Long? = repository.getLayoutsNotFlow().firstOrNull()?.layoutId
+        try {
+            shell("ime enable $target")
+            shell("ime set $target")
+            for (direct in listOf(false, true)) {
+                id = repository.saveLayout(layout.copy(isDirectMode = direct), "Toggle device test", id)
+                for (floating in listOf(false, true)) for (flickOnly in listOf(false, true)) {
+                    check(prefs.edit()
+                        .putString("keyboard_order_preference", "[\"CUSTOM\"]")
+                        .putBoolean("save_last_used_keyboard", false)
+                        .putBoolean("keyboard_floating_preference", floating)
+                        .putBoolean("flick_input_only_preference", flickOnly)
+                        .putInt("time_same_pronounce_typing_preference", 600)
+                        .putBoolean("live_conversion_preference", false)
+                        .putBoolean("theme_custom_input_color_enable", true)
+                        .putInt("theme_custom_pre_edit_bg_color", 0x44112233)
+                        .commit())
+                    ActivityScenario.launch<FastInputHostActivity>(Intent(context, FastInputHostActivity::class.java)).use { scenario ->
+                        awaitStableKeyboard()
+                        val a = key("あ")
+                        val ka = key("か")
+                        tap(a)
+                        assertEquals("direct=$direct floating=$floating flickOnly=$flickOnly", "あ", text(scenario))
+                        val before = color(scenario)
+                        if (!direct) assertEquals(0x44112233, before)
+                        tap(a)
+                        assertEquals("い", text(scenario))
+                        SystemClock.sleep(700)
+                        if (!direct) {
+                            assertNotNull(color(scenario))
+                            assertNotEquals(before, color(scenario))
+                        }
+                        tap(a)
+                        assertEquals("いあ", text(scenario))
+                        tap(ka); tap(ka)
+                        assertEquals("いあかか", text(scenario))
+                        if (!direct) {
+                            tap(cell(1, 3))
+                            assertEquals("いあかが", text(scenario))
+                            tap(key("あ")); tap(cell(1, 3))
+                            assertEquals("いあかがぁ", text(scenario))
+                            flickUp(key("あ"))
+                            assertEquals("いあかがぁう", text(scenario))
+                            tap(key("あ"))
+                            assertEquals("いあかがぁうあ", text(scenario))
+                            tap(cell(4, 0))
+                            assertEquals("いあかがぁう", text(scenario))
+                            SystemClock.sleep(700)
+                            tap(cell(4, 2))
+                            tap(cell(4, 3))
+                            val committed = text(scenario)
+                            assertTrue(committed.isNotEmpty())
+                            scenario.onActivity {
+                                assertEquals(-1, BaseInputConnection.getComposingSpanStart(it.editText.text))
+                            }
+                            SystemClock.sleep(700)
+                            assertEquals(committed, text(scenario))
+                        }
+                    }
+                }
+            }
+        } finally {
+            if (oldIme.isNotEmpty() && oldIme != "null") shell("ime set $oldIme")
+            if (!enabled) shell("ime disable $target")
+            db.close()
+        }
+    }
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardEditorViewModel.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardEditorViewModel.kt
@@ -119,6 +119,10 @@ class KeyboardEditorViewModel @Inject constructor(
             KeyboardDefaultLayouts.createFlickKanaTemplateLayout(true)
         ),
         LayoutTemplate(
+            R.string.template_toggle_kana,
+            KeyboardDefaultLayouts.createToggleKanaTemplateLayout()
+        ),
+        LayoutTemplate(
             R.string.template_flick_english_cursor,
             KeyboardDefaultLayouts.createFlickEnglishTemplateLayout(
                 isDefaultKey = true,

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputState.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputState.kt
@@ -11,6 +11,13 @@ internal class CustomToggleInputState {
     private var index = -1
     private var lastEmittedText: String? = null
     private var lastInputTimeMillis: Long? = null
+    private var timeoutMillis: Long = 0
+
+    fun remainingMillis(nowMillis: Long): Long {
+        val elapsed = lastInputTimeMillis?.let { nowMillis - it } ?: return 0
+        if (elapsed < 0) return 0
+        return (timeoutMillis - elapsed).coerceAtLeast(0)
+    }
 
     fun next(
         keyIdentity: String,
@@ -30,6 +37,7 @@ internal class CustomToggleInputState {
         val elapsedMillis = lastInputTimeMillis?.let { nowMillis - it }
         val expired = elapsedMillis == null || elapsedMillis < 0 || elapsedMillis >= timeoutMillis
         lastInputTimeMillis = nowMillis
+        this.timeoutMillis = timeoutMillis
         if (
             expired ||
             this.keyIdentity != keyIdentity ||
@@ -56,5 +64,6 @@ internal class CustomToggleInputState {
         index = -1
         lastEmittedText = null
         lastInputTimeMillis = null
+        timeoutMillis = 0
     }
 }

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -1447,6 +1447,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         candidate: Candidate?
     ): Boolean = withContext(Dispatchers.Main.immediate) {
         if (!shouldApplyCandidateResult(insertString)) return@withContext false
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) {
+            // A tap may extend the deadline while a completed candidate is queued for Main.
+            delayBeforeApplyingLiveConversion()
+            if (!shouldApplyCandidateResult(insertString)) return@withContext false
+        }
         isContinuousTapInputEnabled.set(true)
         lastFlickConvertedNextHiragana.set(true)
         if (!hasConvertedKatakana) {
@@ -8929,6 +8934,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun setCustomLayoutOnAvailableSurfaces(layout: KeyboardLayout) {
+        resetCustomToggleState()
         getNormalKeyboardSurface()
             ?.customLayout
             ?.let { flickView -> setKeyboardWithDeleteKeyFlickPreferences(flickView, layout) }
@@ -11730,6 +11736,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun showResolvedKeyboard(type: KeyboardType) {
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) resetCustomToggleState()
         hideAllKeyboards()
         Timber.d("showKeyboard called: resolved=$type")
         mainLayoutBinding?.apply {
@@ -12049,6 +12056,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var isCustomLayoutDirectMode = false
     private var customKeyboardShiftState = CustomKeyboardShiftState.OFF
     private val customToggleInputState = CustomToggleInputState()
+    private var customToggleFinalizeJob: Job? = null
     private var customToggleWasDirect: Boolean = false
     private val isCustomLayoutShiftPressed: Boolean
         get() = customKeyboardShiftState == CustomKeyboardShiftState.ONE_SHOT
@@ -12613,7 +12621,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             override fun onActionLongPress(action: KeyAction) {
                 if (isKeyboardLayoutEditModeActive()) return
-                resetCustomToggleState()
+                finishCustomToggleForAction()
                 if (action != KeyAction.DoNothing) {
                     vibrate()
                     clearDeleteBufferWithView()
@@ -12932,7 +12940,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             override fun onFlickActionLongPress(action: KeyAction) {
                 if (isKeyboardLayoutEditModeActive()) return
-                resetCustomToggleState()
+                finishCustomToggleForAction()
                 Timber.d("onFlickActionLongPress: $action")
                 if (action != KeyAction.DoNothing) vibrate()
                 when (action) {
@@ -13390,7 +13398,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
             override fun onAction(action: KeyAction, isFlick: Boolean) {
                 if (isKeyboardLayoutEditModeActive()) return
-                resetCustomToggleState()
+                finishCustomToggleForAction()
                 if (action != KeyAction.DoNothing) handleKeyReleaseFeedback()
 
                 Timber.d("onAction: $action $isFlick")
@@ -13950,6 +13958,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun resetCustomToggleState() {
+        customToggleFinalizeJob?.cancel()
+        customToggleFinalizeJob = null
         customToggleInputState.reset()
         customToggleWasDirect = false
         customToggleExpectedEditorSelection = null
@@ -13957,6 +13967,56 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private var customToggleExpectedEditorSelection: CustomToggleEditorSelection? = null
     private var customToggleEditInProgress = false
+
+    private fun finishCustomToggleForAction() {
+        val shouldUpdateColor = qwertyMode.value == TenKeyQWERTYMode.Custom &&
+            customToggleRemainingMillis() > 0 && !isCustomToggleDirectInput() &&
+            inputString.value.isNotEmpty() && !isHenkan.get()
+        resetCustomToggleState()
+        if (shouldUpdateColor) applyRawComposingFallback(inputString.value)
+    }
+
+    private fun customToggleRemainingMillis(): Long =
+        customToggleInputState.remainingMillis(SystemClock.elapsedRealtime())
+
+    private fun renderCustomKeyboardComposingText(string: String) {
+        if (customToggleRemainingMillis() > 0 && !isCustomToggleDirectInput()) {
+            setComposingTextPreEdit(
+                inputString = string,
+                spannableString = createSpannableWithTail(string),
+                backgroundColor = if (customComposingTextPreference == true) {
+                    inputCompositionBackgroundColor
+                        ?: getColor(com.kazumaproject.core.R.color.char_in_edit_color)
+                } else {
+                    getColor(com.kazumaproject.core.R.color.char_in_edit_color)
+                },
+                textColor = if (customComposingTextPreference == true) inputCompositionTextColor else null,
+            )
+        } else {
+            applyRawComposingFallback(string)
+        }
+    }
+
+    private fun scheduleCustomToggleFinalize() {
+        customToggleFinalizeJob?.cancel()
+        customToggleFinalizeJob = null
+        if (qwertyMode.value != TenKeyQWERTYMode.Custom || currentInputConnection == null) return
+        val remaining = customToggleRemainingMillis()
+        if (remaining <= 0 || isCustomToggleDirectInput()) return
+        val string = inputString.value
+        if (string.isEmpty()) return
+        // Render here as well: cycling equal output values does not emit a StateFlow update.
+        renderCustomKeyboardComposingText(string)
+        val revision = editorMutationRevision.current()
+        customToggleFinalizeJob = scope.launch {
+            delay(customToggleRemainingMillis())
+            if (qwertyMode.value != TenKeyQWERTYMode.Custom ||
+                inputString.value != string || !editorMutationRevision.isCurrent(revision) ||
+                isCustomToggleDirectInput() || isHenkan.get()
+            ) return@launch
+            applyRawComposingFallback(string)
+        }
+    }
 
     private fun captureCustomToggleEditorSelection(
         connection: InputConnection
@@ -14096,12 +14156,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 } else {
                     null
                 }
-                if (isDirect) customToggleEditInProgress = true
+                customToggleEditInProgress = true
                 try {
                     // A new toggle sequence must append, bypassing the legacy kana tap cycle.
                     handleCustomKeyboardText(mutation.text, mainView, isFlick = true)
                 } finally {
-                    if (isDirect) customToggleEditInProgress = false
+                    customToggleEditInProgress = false
                 }
                 if (isDirect) {
                     val after = currentInputConnection?.let(::captureCustomToggleEditorSelection)
@@ -14132,6 +14192,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                             outputValues = emittedValues,
                             mainView = mainView,
                         )
+                        return
                     }
                 } else {
                     val current = inputString.value
@@ -14149,6 +14210,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 }
             }
         }
+        scheduleCustomToggleFinalize()
     }
 
     private fun handleCustomKeyboardText(
@@ -14165,11 +14227,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
         if (applyPendingFlickTextMutation(text, isFlick)) return
         if (text.length == 1) {
-            if (isFlickOnlyMode == true || isFlick) {
-                handleFlick(text.first(), inputString.value, StringBuilder(), mainView)
-            } else {
-                handleTap(text.first(), inputString.value, StringBuilder(), mainView)
-            }
+            // Only onToggleText cycles custom keys; ordinary taps always append.
+            handleFlick(text.first(), inputString.value, StringBuilder(), mainView)
         } else {
             _inputString.update { it + text }
         }
@@ -18337,6 +18396,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
      * TenKeyQWERTY以外のモードの入力処理を担当します。
      */
     private fun handleDefaultInput(string: String) {
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) {
+            renderCustomKeyboardComposingText(string)
+            requestCandidateRefresh(CandidateShowFlag.Updating, string)
+            return
+        }
         val spannable = createSpannableWithTail(string)
         if (!(shouldStartLiveConversion(string) && isFlickOnlyMode == true)) {
             setComposingTextPreEdit(
@@ -18358,6 +18422,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun scheduleDefaultInputFinalize(string: String) {
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) return
         // フリック専用入力はすでに編集後の背景で表示されており、トグル待機は不要。
         if (isFlickOnlyMode == true) return
 
@@ -18453,6 +18518,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun liveConversionApplyDelayMillis(): Long {
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) {
+            return customToggleRemainingMillis()
+        }
         val originalDelay = delayTime?.toLong() ?: DEFAULT_DELAY_MS
 
         if (isFlickOnlyMode == true) {
@@ -18492,6 +18560,16 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private suspend fun delayBeforeApplyingLiveConversion() {
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) {
+            // Equal toggle outputs do not restart the candidate request. Recheck the deadline
+            // after waking so another tap cannot leave that request using an older timeout.
+            while (qwertyMode.value == TenKeyQWERTYMode.Custom) {
+                val remaining = customToggleRemainingMillis()
+                if (remaining <= 0L) break
+                delay(remaining)
+            }
+            return
+        }
         val applyDelay = liveConversionApplyDelayMillis()
         measureDebugStage("IMEService.liveConversionApplyDelay") {
             if (applyDelay > 0L) {
@@ -18503,6 +18581,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun applyFirstSuggestion(
         candidate: Candidate
     ) {
+        // Once a candidate owns the composing display, an old toggle timer must not restore kana.
+        if (qwertyMode.value == TenKeyQWERTYMode.Custom) resetCustomToggleState()
         beginBatchEdit()
         val commitString = getCandidateCommitString(candidate)
         lastCandidate = commitString
@@ -23527,7 +23607,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     ): SpannableString {
         val spanFlag = Spannable.SPAN_EXCLUSIVE_EXCLUSIVE or Spannable.SPAN_COMPOSING
         // フリック専用入力にはトグル待機がないため、最初から編集後の背景を使う。
-        val resolvedBackgroundColor = if (isFlickOnlyMode == true) {
+        val useAfterEditColor = if (qwertyMode.value == TenKeyQWERTYMode.Custom) {
+            customToggleRemainingMillis() == 0L
+        } else {
+            isFlickOnlyMode == true
+        }
+        val resolvedBackgroundColor = if (useAfterEditColor) {
             if (customComposingTextPreference == true) {
                 inputCompositionAfterBackgroundColor
                     ?: getColor(com.kazumaproject.core.R.color.blue)
@@ -27740,7 +27825,14 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     override fun setComposingText(p0: CharSequence?, p1: Int): Boolean {
         if (currentInputConnection == null) return false
         cancelCandidateTranslationIfComposingChanges(p0)
-        return composingTextArbiter.setCanonical(p0, p1)
+        val applied = composingTextArbiter.setCanonical(p0, p1)
+        if (applied && qwertyMode.value == TenKeyQWERTYMode.Custom &&
+            !isCustomToggleDirectInput() && customToggleRemainingMillis() > 0
+        ) {
+            customToggleExpectedEditorSelection =
+                captureCustomToggleEditorSelection(currentInputConnection)
+        }
+        return applied
     }
 
     override fun setComposingRegion(p0: Int, p1: Int): Boolean {
@@ -27750,6 +27842,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun finishComposingText(): Boolean {
+        if (!customToggleEditInProgress) resetCustomToggleState()
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
         clearFunctionKeyConversionSource()
@@ -27760,6 +27853,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     override fun commitText(p0: CharSequence?, p1: Int): Boolean {
+        if (!customToggleEditInProgress) resetCustomToggleState()
         if (currentInputConnection == null) return false
         flickInputPreviewCoordinator.cancel(restore = true)
         clearFunctionKeyConversionSource()

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -718,6 +718,7 @@
     <string name="read_from_template">テンプレートから読み込む</string>
     <string name="show_row_column_delete_buttons">行・列の削除ボタンを表示</string>
     <string name="template_flick_kana_cursor">かな入力 (カーソル)</string>
+    <string name="template_toggle_kana">かな入力（トグル）</string>
     <string name="template_flick_english_cursor">英語入力 (カーソル)</string>
     <string name="template_qwerty">QWERTY</string>
     <string name="template_empty_5x4_flexible">空のフレキシブルレイアウト</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -760,6 +760,7 @@
     <string name="read_from_template">Load from templates</string>
     <string name="show_row_column_delete_buttons">Show row/column delete buttons</string>
     <string name="template_flick_kana_cursor">Kana input (cursor)</string>
+    <string name="template_toggle_kana">Kana input (toggle)</string>
     <string name="template_flick_english_cursor">English input (cursor)</string>
     <string name="template_qwerty">QWERTY</string>
     <string name="template_empty_5x4_flexible">Empty 5x4 Flexible Layout</string>

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardEditorToggleKanaTemplateTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/custom_keyboard/ui/KeyboardEditorToggleKanaTemplateTest.kt
@@ -1,0 +1,51 @@
+package com.kazumaproject.markdownhelperkeyboard.custom_keyboard.ui
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import com.kazumaproject.custom_keyboard.data.KeyTextInputBehavior
+import com.kazumaproject.custom_keyboard.data.FlickAction
+import com.kazumaproject.custom_keyboard.data.PETAL_TOGGLE_DIRECTIONS
+import com.kazumaproject.markdownhelperkeyboard.R
+import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase
+import com.kazumaproject.markdownhelperkeyboard.repository.KeyboardRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class KeyboardEditorToggleKanaTemplateTest {
+    @Test fun selectSaveAndReload_preservesToggleKeysAndFlickMappings() = runBlocking {
+        val db = Room.inMemoryDatabaseBuilder(ApplicationProvider.getApplicationContext<Context>(), AppDatabase::class.java)
+            .allowMainThreadQueries().build()
+        try {
+            val repository = KeyboardRepository(db.keyboardLayoutDao())
+            val editor = KeyboardEditorViewModel(repository)
+            val templates = editor.availableTemplates
+            val originalIndex = templates.indexOfFirst { it.nameResId == R.string.template_flick_kana_cursor }
+            val template = templates[originalIndex + 1]
+            assertEquals(R.string.template_toggle_kana, template.nameResId)
+            editor.applyTemplate(template.layout)
+            val layout = editor.uiState.value.layout
+            val id = repository.saveLayout(layout, "かな入力（トグル）", null)
+            val reloaded = repository.getFullLayout(id).first()
+            val keys = reloaded.keys.filter { it.textInputBehavior == KeyTextInputBehavior.TOGGLE }
+            assertEquals(11, keys.size)
+            keys.forEach { key ->
+                assertNotNull(key.keyId)
+                val before = layout.keys.single { it.label == key.label }
+                assertEquals(layout.flickKeyMaps[before.keyId], reloaded.flickKeyMaps[key.keyId])
+            }
+            val ya = keys.single { it.label == "や" }
+            val actions = reloaded.flickKeyMaps.getValue(ya.keyId!!).first()
+            assertEquals("や(ゆ)よ", PETAL_TOGGLE_DIRECTIONS.mapNotNull { (actions[it] as? FlickAction.Input)?.char }.joinToString(""))
+        } finally {
+            db.close()
+        }
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleComposingTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleComposingTest.kt
@@ -1,0 +1,212 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import android.content.Context
+import android.os.Looper
+import android.text.Selection
+import android.text.SpannableStringBuilder
+import android.text.style.BackgroundColorSpan
+import android.view.View
+import android.view.inputmethod.BaseInputConnection
+import android.view.inputmethod.ExtractedText
+import android.view.inputmethod.ExtractedTextRequest
+import androidx.test.core.app.ApplicationProvider
+import com.kazumaproject.core.domain.state.TenKeyQWERTYMode
+import com.kazumaproject.markdownhelperkeyboard.databinding.MainLayoutBinding
+import com.kazumaproject.markdownhelperkeyboard.ime_service.flick_preview.ComposingTextArbiter
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+import org.junit.After
+import org.junit.Assert.*
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mockito.*
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import org.robolectric.util.ReflectionHelpers.ClassParameter
+import java.time.Duration
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class CustomToggleComposingTest {
+    private class Editor : BaseInputConnection(View(ApplicationProvider.getApplicationContext()), true) {
+        private val content = SpannableStringBuilder()
+        init { Selection.setSelection(content, 0) }
+        override fun getEditable() = content
+        override fun getExtractedText(request: ExtractedTextRequest?, flags: Int) = ExtractedText().apply {
+            text = content.toString()
+            startOffset = 0
+            selectionStart = Selection.getSelectionStart(content)
+            selectionEnd = Selection.getSelectionEnd(content)
+        }
+    }
+
+    private val editor = Editor()
+    private val service = spy(IMEService()).also {
+        doReturn(editor).`when`(it).getCurrentInputConnection()
+        ReflectionHelpers.setField(it, "composingTextArbiter", ComposingTextArbiter(
+            writeComposingText = { text, cursor -> editor.setComposingText(text, cursor) },
+            finishComposingText = { editor.finishComposingText() },
+            copyText = { text -> android.text.SpannableString(text) },
+        ))
+        ReflectionHelpers.callInstanceMethod<Unit>(it, "attachBaseContext",
+            ClassParameter.from(Context::class.java, ApplicationProvider.getApplicationContext<Context>()))
+        ReflectionHelpers.getField<MutableStateFlow<TenKeyQWERTYMode>>(it, "_tenKeyQWERTYMode").value = TenKeyQWERTYMode.Custom
+        ReflectionHelpers.setField(it, "delayTime", 200)
+        ReflectionHelpers.setField(it, "customComposingTextPreference", true)
+        ReflectionHelpers.setField(it, "inputCompositionBackgroundColor", 0x44112233)
+        ReflectionHelpers.setField(it, "inputCompositionAfterBackgroundColor", 0x77556677)
+    }
+    private val binding = mock(MainLayoutBinding::class.java)
+    private val input get() = ReflectionHelpers.getField<MutableStateFlow<String>>(service, "_inputString")
+    private fun reset() = ReflectionHelpers.callInstanceMethod<Unit>(service, "resetCustomToggleState")
+    @After fun cleanup() { reset() }
+    private fun waitMillis(ms: Long) { shadowOf(Looper.getMainLooper()).idleFor(Duration.ofMillis(ms)) }
+    private fun toggle(key: String = "a", values: List<String> = listOf("あ", "い")) {
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "handleCustomToggleText",
+            ClassParameter.from(String::class.java, key),
+            ClassParameter.from(List::class.java, values),
+            ClassParameter.from(List::class.java, values),
+            ClassParameter.from(MainLayoutBinding::class.java, binding))
+    }
+    private fun color() = editor.editable.getSpans(0, editor.editable.length, BackgroundColorSpan::class.java).last().backgroundColor
+
+    @Test fun toggleDeadlineAndColors_ignoreSharedModeAndRestartOnEachTap() {
+        for (flickOnly in listOf(false, true)) {
+            reset()
+            input.value = ""
+            editor.editable.clear()
+            Selection.setSelection(editor.editable, 0)
+            ReflectionHelpers.setField(service, "isFlickOnlyMode", flickOnly)
+            toggle()
+            assertEquals("あ", input.value)
+            assertEquals(0x44112233, color())
+            waitMillis(199)
+            toggle()
+            assertEquals("い", input.value)
+            waitMillis(199)
+            assertEquals(0x44112233, color())
+            waitMillis(1)
+            assertEquals(0x77556677, color())
+            toggle()
+            assertEquals("いあ", input.value)
+        }
+    }
+
+    @Test fun ordinaryTaps_alwaysAppendInBothSharedModes() {
+        for (flickOnly in listOf(false, true)) {
+            input.value = ""
+            ReflectionHelpers.setField(service, "isFlickOnlyMode", flickOnly)
+            repeat(3) {
+                ReflectionHelpers.callInstanceMethod<Unit>(service, "handleCustomKeyboardText",
+                    ClassParameter.from(String::class.java, "あ"),
+                    ClassParameter.from(MainLayoutBinding::class.java, binding),
+                    ClassParameter.from(Boolean::class.javaPrimitiveType, false))
+            }
+            assertEquals("あああ", input.value)
+            ReflectionHelpers.callInstanceMethod<Unit>(service, "renderCustomKeyboardComposingText",
+                ClassParameter.from(String::class.java, input.value))
+            assertEquals(0x77556677, color())
+        }
+    }
+
+    @Test fun equalOutputs_refreshDeadlineWithoutStateFlowEmission() {
+        toggle(values = listOf("あ", "あ"))
+        waitMillis(199)
+        toggle(values = listOf("あ", "あ"))
+        waitMillis(199)
+        assertEquals(0x44112233, color())
+        waitMillis(1)
+        assertEquals(0x77556677, color())
+    }
+
+    @Test fun cursorMoveAndCommit_cancelPendingUpdate() {
+        toggle()
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "invalidateCustomToggleStateForSelection",
+            ClassParameter.from(Int::class.javaPrimitiveType, 0),
+            ClassParameter.from(Int::class.javaPrimitiveType, 0))
+        assertNull(ReflectionHelpers.getField<Any?>(service, "customToggleFinalizeJob"))
+        toggle()
+        assertEquals("ああ", input.value)
+        service.finishComposingText()
+        assertNull(ReflectionHelpers.getField<Any?>(service, "customToggleFinalizeJob"))
+        val previous = editor.editable.toString()
+        waitMillis(250)
+        assertEquals(previous, editor.editable.toString())
+        assertEquals(-1, BaseInputConnection.getComposingSpanStart(editor.editable))
+    }
+
+    @Test fun anotherAction_endsWaitingAndImmediatelyRestoresColor() {
+        toggle()
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "finishCustomToggleForAction")
+        assertEquals(0x77556677, color())
+        assertNull(ReflectionHelpers.getField<Any?>(service, "customToggleFinalizeJob"))
+        toggle()
+        assertEquals("ああ", input.value)
+    }
+
+    @Test fun liveConversion_usesCustomDeadlineInBothSharedModes() {
+        for (flickOnly in listOf(false, true)) {
+            reset()
+            ReflectionHelpers.setField(service, "isFlickOnlyMode", flickOnly)
+            assertEquals(0L, ReflectionHelpers.callInstanceMethod<Long>(service, "liveConversionApplyDelayMillis"))
+            toggle()
+            waitMillis(150)
+            assertEquals(50L, ReflectionHelpers.callInstanceMethod<Long>(service, "liveConversionApplyDelayMillis"))
+            waitMillis(50)
+            assertEquals(0L, ReflectionHelpers.callInstanceMethod<Long>(service, "liveConversionApplyDelayMillis"))
+        }
+    }
+
+    @Test fun liveConversion_rechecksDeadlineWhenEqualOutputDoesNotRestartRequest() {
+        toggle(values = listOf("あ", "あ"))
+        var applied = false
+        val job = CoroutineScope(Dispatchers.Main).launch {
+            suspendCoroutineUninterceptedOrReturn<Unit> { continuation ->
+                val method = IMEService::class.java.getDeclaredMethod(
+                    "delayBeforeApplyingLiveConversion", Continuation::class.java)
+                method.isAccessible = true
+                method.invoke(service, continuation)
+            }
+            applied = true
+        }
+        try {
+            waitMillis(199)
+            toggle(values = listOf("あ", "あ"))
+            waitMillis(1)
+            assertFalse("The original deadline must not end the extended toggle wait", applied)
+            waitMillis(198)
+            assertFalse(applied)
+            waitMillis(1)
+            assertTrue(applied)
+        } finally {
+            job.cancel()
+        }
+    }
+
+    @Test fun appliedCandidate_cannotBeOverwrittenByPendingToggleTimer() {
+        toggle()
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "applyFirstSuggestion",
+            ClassParameter.from(Candidate::class.java, Candidate("亜", 1, 1u, 0)))
+        assertEquals("亜", editor.editable.toString())
+        assertNull(ReflectionHelpers.getField<Any?>(service, "customToggleFinalizeJob"))
+        waitMillis(250)
+        assertEquals("亜", editor.editable.toString())
+    }
+
+    @Test fun replacingCustomLayout_cancelsWaitingEvenWhenKeyIdentitiesMatch() {
+        toggle()
+        ReflectionHelpers.callInstanceMethod<Unit>(service, "setCustomLayoutOnAvailableSurfaces",
+            ClassParameter.from(com.kazumaproject.custom_keyboard.data.KeyboardLayout::class.java,
+                com.kazumaproject.custom_keyboard.layout.KeyboardDefaultLayouts.createToggleKanaTemplateLayout()))
+        assertNull(ReflectionHelpers.getField<Any?>(service, "customToggleFinalizeJob"))
+        toggle()
+        assertEquals("ああ", input.value)
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputStateTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/CustomToggleInputStateTest.kt
@@ -6,6 +6,19 @@ import org.junit.Test
 class CustomToggleInputStateTest {
     private val state = CustomToggleInputState()
 
+    @Test fun remainingTime_tracksTheSameDeadlineAsCycling() {
+        next("key", listOf("あ", "い"), now = 100, timeout = 200)
+        assertEquals(1L, state.remainingMillis(299))
+        assertEquals(0L, state.remainingMillis(300))
+        next("key", listOf("あ", "い"), now = 300, timeout = 200)
+        assertEquals(200L, state.remainingMillis(300))
+        assertEquals(0L, state.remainingMillis(299))
+        state.reset()
+        assertEquals(0L, state.remainingMillis(300))
+        next("single", listOf("あ"), now = 300)
+        assertEquals(0L, state.remainingMillis(300))
+    }
+
     private fun next(
         key: String,
         values: List<String>,

--- a/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
+++ b/custom_keyboard/src/main/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayouts.kt
@@ -18,6 +18,20 @@ import com.kazumaproject.custom_keyboard.data.copyWithKeys
 import com.kazumaproject.custom_keyboard.view.TfbiFlickDirection
 
 object KeyboardDefaultLayouts {
+    fun createToggleKanaTemplateLayout(): KeyboardLayout {
+        val layout = createFlickKanaTemplateLayout(isDefaultKey = true)
+        return layout.copyWithKeys(layout.keys.map { key ->
+            val actions = layout.flickKeyMaps[key.label]?.firstOrNull().orEmpty()
+            if (!key.isSpecialKey && key.keyType == KeyType.PETAL_FLICK &&
+                actions.values.any { it is FlickAction.Input }
+            ) {
+                key.copy(textInputBehavior = com.kazumaproject.custom_keyboard.data.KeyTextInputBehavior.TOGGLE)
+            } else {
+                key
+            }
+        })
+    }
+
     data class DeleteKeyFlickSettings(
         val left: Boolean = true,
         val up: Boolean = false,

--- a/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayoutsToggleKanaTest.kt
+++ b/custom_keyboard/src/test/java/com/kazumaproject/custom_keyboard/layout/KeyboardDefaultLayoutsToggleKanaTest.kt
@@ -1,0 +1,28 @@
+package com.kazumaproject.custom_keyboard.layout
+
+import com.kazumaproject.custom_keyboard.data.*
+import org.junit.Assert.*
+import org.junit.Test
+
+class KeyboardDefaultLayoutsToggleKanaTest {
+    @Test fun template_preservesLayoutAndActionsAndOnlyEnablesTextToggles() {
+        val original = KeyboardDefaultLayouts.createFlickKanaTemplateLayout(true)
+        val toggle = KeyboardDefaultLayouts.createToggleKanaTemplateLayout()
+        assertEquals(original.flickKeyMaps, toggle.flickKeyMaps)
+        assertEquals(original.rowCount, toggle.rowCount)
+        assertEquals(original.columnCount, toggle.columnCount)
+        val labels = setOf("あ", "か", "さ", "た", "な", "は", "ま", "や", "ら", "わ", "、。?!")
+        assertEquals(labels, toggle.keys.filter { it.textInputBehavior == KeyTextInputBehavior.TOGGLE }.map { it.label }.toSet())
+        original.keys.zip(toggle.keys).forEach { (before, after) ->
+            assertEquals(before, after.copy(textInputBehavior = before.textInputBehavior))
+        }
+        assertTrue(original.keys.none { it.textInputBehavior == KeyTextInputBehavior.TOGGLE })
+        val sequences = mapOf("あ" to "あいうえお", "か" to "かきくけこ", "さ" to "さしすせそ",
+            "た" to "たちつてと", "な" to "なにぬねの", "は" to "はひふへほ", "ま" to "まみむめも",
+            "や" to "や(ゆ)よ", "ら" to "らりるれろ", "わ" to "わをんー〜", "、。?!" to "、。？！…")
+        sequences.forEach { (label, expected) ->
+            val map = toggle.flickKeyMaps.getValue(label).first()
+            assertEquals(expected, PETAL_TOGGLE_DIRECTIONS.mapNotNull { (map[it] as? FlickAction.Input)?.char }.joinToString(""))
+        }
+    }
+}

--- a/investigation/custom-toggle.init.gradle
+++ b/investigation/custom-toggle.init.gradle
@@ -1,0 +1,6 @@
+// Keep device-test layouts and preferences separate from the user's installed keyboard.
+gradle.afterProject { project ->
+    if (project.path == ':app') {
+        project.android.defaultConfig.applicationId = 'com.kazumaproject.customtoggletest'
+    }
+}


### PR DESCRIPTION
## 日本語

カスタムキーボードの通常出力が共通の「フリックのみ／トグル併用」設定に影響される問題と、トグル待機状態に入力中文字の背景色が連動しない問題を修正します。「かな入力（トグル）」テンプレートも追加します。

### 変更内容

- 通常出力は連打しても文字を追加し、トグル指定キーだけ待機時間内に設定順で文字を切り替えます。待機時間と入力中文字の色設定は引き続き使用します。
- 背景色をトグルの待機期限と同期し、連打で期限を更新します。別操作・カーソル移動・確定・キーボード切り替えでは待機処理を解除します。
- 同一文字を出力する連打でもライブ変換は延長後の期限を待ちます。変換候補の適用後は、古い背景色更新が変換結果を元のかなに戻さないようにします。
- 既存のカーソル付きかな配列を基に、文字キーをトグル出力にしたテンプレートを追加します。フリック・機能キー・文字順は維持し、や行は「や→(→ゆ→)→よ」です。
- 動作変更はカスタムキーボードに限定します。既存テンプレート、保存済みレイアウト、DB形式の変更はありません。

### 検証

- 単体・回帰テスト34件が通過。待機時間の境界、背景色、共通設定からの独立、待機解除、ライブ変換の競合、テンプレート保存・再読み込みを確認しました。
- Pixel 6で、共通設定2種類 × 通常／フローティング表示 × 変換あり／直接入力の8通りを確認しました。変換あり入力ではフリック・濁点・小文字化・削除・変換・確定も確認済みです。
- 実機テストは専用の別アプリIDを使用し、終了後に元のIME選択を復元します。

## English

Fix custom keyboard normal output being affected by the shared flick-only/toggle setting, and composing-text background colors not following the toggle waiting state. Add a “Kana input (toggle)” template.

### Changes

- Normal keys always append text; only toggle-configured keys cycle through their configured values within the timeout. Existing timeout and composing-text color preferences remain in use.
- Synchronize composing colors with the toggle deadline and extend it on repeated taps. Cancel pending updates on other actions, cursor movement, commit, and keyboard changes.
- Live conversion respects an extended deadline even when repeated taps produce identical text. Applying a candidate cancels the old color timer so it cannot replace converted text with the original kana.
- Derive the new template from the existing kana layout with cursor keys. Preserve flick gestures, function keys, and character order, including “や→(→ゆ→)→よ”.
- Behavior changes are limited to custom keyboards. Existing templates, saved layouts, and the database format are unchanged.

### Validation

- 34 unit/regression tests passed, covering timeout boundaries, colors, independence from shared settings, cancellation, live-conversion races, and template persistence.
- Pixel 6 device tests passed across eight combinations of shared input setting, normal/floating surface, and composing/direct input. Composing scenarios also exercised flicks, dakuten, small kana, deletion, conversion, and commit.
- Device tests use an isolated application ID and restore the previously selected IME afterward.

### Test commands / テストコマンド

```sh
./gradlew -I investigation/custom-toggle.init.gradle \
  :app:testLiteStandardDebugUnitTest \
  --tests '*CustomToggle*' --tests '*FlickComposingBackgroundTest' \
  --tests '*KeyboardEditorToggleKanaTemplateTest' \
  :custom_keyboard:testDebugUnitTest --tests '*KeyboardDefaultLayouts*'

./gradlew -I investigation/custom-toggle.init.gradle \
  :app:connectedLiteStandardDebugAndroidTest \
  -Pandroid.testInstrumentationRunnerArguments.class=com.kazumaproject.markdownhelperkeyboard.CustomToggleKeyboardDeviceTest
```
