### PR TITLE
候補欄のIncognitoアイコンをテーマ色に追従 / Match candidate-strip Incognito icon to theme color

### DIFF
--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapter.kt
@@ -1532,6 +1532,7 @@ class SuggestionAdapter internal constructor(
                     visibility = View.GONE
                 }
             }
+            applyEmptyHelperIconColor(incognitoIcon)
 
             undoIcon?.apply {
                 isVisible = state.undoEnabled
@@ -1713,6 +1714,10 @@ class SuggestionAdapter internal constructor(
     ) {
         applyEmptyHelperButtonBackground(parent, isDynamicColorEnable)
         applyEmptyHelperTextColor(text)
+        applyEmptyHelperIconColor(icon)
+    }
+
+    private fun applyEmptyHelperIconColor(icon: ImageView?) {
         candidateEmptyDrawableTextColor?.let { color ->
             icon?.setColorFilter(color, PorterDuff.Mode.SRC_IN)
         } ?: icon?.clearColorFilter()

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/SuggestionAdapter2.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/setting_activity/ui/candidate_view_height_setting/SuggestionAdapter2.kt
@@ -675,6 +675,7 @@ class SuggestionAdapter2 : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
                     visibility = View.GONE
                 }
             }
+            applyEmptyHelperIconColor(incognitoIcon)
 
             undoIcon?.apply {
                 isVisible = state.undoEnabled
@@ -792,6 +793,10 @@ class SuggestionAdapter2 : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
     ) {
         applyEmptyHelperButtonBackground(parent, isDynamicColorEnable)
         applyEmptyHelperTextColor(text)
+        applyEmptyHelperIconColor(icon)
+    }
+
+    private fun applyEmptyHelperIconColor(icon: ImageView?) {
         candidateEmptyDrawableTextColor?.let { color ->
             icon?.setColorFilter(color, PorterDuff.Mode.SRC_IN)
         } ?: icon?.clearColorFilter()

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapterVectorTintTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/adapters/SuggestionAdapterVectorTintTest.kt
@@ -3,14 +3,18 @@ package com.kazumaproject.markdownhelperkeyboard.ime_service.adapters
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.os.Looper
 import android.view.ContextThemeWrapper
+import android.view.LayoutInflater
 import android.widget.FrameLayout
 import android.widget.ImageView
+import androidx.core.content.ContextCompat
 import androidx.test.core.app.ApplicationProvider
 import com.kazumaproject.markdownhelperkeyboard.short_cut.ShortcutType
 import com.kazumaproject.markdownhelperkeyboard.ime_service.candidate.CandidateStripContent
 import com.kazumaproject.markdownhelperkeyboard.ime_service.candidate.QuickActionsState
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -50,6 +54,84 @@ class SuggestionAdapterVectorTintTest {
         adapter.setShortcutIconColor(null)
         adapter.onBindViewHolder(holder,index)
         assertTrue("Skin tint was retained",pixels(expected).sameAs(pixels(holder.imageView)))
+        adapter.release()
+    }
+
+    @Test fun incognitoBindingUsesCandidateThemeColorAndRestoresVectorTint() {
+        val ctx = ContextThemeWrapper(
+            ApplicationProvider.getApplicationContext<Context>(),
+            com.kazumaproject.markdownhelperkeyboard.R.style.Theme_MarkdownKeyboard,
+        )
+        val adapter = SuggestionAdapter()
+        adapter.setIncognitoIcon(
+            ContextCompat.getDrawable(ctx, com.kazumaproject.core.R.drawable.incognito),
+        )
+        adapter.submitContent(
+            CandidateStripContent.EmptyState(
+                showShortcutEntry = false,
+                quickActions = QuickActionsState(
+                    incognitoVisible = true,
+                    undoEnabled = false,
+                    redoEnabled = false,
+                    reconvertEnabled = false,
+                    undoText = "",
+                    redoText = "",
+                ),
+                clipboardPreview = null,
+                shortcutItems = emptyList(),
+                showIntegratedShortcuts = false,
+            ),
+        )
+        repeat(100) {
+            if (adapter.itemCount == 0) {
+                shadowOf(Looper.getMainLooper()).idle()
+                Thread.sleep(10)
+            }
+        }
+        assertEquals(1, adapter.itemCount)
+
+        val holder = adapter.onCreateViewHolder(
+            FrameLayout(ctx),
+            SuggestionAdapter.VIEW_TYPE_EMPTY,
+        ) as SuggestionAdapter.QuickActionsViewHolder
+        val expected = LayoutInflater.from(ctx)
+            .inflate(
+                com.kazumaproject.markdownhelperkeyboard.R.layout.suggestion_quick_actions_item,
+                FrameLayout(ctx),
+                false,
+            )
+            .findViewById<ImageView>(com.kazumaproject.markdownhelperkeyboard.R.id.incognito_icon)
+            .apply {
+                setImageDrawable(
+                    ContextCompat.getDrawable(ctx, com.kazumaproject.core.R.drawable.incognito),
+                )
+                setColorFilter(Color.MAGENTA, android.graphics.PorterDuff.Mode.SRC_IN)
+            }
+        adapter.setCandidateEmptyPopupColors(Color.BLACK, Color.MAGENTA)
+        adapter.onBindViewHolder(holder, 0)
+        assertTrue(
+            "Incognito icon should use the candidate empty action text color",
+            pixels(expected).sameAs(pixels(holder.incognitoIcon!!)),
+        )
+
+        adapter.clearCandidateEmptyPopupColors()
+        adapter.onBindViewHolder(holder, 0)
+        val vectorDefault = LayoutInflater.from(ctx)
+            .inflate(
+                com.kazumaproject.markdownhelperkeyboard.R.layout.suggestion_quick_actions_item,
+                FrameLayout(ctx),
+                false,
+            )
+            .findViewById<ImageView>(com.kazumaproject.markdownhelperkeyboard.R.id.incognito_icon)
+            .apply {
+                setImageDrawable(
+                    ContextCompat.getDrawable(ctx, com.kazumaproject.core.R.drawable.incognito),
+                )
+            }
+        assertTrue(
+            "Clearing the candidate theme should restore the vector's own tint",
+            pixels(vectorDefault).sameAs(pixels(holder.incognitoIcon!!)),
+        )
         adapter.release()
     }
 }


### PR DESCRIPTION
## 概要 / Summary

### 日本語
変換候補欄の Incognito アイコンがカスタム／Cupertino テーマの文字色に追従しない問題を修正しました。

候補欄本体と設定画面プレビューで、既存の候補欄アクション用テーマ色を Incognito アイコンにも適用します。テーマ色を解除した場合は、ベクター drawable 自身の色に戻ります。

### English
Fixed an issue where the Incognito icon in the candidate strip did not follow the custom/Cupertino theme text color and instead used the system icon color.

The existing candidate-strip action color is now applied to the Incognito icon in both the runtime candidate strip and the settings preview. Clearing the custom theme restores the vector drawable tint.

## 変更内容 / Changes

- Incognito アイコンに既存の候補欄アクション用色適用処理を追加 / Apply the existing candidate-strip action tint to the Incognito icon.
- 設定画面の候補欄プレビューにも同じ修正を適用 / Apply the same fix to the settings preview.
- テーマ色の適用と解除を検証する Robolectric 回帰テストを追加 / Add a Robolectric regression test covering theme tinting and restoration.

## 確認 / Verification

- ./gradlew :app:testFullStandardDebugUnitTest --tests SuggestionAdapterVectorTintTest
- ./gradlew :app:testFullStandardDebugUnitTest --tests SuggestionAdapter*
- git diff --check