### PR TITLE
文節変換で全文の表記を保持 / Preserve full conversion across bunsetsu segments

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/FastInputMatrixInstrumentedTest.kt
@@ -65,6 +65,60 @@ class FastInputMatrixInstrumentedTest {
         get() = instrumentation.uiAutomation
 
     @Test
+    fun bunsetsuConversionOnNormalAndFloatingSoftwareKeyboards() {
+        runPhysicalDeviceSession("bunsetsu-software") { session ->
+            for (floating in listOf(false, true)) {
+                check(session.preferences.edit()
+                    .putString("keyboard_order_preference", "[\"ROMAJI\",\"TENKEY\",\"QWERTY\",\"GOJUON\",\"SUMIRE\"]")
+                    .putBoolean("save_last_used_keyboard", false)
+                    .putInt("save_last_used_keyboard_int", 0)
+                    .putBoolean("keyboard_floating_preference", floating)
+                    .putBoolean("qwerty_show_cursor_buttons_preference", true)
+                    .putBoolean("conversion_bunsetsu_separation_preference", true)
+                    .putBoolean("conversion_bunsetsu_cursor_move_preference", true)
+                    .putBoolean("live_conversion_preference", false)
+                    .putBoolean("candidate_order_override_enable_preference", false)
+                    .putBoolean("learn_dictionary_preference", false)
+                    .commit())
+                val scenario = launchHost(session.context)
+                try {
+                    ensureTargetImeSelected(session)
+                    restartInput(scenario)
+                    SystemClock.sleep(IME_LAYOUT_SETTLE_MS)
+                    fun tap(id: String) {
+                        assertTrue(injectTap(awaitVisibleNodeBounds(id).center))
+                        SystemClock.sleep(100)
+                    }
+                    "ashitahatoukyouniikimasu".forEach { tap("key_$it") }
+                    awaitEditorText(scenario) { it == "あしたはとうきょうにいきます" }
+                    tap("key_space")
+                    awaitEditorText(scenario) { it == "明日は東京に行きます" }
+                    val initial = readEditorDecoration(scenario)
+                    assertEquals(3, initial.underlines.size)
+                    saveScreenshot(session, "floating-$floating-initial")
+                    tap("cursor_right")
+                    val moved = readEditorDecoration(scenario)
+                    assertEquals(initial.text, moved.text)
+                    assertEquals(3, moved.backgrounds.single().start)
+                    assertEquals(6, moved.backgrounds.single().end)
+                    tap("key_space")
+                    awaitEditorText(scenario) { it != initial.text }
+                    val changed = readEditorDecoration(scenario).text
+                    assertTrue(changed.startsWith("明日は") && changed.endsWith("行きます"))
+                    saveScreenshot(session, "floating-$floating-second-candidate")
+                    tap("key_return")
+                    assertEquals(changed, readEditorDecoration(scenario).text)
+                    scenario.onActivity {
+                        assertEquals(-1, android.view.inputmethod.BaseInputConnection.getComposingSpanStart(it.editText.text))
+                    }
+                } finally {
+                    scenario.close()
+                }
+            }
+        }
+    }
+
+    @Test
     fun flickOnlyBackgroundDoesNotChangeAfterToggleTimeoutOnPhysicalDevice() {
         runPhysicalDeviceSession("flick-background-timeout") { session ->
             val scenario = launchHost(session.context)

--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/PhysicalCandidateCompositionInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/PhysicalCandidateCompositionInstrumentedTest.kt
@@ -27,6 +27,71 @@ class PhysicalCandidateCompositionInstrumentedTest {
     private lateinit var host: ActivityScenario<FastInputHostActivity>
     private var keyboardId = 0
 
+    @Test fun bunsetsuFirstConversionAndCandidateChangePreserveOtherSegments() = withKeyboard(bunsetsu = true) {
+        assertBunsetsuConversionAndNavigation()
+    }
+
+    @Test fun bunsetsuConversionAlsoWorksWithCandidateOrderingEnabled() =
+        withKeyboard(bunsetsu = true, candidateOrdering = true) {
+            assertBunsetsuConversionAndNavigation()
+        }
+
+    @Test fun bunsetsuRapidNavigationAndCancellationDoNotRestoreStaleConversion() = withKeyboard(bunsetsu = true) {
+        type("ashitahatoukyouniikimasu")
+        awaitText("あしたはとうきょうにいきます")
+        key(KeyEvent.KEYCODE_SPACE)
+        awaitText("明日は東京に行きます")
+        repeat(5) {
+            key(KeyEvent.KEYCODE_DPAD_RIGHT, settleMillis = 0)
+            key(KeyEvent.KEYCODE_DPAD_LEFT, settleMillis = 0)
+        }
+        await { focusedRange().first == 0 }
+        assertEquals("明日は東京に行きます", text())
+        key(KeyEvent.KEYCODE_DPAD_RIGHT, settleMillis = 0)
+        key(KeyEvent.KEYCODE_SPACE, settleMillis = 0)
+        key(KeyEvent.KEYCODE_ESCAPE, settleMillis = 0)
+        awaitText("あしたはとうきょうにいきます")
+        SystemClock.sleep(1000)
+        assertEquals("あしたはとうきょうにいきます", text())
+        key(KeyEvent.KEYCODE_DEL)
+        awaitText("あしたはとうきょうにいきま")
+    }
+
+    private fun assertBunsetsuConversionAndNavigation() {
+        type("ashitahatoukyouniikimasu")
+        awaitText("あしたはとうきょうにいきます")
+        key(KeyEvent.KEYCODE_SPACE)
+        awaitText("明日は東京に行きます")
+        await { focusedRange() == (0 until 3) }
+        key(KeyEvent.KEYCODE_DPAD_RIGHT)
+        await { focusedRange() == (3 until 6) }
+        assertEquals("明日は東京に行きます", text())
+        key(KeyEvent.KEYCODE_SPACE)
+        await { text() != "明日は東京に行きます" }
+        val changed = text()
+        assertTrue("Only the second segment may change: $changed", changed.startsWith("明日は") && changed.endsWith("行きます"))
+        val secondRange = focusedRange()
+        key(KeyEvent.KEYCODE_DPAD_RIGHT)
+        await { focusedRange().first == secondRange.last + 1 }
+        assertEquals(changed, text())
+        key(KeyEvent.KEYCODE_DPAD_LEFT)
+        await { focusedRange() == secondRange }
+        assertEquals(changed, text())
+        key(KeyEvent.KEYCODE_ENTER)
+        awaitText(changed)
+        host.onActivity { assertEquals(-1, BaseInputConnection.getComposingSpanStart(it.editText.text)) }
+    }
+
+    private fun focusedRange(): IntRange {
+        var range = IntRange.EMPTY
+        host.onActivity { activity ->
+            val value = activity.editText.text
+            val span = value.getSpans(0, value.length, BackgroundColorSpan::class.java).singleOrNull()
+            if (span != null) range = value.getSpanStart(span) until value.getSpanEnd(span)
+        }
+        return range
+    }
+
     @Test fun cursorTailSurvivesPreviewCancelAndCommit() = withKeyboard {
         type("ashitaha")
         awaitText("あしたは")
@@ -124,9 +189,20 @@ class PhysicalCandidateCompositionInstrumentedTest {
     @Test fun typingImmediatelyAfterPartialEnterDoesNotDropKeyOrReading() = withKeyboard {
         selectPartialCandidate()
         val preview = text()
+        val selectedEnd = focusedRange().last + 1
+        val prefix = preview.take(selectedEnd)
+        val tail = preview.drop(selectedEnd)
+        // Partial Enter may convert the entire remaining reading before A arrives.
+        // Check both exact fixture outputs without allowing a lost prefix, tail, or new key.
+        val convertedTail = when (tail) {
+            "はれるといいですねはれた" -> "晴れると良いですね晴れた"
+            "はれた" -> "晴れた"
+            else -> error("Unexpected partial-candidate fixture: prefix=[$prefix], tail=[$tail]")
+        }
+        val expected = setOf(preview + "あ", prefix + convertedTail + "あ")
         key(KeyEvent.KEYCODE_ENTER, settleMillis = 0)
         key(KeyEvent.KEYCODE_A)
-        awaitText(preview + "あ")
+        await { text() in expected }
     }
 
     private fun selectPartialCandidate() {
@@ -202,13 +278,15 @@ class PhysicalCandidateCompositionInstrumentedTest {
 
         @JvmStatic @BeforeClass fun selectIme() {
             val context = InstrumentationRegistry.getInstrumentation().targetContext
-            targetIme = "${context.packageName}/com.kazumaproject.markdownhelperkeyboard.ime_service.IMEService"
+            val component = "${context.packageName}/com.kazumaproject.markdownhelperkeyboard.ime_service.IMEService"
+            targetIme = shell("ime list -a -s").lines().first { sameIme(it, component) }
             originalIme = shell("settings get secure default_input_method")
             originalShowWithHardware = shell("settings get secure show_ime_with_hard_keyboard")
             wasEnabled = shell("ime list -s").lines().any { sameIme(it, targetIme) }
             shell("settings put secure show_ime_with_hard_keyboard 1")
             shell("ime enable $targetIme")
             shell("ime set $targetIme")
+            assertTrue("Test IME was not selected", sameIme(shell("settings get secure default_input_method"), targetIme))
         }
 
         @JvmStatic @AfterClass fun restoreIme() {
@@ -222,7 +300,7 @@ class PhysicalCandidateCompositionInstrumentedTest {
         }
     }
 
-    private fun withKeyboard(kana: Boolean = false, bunsetsu: Boolean = false, block: () -> Unit) {
+    private fun withKeyboard(kana: Boolean = false, bunsetsu: Boolean = false, candidateOrdering: Boolean = false, block: () -> Unit) {
         keyboardId = InputDevice.getDeviceIds().toList().mapNotNull(InputDevice::getDevice)
             .firstOrNull { !it.isVirtual && it.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC }
             ?.id ?: error("A physical or emulator hardware keyboard is required")
@@ -234,6 +312,8 @@ class PhysicalCandidateCompositionInstrumentedTest {
         val values = mapOf<String, Any>(
             "conversion_bunsetsu_separation_preference" to true,
             "conversion_bunsetsu_cursor_move_preference" to bunsetsu,
+            "candidate_order_override_enable_preference" to candidateOrdering,
+            "learn_dictionary_preference" to false,
             "physical_keyboard_input_mode_preference" to if (kana) "kana" else "romaji",
             "live_conversion_preference" to false,
             "sumire_keymap_guide_japanese" to false,

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuConversionProjection.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuConversionProjection.kt
@@ -1,0 +1,91 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CandidateConversionSegment
+
+/** Candidates and their paths belong to the same whole-input query. */
+internal data class BunsetsuConversionSnapshot(
+    val input: String,
+    val candidates: List<Candidate>,
+    val paths: Map<String, List<CandidateConversionSegment>>,
+    val splitPatterns: List<List<Int>> = emptyList(),
+    val initialSplitPositions: List<Int> = emptyList(),
+)
+
+internal data class BunsetsuSegmentState(
+    val reading: String,
+    val displayText: String,
+    val candidates: List<Candidate> = emptyList(),
+    val selectedIndex: Int = 0,
+    val overrideDisplayCandidate: Candidate? = null,
+    val hasConvertedDisplay: Boolean = false,
+    val candidatesLoaded: Boolean = false,
+)
+
+/** Project entire lattice nodes onto reading ranges; never slice the converted output by length. */
+internal fun buildConvertedBunsetsuSegments(
+    input: String,
+    splitPositions: List<Int>,
+    snapshot: BunsetsuConversionSnapshot?,
+    displayText: (Candidate) -> String = { it.string },
+): List<BunsetsuSegmentState> {
+    if (input.isEmpty()) return emptyList()
+    val boundaries = listOf(0) + splitPositions.filter { it in 1 until input.length }
+        .distinct().sorted() + input.length
+    val current = snapshot?.takeIf { it.input == input }
+    // Choose one coherent full path, rather than mixing words from different N-best paths.
+    val paths = current?.candidates?.mapNotNull { candidate ->
+        current.paths[candidate.string]?.takeIf { nodes ->
+            nodes.isNotEmpty() && nodes.first().inputStart == 0 &&
+                nodes.last().inputEnd == input.length &&
+                nodes.all { it.inputStart < it.inputEnd } &&
+                nodes.zipWithNext().all { (left, right) -> left.inputEnd == right.inputStart } &&
+                nodes.joinToString("") { it.output } == candidate.string
+        }
+    }.orEmpty()
+    val path = paths.firstOrNull { nodes ->
+        boundaries.all { boundary -> boundary == 0 || nodes.any { it.inputEnd == boundary } }
+    } ?: paths.firstOrNull()
+    return boundaries.zipWithNext().map { (start, end) ->
+        val reading = input.substring(start, end)
+        val wholeCandidate = current?.candidates?.firstOrNull()?.takeIf {
+            start == 0 && end == input.length && it.length.toInt() == input.length &&
+                it.sourceId == null && it.presentation == null && it.commitText == it.string
+        }?.let(displayText)
+        val output = wholeCandidate ?: path?.takeIf { nodes ->
+            nodes.any { it.inputStart == start } && nodes.any { it.inputEnd == end }
+        }?.filter { it.inputStart >= start && it.inputEnd <= end }?.joinToString("") { it.output }
+        BunsetsuSegmentState(
+            reading = reading,
+            displayText = output ?: reading,
+            hasConvertedDisplay = output != null,
+        )
+    }
+}
+
+/** Loading alternatives must not replace the whole-sentence choice with an isolated-word choice. */
+internal fun mergeBunsetsuCandidates(
+    segment: BunsetsuSegmentState,
+    candidates: List<Candidate>,
+    displayText: (Candidate) -> String = { it.string },
+): BunsetsuSegmentState {
+    val initialText = if (segment.hasConvertedDisplay) segment.displayText else {
+        candidates.firstOrNull()?.let(displayText) ?: segment.reading
+    }
+    val initialCandidate = candidates.firstOrNull { displayText(it) == initialText }
+        ?: Candidate(
+            string = initialText,
+            type = if (initialText == segment.reading) 3 else 1,
+            length = segment.reading.length.toUByte(),
+            score = 3000,
+            yomi = segment.reading,
+        )
+    val merged = (listOf(initialCandidate) + candidates).distinctBy(displayText)
+    return segment.copy(
+        displayText = initialText,
+        candidates = merged,
+        selectedIndex = 0,
+        hasConvertedDisplay = true,
+        candidatesLoaded = true,
+    )
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -453,18 +453,12 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         QwertyGlideDecode
     }
 
-    private data class BunsetsuSegmentState(
-        val reading: String,
-        val displayText: String,
-        val candidates: List<Candidate> = emptyList(),
-        val selectedIndex: Int = 0,
-        val overrideDisplayCandidate: Candidate? = null
-    )
-
     private data class BunsetsuConversionSession(
         val rawInput: String,
         val conversionInput: String,
         val segments: List<BunsetsuSegmentState>,
+        val generation: Long,
+        val conversionSnapshot: BunsetsuConversionSnapshot?,
         val tailText: String = "",
         val focusedIndex: Int = 0,
         val splitPatterns: List<List<Int>> = emptyList(),
@@ -697,6 +691,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private var bunsetsuPositionList: List<Int>? = emptyList()
     private var bunsetsuSplitPatterns: List<List<Int>> = emptyList()
     private var bunsetsuConversionSession: BunsetsuConversionSession? = null
+    private var latestBunsetsuConversionSnapshot: BunsetsuConversionSnapshot? = null
+    private var bunsetsuSessionGeneration = 0L
+    private val bunsetsuOperationMutex = Mutex()
     private var pendingReconversionEntry: ReconversionEntry? = null
     private var pendingReconversionValid: Boolean = false
     private val reconversionValidationRequestId = AtomicLong(0L)
@@ -18634,9 +18631,10 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
 
     private fun normalizeBunsetsuSplitPatterns(
         input: String,
-        splitPatterns: List<List<Int>>
+        splitPatterns: List<List<Int>>,
+        initialSplitPositions: List<Int>,
     ): List<List<Int>> {
-        val initialPattern = sanitizeSplitPositions(input, bunsetsuPositionList.orEmpty())
+        val initialPattern = sanitizeSplitPositions(input, initialSplitPositions)
         val normalizedPatterns = splitPatterns
             .map { sanitizeSplitPositions(input, it) }
             .distinct()
@@ -18675,9 +18673,11 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     private fun updateBunsetsuStateAfterCandidateMerge(
         input: String,
         mergedCandidates: List<Candidate>,
-        engineResult: BunsetsuCandidateResult?
+        engineResult: BunsetsuCandidateResult?,
+        candidateSegments: Map<String, List<CandidateConversionSegment>>,
     ) {
         if (bunsetsuSeparation != true || engineResult == null) {
+            latestBunsetsuConversionSnapshot = null
             bunsetsuSplitPatterns = emptyList()
             bunsetsuPositionList = emptyList()
             return
@@ -18691,32 +18691,19 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             mergedCandidates = mergedCandidates,
             engineResult = engineResult
         )
+        latestBunsetsuConversionSnapshot = BunsetsuConversionSnapshot(
+            input, mergedCandidates, candidateSegments, bunsetsuSplitPatterns,
+            bunsetsuPositionList.orEmpty(),
+        )
     }
 
     private fun buildBunsetsuSegments(
         input: String,
-        splitPositions: List<Int>
-    ): List<BunsetsuSegmentState> {
-        val sanitizedSplitPositions = sanitizeSplitPositions(input, splitPositions)
-
-        val boundaries = buildList {
-            add(0)
-            addAll(sanitizedSplitPositions)
-            add(input.length)
-        }.distinct()
-
-        return boundaries.zipWithNext()
-            .mapNotNull { (start, end) ->
-                input.substring(start, end)
-                    .takeIf { it.isNotEmpty() }
-                    ?.let { reading ->
-                        BunsetsuSegmentState(
-                            reading = reading,
-                            displayText = reading
-                        )
-                    }
-            }
-    }
+        splitPositions: List<Int>,
+        snapshot: BunsetsuConversionSnapshot?,
+    ): List<BunsetsuSegmentState> = buildConvertedBunsetsuSegments(
+        input, sanitizeSplitPositions(input, splitPositions), snapshot, ::displayTextFromCandidate,
+    )
 
     private fun displayTextFromCandidate(candidate: Candidate): String {
         return if (candidate.type == (15).toByte()) {
@@ -18726,39 +18713,70 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         }
     }
 
+    private suspend fun queryBunsetsuConversion(input: String): KanaKanjiQueryResult {
+        // Query the converter directly: suggestion lookup also mutates the whole-input split state.
+        val result = withContext(kanaKanjiConversionDispatcher) {
+            queryKanaKanjiCore(
+                input = input,
+                mode = CandidateQueryMode.CONVERSION,
+                learnRepository = learnedRepositoryForSuggestion(),
+            )
+        }
+        val ngWords = if (isNgWordEnable == true) ngWordsList.value else emptyList()
+        val candidates = result.candidates.filter {
+            it.length.toInt() == input.length &&
+                !NgWordMatcher.matchesAny(input, it.string, ngWords)
+        }.withoutHentaiganaCandidatesIfNeeded().distinctBy { it.string }
+        val orderedCandidates = if (appPreference.candidate_order_override_enable_preference == true) {
+            candidateOrderOverrideRepository.applyOrderFromSnapshot(
+                input = input,
+                candidates = candidates,
+                candidateSegmentsByString = result.candidateSegmentsByString,
+            )
+        } else candidates
+        return result.copy(candidates = orderedCandidates)
+    }
+
     private suspend fun loadCandidatesForBunsetsuSegment(
         session: BunsetsuConversionSession,
         segmentIndex: Int,
-        mainView: MainLayoutBinding
     ): BunsetsuConversionSession {
-        if (segmentIndex !in session.segments.indices) return session
+        val targetSegment = session.segments.getOrNull(segmentIndex) ?: return session
+        if (targetSegment.candidatesLoaded) return session
 
-        val targetSegment = session.segments[segmentIndex]
-        if (targetSegment.candidates.isNotEmpty()) return session
-
-        val previousPositions = bunsetsuPositionList
-        val previousSplitPatterns = bunsetsuSplitPatterns
-        val targetReadingLength = targetSegment.reading.length
-        val candidates = try {
-            getSuggestionList(targetSegment.reading, mainView).filter {
-                it.length.toInt() == targetReadingLength
-            }
-        } finally {
-            bunsetsuPositionList = previousPositions
-            bunsetsuSplitPatterns = previousSplitPatterns
-        }
-
-        val displayText = candidates.firstOrNull()?.let(::displayTextFromCandidate)
-            ?: targetSegment.reading
-
+        val candidates = queryBunsetsuConversion(targetSegment.reading).candidates
         val updatedSegments = session.segments.toMutableList()
-        updatedSegments[segmentIndex] = targetSegment.copy(
-            candidates = candidates,
-            displayText = displayText,
-            selectedIndex = 0,
-            overrideDisplayCandidate = null
+        updatedSegments[segmentIndex] = mergeBunsetsuCandidates(
+            targetSegment, candidates, ::displayTextFromCandidate,
         )
         return session.copy(segments = updatedSegments)
+    }
+
+    private suspend fun prepareBunsetsuSegments(
+        session: BunsetsuConversionSession,
+    ): BunsetsuConversionSession {
+        var prepared = session
+        for (index in session.segments.indices) {
+            if (index == session.focusedIndex || !session.segments[index].hasConvertedDisplay) {
+                prepared = loadCandidatesForBunsetsuSegment(prepared, index)
+            }
+        }
+        return prepared
+    }
+
+    private fun launchBunsetsuOperation(
+        operation: suspend (BunsetsuConversionSession) -> Unit,
+    ) {
+        val generation = bunsetsuConversionSession?.generation ?: return
+        scope.launch {
+            bunsetsuOperationMutex.withLock {
+                val current = bunsetsuConversionSession ?: return@withLock
+                if (current.generation != generation || !isBunsetsuCursorMoveSessionActive()) {
+                    return@withLock
+                }
+                operation(current)
+            }
+        }
     }
 
     private suspend fun activateBunsetsuConversionSession(
@@ -18766,43 +18784,70 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         mainView: MainLayoutBinding,
         floatingKeyboardLayoutBinding: FloatingKeyboardLayoutBinding? = null
     ): Boolean {
-        if (!shouldUseBunsetsuCursorMoveSession()) return false
+        val requestedGeneration = bunsetsuSessionGeneration
+        return bunsetsuOperationMutex.withLock {
+            if (requestedGeneration != bunsetsuSessionGeneration || inputString.value != input) {
+                return@withLock true
+            }
+            if (!shouldUseBunsetsuCursorMoveSession()) return@withLock false
+            if (isBunsetsuCursorMoveSessionActive()) return@withLock true
 
-        val tailText = stringInTail.get()
-        val splitPatterns = normalizeBunsetsuSplitPatterns(input, bunsetsuSplitPatterns)
-        val initialSplitPositions = splitPatterns.firstOrNull().orEmpty()
-        val initialSegments = buildBunsetsuSegments(input, initialSplitPositions)
-        if (initialSegments.isEmpty()) {
-            clearBunsetsuConversionSession()
-            return false
+            val tailText = stringInTail.get()
+            val snapshot = latestBunsetsuConversionSnapshot?.takeIf { it.input == input }
+                ?: queryBunsetsuConversion(input).let { result ->
+                    BunsetsuConversionSnapshot(
+                        input = input,
+                        candidates = result.candidates,
+                        paths = result.candidateSegmentsByString,
+                        splitPatterns = result.bunsetsuResult?.splitPatterns.orEmpty(),
+                        initialSplitPositions = resolveInitialBunsetsuSplitPositions(
+                            input, result.candidates, result.bunsetsuResult,
+                        ),
+                    )
+                }
+            if (requestedGeneration != bunsetsuSessionGeneration || inputString.value != input) {
+                return@withLock true
+            }
+            val splitPatterns = normalizeBunsetsuSplitPatterns(
+                input, snapshot.splitPatterns, snapshot.initialSplitPositions,
+            )
+            val initialSplitPositions = splitPatterns.firstOrNull().orEmpty()
+            val initialSegments = buildBunsetsuSegments(input, initialSplitPositions, snapshot)
+            if (initialSegments.isEmpty()) {
+                clearBunsetsuConversionSession()
+                return@withLock false
+            }
+
+            val initialSession = BunsetsuConversionSession(
+                rawInput = input + tailText,
+                generation = ++bunsetsuSessionGeneration,
+                conversionSnapshot = snapshot,
+                conversionInput = input,
+                segments = initialSegments,
+                tailText = tailText,
+                focusedIndex = 0,
+                splitPatterns = splitPatterns,
+                activeSplitPatternIndex = 0
+            )
+
+            clearZenzLiveSlot("bunsetsu conversion session activated")
+            isHenkan.set(true)
+            henkanPressedWithBunsetsuDetect = true
+            bunsetusMultipleDetect = true
+            stringInTail.set("")
+            suggestionClickNum = 0
+            currentHighlightIndex = RecyclerView.NO_POSITION
+            bunsetsuPositionList = initialSplitPositions
+            bunsetsuSplitPatterns = splitPatterns
+            bunsetsuConversionSession = initialSession
+            val prepared = prepareBunsetsuSegments(initialSession)
+            if (bunsetsuConversionSession !== initialSession || !isBunsetsuCursorMoveSessionActive()) {
+                return@withLock true
+            }
+            bunsetsuConversionSession = prepared
+            renderBunsetsuConversionSession(mainView, floatingKeyboardLayoutBinding)
+            true
         }
-
-        val initialSession = BunsetsuConversionSession(
-            rawInput = input + tailText,
-            conversionInput = input,
-            segments = initialSegments,
-            tailText = tailText,
-            focusedIndex = 0,
-            splitPatterns = splitPatterns,
-            activeSplitPatternIndex = 0
-        )
-
-        clearZenzLiveSlot("bunsetsu conversion session activated")
-        isHenkan.set(true)
-        henkanPressedWithBunsetsuDetect = true
-        bunsetusMultipleDetect = true
-        stringInTail.set("")
-        suggestionClickNum = 0
-        currentHighlightIndex = RecyclerView.NO_POSITION
-        bunsetsuPositionList = initialSplitPositions
-        bunsetsuSplitPatterns = splitPatterns
-        bunsetsuConversionSession = loadCandidatesForBunsetsuSegment(
-            initialSession,
-            segmentIndex = 0,
-            mainView = mainView
-        )
-        renderBunsetsuConversionSession(mainView, floatingKeyboardLayoutBinding)
-        return true
     }
 
     private fun buildBunsetsuSegmentRanges(
@@ -18851,19 +18896,19 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     ): Boolean {
         if (!isBunsetsuCursorMoveSessionActive()) return false
         val mainView = mainLayoutBinding ?: return false
-        val session = bunsetsuConversionSession ?: return false
-        if (session.splitPatterns.size <= 1) return false
+        if ((bunsetsuConversionSession?.splitPatterns?.size ?: 0) <= 1) return false
 
-        scope.launch {
+        launchBunsetsuOperation { session ->
             val nextPatternIndex =
                 ((session.activeSplitPatternIndex + delta) % session.splitPatterns.size + session.splitPatterns.size) % session.splitPatterns.size
             val nextSplitPositions = session.splitPatterns[nextPatternIndex]
             val rebuiltSegments = buildBunsetsuSegments(
                 input = session.conversionInput,
-                splitPositions = nextSplitPositions
+                splitPositions = nextSplitPositions,
+                snapshot = session.conversionSnapshot,
             )
             if (rebuiltSegments.isEmpty()) {
-                return@launch
+                return@launchBunsetsuOperation
             }
 
             val nextFocusedIndex = findFocusedSegmentIndexForSplitPattern(
@@ -18877,13 +18922,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 focusedIndex = nextFocusedIndex,
                 activeSplitPatternIndex = nextPatternIndex
             )
+            val prepared = prepareBunsetsuSegments(switchedSession)
+            if (bunsetsuConversionSession !== session || !isBunsetsuCursorMoveSessionActive()) {
+                return@launchBunsetsuOperation
+            }
             bunsetsuPositionList = nextSplitPositions
             bunsetsuSplitPatterns = session.splitPatterns
-            bunsetsuConversionSession = loadCandidatesForBunsetsuSegment(
-                switchedSession,
-                segmentIndex = nextFocusedIndex,
-                mainView = mainView
-            )
+            bunsetsuConversionSession = prepared
             renderBunsetsuConversionSession(mainView, floatingKeyboardLayoutBinding)
         }
         return true
@@ -19081,6 +19126,7 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     }
 
     private fun clearBunsetsuConversionSession() {
+        bunsetsuSessionGeneration++
         bunsetsuConversionSession = null
         bunsetusMultipleDetect = false
     }
@@ -19147,17 +19193,18 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     ): Boolean {
         if (!isBunsetsuCursorMoveSessionActive()) return false
         val mainView = mainLayoutBinding ?: return false
-        val session = bunsetsuConversionSession ?: return false
-        val nextIndex = (session.focusedIndex + delta).coerceIn(0, session.segments.lastIndex)
-        if (nextIndex == session.focusedIndex) return true
-
-        scope.launch {
+        launchBunsetsuOperation { session ->
+            val nextIndex = (session.focusedIndex + delta).coerceIn(0, session.segments.lastIndex)
+            if (nextIndex == session.focusedIndex) return@launchBunsetsuOperation
             val movedSession = session.copy(focusedIndex = nextIndex)
-            bunsetsuConversionSession = loadCandidatesForBunsetsuSegment(
+            val loadedSession = loadCandidatesForBunsetsuSegment(
                 movedSession,
-                segmentIndex = nextIndex,
-                mainView = mainView
+                segmentIndex = nextIndex
             )
+            if (bunsetsuConversionSession !== session || !isBunsetsuCursorMoveSessionActive()) {
+                return@launchBunsetsuOperation
+            }
+            bunsetsuConversionSession = loadedSession
             renderBunsetsuConversionSession(mainView, floatingKeyboardLayoutBinding)
         }
         return true
@@ -19169,19 +19216,19 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
     ): Boolean {
         if (!isBunsetsuCursorMoveSessionActive()) return false
         val mainView = mainLayoutBinding ?: return false
-        val session = bunsetsuConversionSession ?: return false
-
-        scope.launch {
+        launchBunsetsuOperation { session ->
             val loadedSession = loadCandidatesForBunsetsuSegment(
                 session,
-                segmentIndex = session.focusedIndex,
-                mainView = mainView
+                segmentIndex = session.focusedIndex
             )
+            if (bunsetsuConversionSession !== session || !isBunsetsuCursorMoveSessionActive()) {
+                return@launchBunsetsuOperation
+            }
             val segment = loadedSession.segments[loadedSession.focusedIndex]
             if (segment.candidates.isEmpty()) {
                 bunsetsuConversionSession = loadedSession
                 renderBunsetsuConversionSession(mainView, floatingKeyboardLayoutBinding)
-                return@launch
+                return@launchBunsetsuOperation
             }
 
             val candidateCount = segment.candidates.size
@@ -24510,7 +24557,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             updateBunsetsuStateAfterCandidateMerge(
                 input = insertString,
                 mergedCandidates = orderedCandidates,
-                engineResult = engineResult
+                engineResult = engineResult,
+                candidateSegments = coreResult.candidateSegmentsByString,
             )
         }
 
@@ -24644,7 +24692,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             updateBunsetsuStateAfterCandidateMerge(
                 input = insertString,
                 mergedCandidates = orderedCandidates,
-                engineResult = engineResult
+                engineResult = engineResult,
+                candidateSegments = coreResult.candidateSegmentsByString,
             )
         }
 
@@ -24767,7 +24816,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
             updateBunsetsuStateAfterCandidateMerge(
                 input = insertString,
                 mergedCandidates = orderedCandidates,
-                engineResult = engineResult
+                engineResult = engineResult,
+                candidateSegments = coreResult.candidateSegmentsByString,
             )
         }
 
@@ -24868,7 +24918,8 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 beamWidth = conversionBeamWidth,
                 predictionConfig = predictionConfig,
                 collectCandidateSegments =
-                    appPreference.candidate_order_override_enable_preference == true,
+                    appPreference.candidate_order_override_enable_preference == true ||
+                        shouldUseBunsetsuCursorMoveSession(),
             )
         )
         if (BuildConfig.DEBUG) {

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -18722,8 +18722,13 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
                 learnRepository = learnedRepositoryForSuggestion(),
             )
         }
+        val romajiCandidates = if (conversionCandidatesRomajiEnablePreference == true) {
+            getRomajiCandidates(input)
+        } else {
+            emptyList()
+        }
         val ngWords = if (isNgWordEnable == true) ngWordsList.value else emptyList()
-        val candidates = result.candidates.filter {
+        val candidates = (result.candidates + romajiCandidates).filter {
             it.length.toInt() == input.length &&
                 !NgWordMatcher.matchesAny(input, it.string, ngWords)
         }.withoutHentaiganaCandidatesIfNeeded().distinctBy { it.string }

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/converter/session/KanaKanjiConversionSessionParityTest.kt
@@ -1,5 +1,8 @@
 package com.kazumaproject.markdownhelperkeyboard.converter.session
 
+import com.kazumaproject.markdownhelperkeyboard.ime_service.BunsetsuConversionSnapshot
+import com.kazumaproject.markdownhelperkeyboard.ime_service.buildConvertedBunsetsuSegments
+import com.kazumaproject.markdownhelperkeyboard.ime_service.mergeBunsetsuCandidates
 import com.kazumaproject.markdownhelperkeyboard.converter.TestEngineFactory
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.PredictionConfig
@@ -21,6 +24,38 @@ import org.robolectric.annotation.Config
 @RunWith(RobolectricTestRunner::class)
 @Config(sdk = [35])
 class KanaKanjiConversionSessionParityTest {
+
+    @Test
+    fun bunsetsuDisplayPreservesFullLatticeResultAcrossBackendsAndCandidateLoading() = runBlocking {
+        val input = "あしたはとうきょうにいきます"
+        for (backend in ConversionBackend.entries) {
+            val session = KanaKanjiConversionSession(engine, backend)
+            for (mode in listOf(CandidateQueryMode.NO_TAB_DEFAULT, CandidateQueryMode.PREDICTION, CandidateQueryMode.CONVERSION)) {
+                val query = request(input, mode, bunsetsu = true)
+                val result = session.query(query)
+                val first = result.candidates.first()
+                val splits = result.bunsetsuResult!!.primarySplitPositions
+                assertTrue("$backend/$mode must have multiple bunsetsu", splits.size >= 2)
+                val segments = buildConvertedBunsetsuSegments(
+                    input, splits,
+                    BunsetsuConversionSnapshot(input, result.candidates, result.candidateSegmentsByString),
+                )
+                assertTrue("$backend/$mode must provide exact paths", segments.all { it.hasConvertedDisplay })
+                assertEquals(first.string, segments.joinToString("") { it.displayText })
+                for (segment in segments) {
+                    val alternatives = session.query(request(segment.reading, CandidateQueryMode.CONVERSION, true))
+                    val loaded = mergeBunsetsuCandidates(segment, alternatives.candidates.filter {
+                        it.length.toInt() == segment.reading.length
+                    })
+                    assertEquals(segment.displayText, loaded.displayText)
+                    assertEquals(segment.displayText, loaded.candidates[loaded.selectedIndex].string)
+                }
+                // Collection changes metadata only, not the converter's scores or ordering.
+                val withoutPaths = session.query(query.copy(collectCandidateSegments = false))
+                assertEquals(result.candidates.fingerprint(), withoutPaths.candidates.fingerprint())
+            }
+        }
+    }
 
     @Test
     fun incrementalSessionMatchesLegacyAcrossModesAndBunsetsu() = runBlocking {

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuConversionProjectionTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuConversionProjectionTest.kt
@@ -1,0 +1,117 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CandidateConversionSegment
+import org.junit.Assert.*
+import org.junit.Test
+
+class BunsetsuConversionProjectionTest {
+    private val reading = "あしたはとうきょうにいきます"
+    private val path = listOf(
+        CandidateConversionSegment(0, 3, "明日"),
+        CandidateConversionSegment(3, 4, "は"),
+        CandidateConversionSegment(4, 9, "東京"),
+        CandidateConversionSegment(9, 10, "に"),
+        CandidateConversionSegment(10, 12, "行き"),
+        CandidateConversionSegment(12, 14, "ます"),
+    )
+    private fun candidate(text: String, length: Int = reading.length) = Candidate(
+        string = text, type = 1, length = length.toUByte(), score = 1000,
+    )
+    private fun snapshot(nodes: List<CandidateConversionSegment> = path) = BunsetsuConversionSnapshot(
+        reading, listOf(candidate("明日は東京に行きます")), mapOf("明日は東京に行きます" to nodes),
+    )
+
+    @Test
+    fun unsplitInputKeepsPromotedCandidateEvenWhenOnlyLowerCandidateHasPath() {
+        val promoted = candidate("あすは東京に行きます")
+        val source = snapshot().copy(candidates = listOf(promoted) + snapshot().candidates)
+        val segment = buildConvertedBunsetsuSegments(reading, emptyList(), source).single()
+        assertEquals(promoted.string, segment.displayText)
+    }
+
+    @Test
+    fun readingCorrectionUsesDisplayTextAndDoesNotCreateDuplicateAlternatives() {
+        val corrected = candidate("correction-markup", 2).copy(type = 15)
+        val segment = BunsetsuSegmentState("よみ", "表記", hasConvertedDisplay = true)
+        val loaded = mergeBunsetsuCandidates(segment, listOf(corrected)) { "表記" }
+        assertEquals("表記", loaded.displayText)
+        assertEquals(listOf(corrected), loaded.candidates)
+    }
+
+    @Test
+    fun firstConversionDisplaysEverySegmentUsingReadingOffsets() {
+        val segments = buildConvertedBunsetsuSegments(reading, listOf(4, 10), snapshot())
+        assertEquals(listOf("明日は", "東京に", "行きます"), segments.map { it.displayText })
+        assertEquals(reading, segments.joinToString("") { it.reading })
+        assertTrue(segments.all { it.hasConvertedDisplay })
+        assertFalse(segments.any { it.candidatesLoaded })
+    }
+
+    @Test
+    fun loadingSecondSegmentPreservesSentenceChoiceDespiteDifferentLocalRanking() {
+        val segments = buildConvertedBunsetsuSegments(reading, listOf(4, 10), snapshot())
+        val tokyo = candidate("東京に", 6)
+        val alternative = candidate("とうきょうに", 6)
+        val loaded = mergeBunsetsuCandidates(segments[1], listOf(alternative, tokyo))
+        assertEquals("東京に", loaded.displayText)
+        assertEquals(listOf(tokyo, alternative), loaded.candidates)
+        assertEquals(0, loaded.selectedIndex)
+        assertTrue(loaded.candidatesLoaded)
+        val updated = segments.toMutableList().apply { this[1] = loaded }
+        assertEquals("明日は東京に行きます", updated.joinToString("") { it.displayText })
+    }
+
+    @Test
+    fun wholeSentenceChoiceSurvivesMissingLocalCandidate() {
+        val segment = buildConvertedBunsetsuSegments(reading, listOf(4, 10), snapshot())[2]
+        val loaded = mergeBunsetsuCandidates(segment, listOf(candidate("いきます", 4)))
+        assertEquals("行きます", loaded.displayText)
+        assertEquals(listOf("行きます", "いきます"), loaded.candidates.map { it.string })
+    }
+
+    @Test
+    fun changingSplitPatternCombinesCompleteNodes() {
+        val segments = buildConvertedBunsetsuSegments(reading, listOf(10), snapshot())
+        assertEquals(listOf("明日は東京に", "行きます"), segments.map { it.displayText })
+    }
+
+    @Test
+    fun boundaryInsideNodeRequiresConversionInsteadOfSlicingKanji() {
+        val segments = buildConvertedBunsetsuSegments(reading, listOf(2, 10), snapshot())
+        assertFalse(segments[0].hasConvertedDisplay)
+        assertFalse(segments[1].hasConvertedDisplay)
+        assertEquals("行きます", segments[2].displayText)
+        assertEquals(reading, segments.joinToString("") { it.reading })
+        val loaded = mergeBunsetsuCandidates(segments[0], listOf(candidate("足", 2)))
+        assertEquals("足", loaded.displayText)
+    }
+
+    @Test
+    fun staleOrIncompletePathsAreNotApplied() {
+        val stale = snapshot().copy(input = "べつのよみ")
+        val gap = snapshot(path.filterNot { it.inputStart == 3 })
+        val incorrectOutput = snapshot(path.map { if (it.inputStart == 0) it.copy(output = "昨日") else it })
+        for (invalid in listOf(stale, gap, incorrectOutput, null)) {
+            val segments = buildConvertedBunsetsuSegments(reading, listOf(4, 10), invalid)
+            assertFalse(segments.any { it.hasConvertedDisplay })
+            assertEquals(reading, segments.joinToString("") { it.displayText })
+        }
+    }
+
+    @Test
+    fun unknownReadingHasSelectableFallbackAndEmptyInputHasNoSegments() {
+        val segment = buildConvertedBunsetsuSegments("ほげ", emptyList(), null).single()
+        val loaded = mergeBunsetsuCandidates(segment, emptyList())
+        assertEquals("ほげ", loaded.displayText)
+        assertEquals("ほげ", loaded.candidates.single().string)
+        assertTrue(loaded.candidatesLoaded)
+        assertTrue(buildConvertedBunsetsuSegments("", listOf(1), null).isEmpty())
+    }
+
+    @Test
+    fun splitNormalizationDoesNotLoseOrDuplicateText() {
+        val segments = buildConvertedBunsetsuSegments(reading, listOf(10, -1, 4, 4, 99), snapshot())
+        assertEquals(listOf("明日は", "東京に", "行きます"), segments.map { it.displayText })
+    }
+}

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuRomajiCandidatesTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuRomajiCandidatesTest.kt
@@ -1,0 +1,96 @@
+package com.kazumaproject.markdownhelperkeyboard.ime_service
+
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.engine.KanaKanjiEngine
+import com.kazumaproject.markdownhelperkeyboard.converter.session.KanaKanjiConversionSession
+import com.kazumaproject.markdownhelperkeyboard.converter.session.KanaKanjiQueryResult
+import com.kazumaproject.markdownhelperkeyboard.ime_service.romaji_kana.RomajiKanaConverter
+import com.kazumaproject.markdownhelperkeyboard.ng_word.database.NgWord
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.ExecutorCoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.*
+import org.junit.runner.RunWith
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.util.ReflectionHelpers
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.intrinsics.suspendCoroutineUninterceptedOrReturn
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [35])
+class BunsetsuRomajiCandidatesTest {
+    private val service = IMEService()
+    private val session = mock<KanaKanjiConversionSession>()
+    private val school = Candidate(string = "学校", type = 1, length = 4u, score = 1000)
+    private val romaji = listOf("ｇａｋｋｏｕ", "gakkou", "Ｇａｋｋｏｕ", "Gakkou", "ＧＡＫＫＯＵ", "GAKKOU")
+
+    @Before fun setUp() = runBlocking {
+        service.appPreference = mock()
+        service.userDictionaryRepository = mock()
+        ReflectionHelpers.getField<CompletableDeferred<KanaKanjiEngine>>(service, "kanaKanjiEngineReady")
+            .complete(mock())
+        ReflectionHelpers.setField(service, "kanaKanjiConversionSession", session)
+        ReflectionHelpers.setField(service, "isLearnDictionaryMode", false)
+        ReflectionHelpers.setField(service, "romajiConverter", RomajiKanaConverter(mapOf(
+            "ga" to ("が" to 0), "ko" to ("こ" to 0), "u" to ("う" to 0),
+        )))
+        whenever(session.query(any())).thenReturn(KanaKanjiQueryResult(listOf(school)))
+        Unit
+    }
+
+    @After fun tearDown() {
+        ReflectionHelpers.getField<ExecutorCoroutineDispatcher>(service, "kanaKanjiConversionDispatcher").close()
+    }
+
+    @Test fun enabledAddsAllRomajiVariantsWithoutReplacingConvertedDisplay() = runBlocking {
+        ReflectionHelpers.setField(service, "conversionCandidatesRomajiEnablePreference", true)
+        val result = query()
+        assertEquals(listOf("学校") + romaji, result.candidates.map { it.string })
+        assertTrue(result.candidates.all { it.length.toInt() == 4 })
+        val loaded = mergeBunsetsuCandidates(
+            BunsetsuSegmentState("がっこう", "学校", hasConvertedDisplay = true), result.candidates,
+        )
+        assertEquals("学校", loaded.displayText)
+        assertEquals(0, loaded.selectedIndex)
+        assertTrue(loaded.candidates.map { it.string }.containsAll(romaji))
+    }
+
+    @Test fun disabledDoesNotAddRomaji() = runBlocking {
+        ReflectionHelpers.setField(service, "conversionCandidatesRomajiEnablePreference", false)
+        assertEquals(listOf(school), query().candidates)
+    }
+
+    @Test fun romajiPassesThroughNgWordFilteringAndDeduplication() = runBlocking {
+        ReflectionHelpers.setField(service, "conversionCandidatesRomajiEnablePreference", true)
+        ReflectionHelpers.setField(service, "isNgWordEnable", true)
+        ReflectionHelpers.getField<MutableStateFlow<List<NgWord>>>(service, "_ngWordsList").value =
+            listOf(NgWord(yomi = "がっこう", tango = "GAKKOU"))
+        val duplicate = school.copy(string = "gakkou")
+        whenever(session.query(any())).thenReturn(KanaKanjiQueryResult(listOf(school, duplicate)))
+        val candidates = query().candidates
+        assertFalse(candidates.any { it.string == "GAKKOU" })
+        assertEquals(1, candidates.count { it.string == "gakkou" })
+        assertEquals(duplicate, candidates.single { it.string == "gakkou" })
+        assertTrue(candidates.any { it.string == "ｇａｋｋｏｕ" })
+    }
+
+    @Test fun missingConverterKeepsEngineCandidates() = runBlocking {
+        ReflectionHelpers.setField(service, "conversionCandidatesRomajiEnablePreference", true)
+        ReflectionHelpers.setField(service, "romajiConverter", null)
+        assertEquals(listOf(school), query().candidates)
+    }
+
+    private suspend fun query(): KanaKanjiQueryResult = suspendCoroutineUninterceptedOrReturn { continuation ->
+        IMEService::class.java.getDeclaredMethod(
+            "queryBunsetsuConversion", String::class.java, Continuation::class.java,
+        ).apply { isAccessible = true }.invoke(service, "がっこう", continuation)
+    }
+}


### PR DESCRIPTION
## 日本語

### 問題と変更後の動作

「変換キーで文節を分割」と文節単位のカーソル移動が有効な場合、変換開始時に全ての文節を読みで初期化し、先頭文節だけ候補を取得していました。そのため、2文節目以降がひらがなのまま残り、カーソル移動時には全文の変換結果と異なる表記になることがありました。

この変更では、例えば「あしたはとうきょうにいきます」を初めて変換した時点で「明日は｜東京に｜行きます」と表示します。左右キーで文節を移動しても表記を保持し、変換キーは選択中の文節の候補だけを変更します。他の文節はそのまま残ります。

### 実装の詳細

- 既存の LOUDS 辞書検索、ラティス、単語コスト・Mozc 品詞接続コストによる変換経路を再利用します。辞書・スコア体系は変更していません。
- 文節変換でも既存の `CandidateConversionSegment` を収集し、全文の入力・候補・経路・分割位置を一つのスナップショットとして保持します。候補順序設定が無効でも経路情報を利用できます。
- 読みの範囲に含まれる経路ノードの表記を連結して、各文節の初期表示を復元します。読みと漢字の文字数が異なる場合でも、変換後の文字列を読みの文字数で切り分けません。
- 全文結果がまだない場合は、全文を検索してから文節を初期化します。分割位置を変えた場合も、経路で復元できない範囲は既存エンジンで変換し、候補がない場合だけ読みへフォールバックします。
- 文節の追加候補は既存エンジンへ直接問い合わせます。全文の分割状態を変更せず、現在の表記を先頭候補として保持したうえで、重複を除いて候補を統合します。候補順序設定・NG ワードのフィルタ・表示用の読み補正も適用します。
- 文節移動・候補変更・分割変更を直列化し、世代番号とセッションの同一性を確認します。取消・確定・入力変更後に古い非同期結果が表示を上書きしないようにします。

### テストとレビュー

- 差分レビューでは、初期表記の復元、読みの範囲の整合性、局所候補取得の副作用、取消後の非同期更新、確定時の文字欠落を確認しました。
- 変更前の `dev`（`dc6e4ec86`）でも同じエミュレータテストを実行し、「明日はとうきょうにいきます」となって新規回帰テストが失敗することを確認しました。修正版では「明日は東京に行きます」となり、同じ回帰テストが成功します。
- JVM: 33件成功、明示的な実行指定が必要な性能測定1件はスキップ。経路の不整合、文字数の差、未知語、分割変更、候補の重複、局所候補を取得した際の全文表記の保持を確認しました。
- 実辞書を使ったテストで、通常バックエンド・増分バックエンドの両方と、通常候補・予測・変換の各モードを確認しました。経路収集の有無で候補とスコアの順序が変わらないことも検証しています。
- Android 15 / API 35 のエミュレータで、物理キー操作と画面タップを検証しました。画面タップは通常表示・フローティング表示の両方で、初回変換、文節移動、選択文節だけの候補変更、確定を確認しています。
- エミュレータの最終実行は計12件成功（物理キー11件、通常・フローティング両表示を含む画面タップ1件）。文節幅変更後の取消、候補順序設定のオン・オフ、連続した移動・変換・取消、部分確定、エディタ再開を確認しました。
- `fullStandardDebug` APK と AndroidTest APK のビルド、`git diff --check` が成功しています。
- テスト用 IME は Android が返す実際のコンポーネント ID で選択し、選択成功を検証するよう修正しました。また、テスト間の学習結果による候補順位の変動を避けるため、学習を無効化して終了時に設定を復元します。
- 既存の部分確定直後の入力テストは、未確定の後続全体（例：「はれるといいですねはれた」）が自動変換される正当なタイミング差も検証対象にしました。許容するのは具体的な2つの期待文字列だけであり、確定した前半・後続文節・新規入力「あ」の欠落は引き続き失敗になります。

再確認した差分と上記テストの範囲で、未解消の問題は見つかりませんでした。

### 変更範囲

`dev` 起点の `fix/bunsetsu-full-conversion` で実装しました。本体2ファイルと関連テスト4ファイルのみを含みます。APK、スクリーンショット、ログ、ローカル設定、PR本文ファイルはコミットしません。検証結果はエミュレータの結果であり、実機での確認結果ではありません。

---

## English

### Problem and resulting behavior

When bunsetsu separation and cursor navigation were enabled, conversion initialized every segment with its reading and fetched candidates only for the first segment. Later segments remained in hiragana, and navigating to them could replace the full-sentence choice with an independently ranked local result.

With this change, the first conversion of `あしたはとうきょうにいきます` displays `明日は | 東京に | 行きます`. Moving between segments preserves their output. Pressing the conversion key changes only the focused segment and leaves the other segments unchanged.

### Implementation details

- Reuse the existing LOUDS dictionaries, lattice search, word costs, and Mozc part-of-speech connection costs. No dictionary or scoring changes are introduced.
- Collect the existing `CandidateConversionSegment` metadata for bunsetsu conversion independently of candidate-order overrides. Retain the input, candidates, paths, and split positions from the same query in one snapshot.
- Initialize each segment from complete lattice nodes covering its reading range. Converted text is never sliced using reading lengths, which can differ from kanji output lengths.
- If a matching full-input result is not yet available, query the full input before initializing the session. After a split change, convert ranges that cannot be projected from a path; use the reading only when no candidate is available.
- Query the converter directly for additional segment candidates without mutating the full-input split state. Keep the current output as the initial selection, deduplicate alternatives, and honor candidate-order overrides, NG-word filtering, and corrected display text.
- Serialize navigation, candidate cycling, and split changes. Check session generation and identity before applying asynchronous results so canceled, committed, or replaced sessions cannot be restored by stale work.

### Validation and review

- Reviewed initial output projection, reading-range consistency, side effects of local candidate loading, asynchronous updates after cancellation, and text preservation on commit.
- Ran the same emulator regression test against the unchanged `dev` baseline (`dc6e4ec86`): it fails with `明日はとうきょうにいきます`, reproducing the reported bug. The patched build displays `明日は東京に行きます` and passes that test.
- JVM tests: 33 passed; one opt-in performance probe skipped. Coverage includes unequal reading/output lengths, invalid paths, unknown readings, split changes, duplicate alternatives, and preservation of the sentence-level choice during local candidate loading.
- Real-dictionary tests cover both legacy and incremental backends across default, prediction, and conversion queries. Enabling path collection preserves candidate ordering and scores.
- Android 15 / API 35 emulator tests cover hardware-key events and actual touchscreen taps. Touch tests exercise both the normal and floating keyboards, including initial conversion, navigation, focused-only candidate changes, and commit.
- Final emulator runs: 12 tests passed (11 hardware-key tests and one touch test covering both normal and floating displays). Coverage includes split-width cancellation, candidate ordering enabled/disabled, rapid navigation/conversion/cancellation, partial commits, and editor restarts.
- `fullStandardDebug`, AndroidTest APK builds, and `git diff --check` pass.
- Fix the test harness to select the exact IME component ID returned by Android and verify that selection succeeded. Disable learning during tests and restore preferences afterward to prevent one test's learned candidates from changing later expectations.
- The existing immediate-input-after-partial-commit test now checks both valid schedules: the complete remaining reading (for example, `はれるといいですねはれた`) may stay in kana or be automatically converted before the next key arrives. Only two exact expected strings are accepted; loss of the committed prefix, remaining segment, or new `あ` still fails.

No unresolved issues were found in the reviewed changes and the validation above.

### Scope

Implemented on `fix/bunsetsu-full-conversion`, based on `dev`. The PR contains only two production files and four relevant test files. APKs, screenshots, logs, local configuration, and this PR description file are not committed. Device-level results above are emulator results, not physical-device results.
