### PR TITLE
文節変換の定型文候補とNGワード判定を修正

### DIFF
--- a/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/PhysicalCandidateCompositionInstrumentedTest.kt
+++ b/app/src/androidTest/java/com/kazumaproject/markdownhelperkeyboard/PhysicalCandidateCompositionInstrumentedTest.kt
@@ -13,6 +13,11 @@ import androidx.preference.PreferenceManager
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
+import com.kazumaproject.markdownhelperkeyboard.ng_word.database.NgWord
+import com.kazumaproject.markdownhelperkeyboard.ng_word.database.NgWordMatchMode
+import com.kazumaproject.markdownhelperkeyboard.user_template.database.UserTemplate
+import dagger.hilt.android.EntryPointAccessors
+import kotlinx.coroutines.runBlocking
 import org.junit.Assert.*
 import org.junit.Test
 import org.junit.BeforeClass
@@ -55,6 +60,102 @@ class PhysicalCandidateCompositionInstrumentedTest {
         assertEquals("あしたはとうきょうにいきます", text())
         key(KeyEvent.KEYCODE_DEL)
         awaitText("あしたはとうきょうにいきま")
+    }
+
+    @Test fun bunsetsuTemplatesRemainSelectableAndCommitWithSurroundingSegments() {
+        val templates = listOf(
+            UserTemplate(word = "文節テスト定型文Ａ", reading = "とうきょうに", posIndex = 0, posScore = 100),
+            UserTemplate(word = "文節テスト定型文Ｂ", reading = "とうきょうに", posIndex = 0, posScore = 200),
+        )
+        withCandidateFixtures(templates = templates) {
+            withKeyboard(bunsetsu = true) {
+                type("ashitahatoukyouniikimasu")
+                awaitText("あしたはとうきょうにいきます")
+                key(KeyEvent.KEYCODE_SPACE)
+                awaitText("明日は東京に行きます")
+                key(KeyEvent.KEYCODE_DPAD_RIGHT)
+                await { focusedRange() == (3 until 6) }
+                key(KeyEvent.KEYCODE_SPACE)
+                awaitText("明日は文節テスト定型文Ａ行きます")
+                key(KeyEvent.KEYCODE_SPACE)
+                awaitText("明日は文節テスト定型文Ｂ行きます")
+                key(KeyEvent.KEYCODE_DPAD_RIGHT)
+                key(KeyEvent.KEYCODE_DPAD_LEFT)
+                assertEquals("明日は文節テスト定型文Ｂ行きます", text())
+                key(KeyEvent.KEYCODE_ENTER)
+                awaitText("明日は文節テスト定型文Ｂ行きます")
+                host.onActivity { assertEquals(-1, BaseInputConnection.getComposingSpanStart(it.editText.text)) }
+            }
+        }
+    }
+
+    @Test fun bunsetsuExactNgWordIsExcludedFromUnfocusedSegmentAndCommit() {
+        assertExactNgWordExcluded("とうきょうに", "東京に", moveRight = true)
+    }
+
+    @Test fun bunsetsuExactNgWordIsExcludedFromFirstSegmentAndCommit() {
+        assertExactNgWordExcluded("あしたは", "明日は", moveRight = false)
+    }
+
+    private fun assertExactNgWordExcluded(reading: String, blocked: String, moveRight: Boolean) {
+        withCandidateFixtures(ngWord = NgWord(yomi = reading, tango = blocked, matchMode = NgWordMatchMode.EXACT)) {
+            withKeyboard(bunsetsu = true) {
+                type("ashitahatoukyouniikimasu")
+                awaitText("あしたはとうきょうにいきます")
+                key(KeyEvent.KEYCODE_SPACE)
+                await { focusedRange().first == 0 && text().endsWith("行きます") }
+                assertFalse("Blocked output appeared on initial conversion: ${text()}", text().contains(blocked))
+                if (moveRight) {
+                    assertTrue(text().startsWith("明日は"))
+                    key(KeyEvent.KEYCODE_DPAD_RIGHT)
+                    await { focusedRange().first == 3 }
+                } else {
+                    assertTrue(text().endsWith("東京に行きます"))
+                }
+                repeat(6) {
+                    key(KeyEvent.KEYCODE_SPACE)
+                    assertFalse("Blocked output returned while cycling: ${text()}", text().contains(blocked))
+                    assertTrue(text().endsWith("行きます"))
+                }
+                val converted = text()
+                key(KeyEvent.KEYCODE_ENTER)
+                awaitText(converted)
+                host.onActivity { assertEquals(-1, BaseInputConnection.getComposingSpanStart(it.editText.text)) }
+            }
+        }
+    }
+
+    private fun withCandidateFixtures(
+        templates: List<UserTemplate> = emptyList(),
+        ngWord: NgWord? = null,
+        block: () -> Unit,
+    ) {
+        val db = EntryPointAccessors.fromApplication(
+            instrumentation.targetContext.applicationContext, BunsetsuTestDatabaseEntryPoint::class.java,
+        ).database()
+        val insertedTemplates = mutableListOf<Int>()
+        var insertedNgWord: NgWord? = null
+        try {
+            runBlocking {
+                for (template in templates) {
+                    val existing = db.userTemplateDao().searchByReadingExactSuspend(template.reading, Int.MAX_VALUE)
+                    check(existing.none { it.word == template.word }) { "Fixture already exists" }
+                    db.userTemplateDao().insert(template)
+                    insertedTemplates += db.userTemplateDao().searchByReadingExactSuspend(template.reading, Int.MAX_VALUE)
+                        .single { it.word == template.word }.id
+                }
+                if (ngWord != null) {
+                    check(db.ngWordDao().find(ngWord.yomi, ngWord.tango) == null) { "NG fixture already exists" }
+                    insertedNgWord = ngWord.copy(id = db.ngWordDao().insert(ngWord).toInt())
+                }
+            }
+            block()
+        } finally {
+            runBlocking {
+                insertedTemplates.forEach { db.userTemplateDao().delete(it) }
+                insertedNgWord?.let { db.ngWordDao().delete(it) }
+            }
+        }
     }
 
     private fun assertBunsetsuConversionAndNavigation() {
@@ -314,6 +415,8 @@ class PhysicalCandidateCompositionInstrumentedTest {
             "conversion_bunsetsu_cursor_move_preference" to bunsetsu,
             "candidate_order_override_enable_preference" to candidateOrdering,
             "learn_dictionary_preference" to false,
+            "user_template_preference" to true,
+            "ng_word_enable_preference" to true,
             "physical_keyboard_input_mode_preference" to if (kana) "kana" else "romaji",
             "live_conversion_preference" to false,
             "sumire_keymap_guide_japanese" to false,

--- a/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/BunsetsuTestDatabaseEntryPoint.kt
+++ b/app/src/debug/java/com/kazumaproject/markdownhelperkeyboard/BunsetsuTestDatabaseEntryPoint.kt
@@ -1,0 +1,13 @@
+package com.kazumaproject.markdownhelperkeyboard
+
+import com.kazumaproject.markdownhelperkeyboard.database.AppDatabase
+import dagger.hilt.EntryPoint
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+/** Lets instrumentation seed and clean up fixtures in the same Room instance used by the IME. */
+@EntryPoint
+@InstallIn(SingletonComponent::class)
+interface BunsetsuTestDatabaseEntryPoint {
+    fun database(): AppDatabase
+}

--- a/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
+++ b/app/src/main/java/com/kazumaproject/markdownhelperkeyboard/ime_service/IMEService.kt
@@ -18701,9 +18701,20 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         input: String,
         splitPositions: List<Int>,
         snapshot: BunsetsuConversionSnapshot?,
-    ): List<BunsetsuSegmentState> = buildConvertedBunsetsuSegments(
-        input, sanitizeSplitPositions(input, splitPositions), snapshot, ::displayTextFromCandidate,
-    )
+    ): List<BunsetsuSegmentState> {
+        val ngWords = if (isNgWordEnable == true) ngWordsList.value else emptyList()
+        return buildConvertedBunsetsuSegments(
+            input, sanitizeSplitPositions(input, splitPositions), snapshot, ::displayTextFromCandidate,
+        ).map { segment ->
+            // A full-input candidate can pass an exact NG rule that matches one of its segments.
+            // Invalidate before preparation so even unfocused segments load a permitted alternative.
+            if (NgWordMatcher.matchesAny(segment.reading, segment.displayText, ngWords)) {
+                segment.copy(displayText = segment.reading, hasConvertedDisplay = false)
+            } else {
+                segment
+            }
+        }
+    }
 
     private fun displayTextFromCandidate(candidate: Candidate): String {
         return if (candidate.type == (15).toByte()) {
@@ -18727,8 +18738,9 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         } else {
             emptyList()
         }
+        val templateCandidates = getLegacyUserTemplateCandidates(input)
         val ngWords = if (isNgWordEnable == true) ngWordsList.value else emptyList()
-        val candidates = (result.candidates + romajiCandidates).filter {
+        val candidates = (templateCandidates + result.candidates + romajiCandidates).filter {
             it.length.toInt() == input.length &&
                 !NgWordMatcher.matchesAny(input, it.string, ngWords)
         }.withoutHentaiganaCandidatesIfNeeded().distinctBy { it.string }
@@ -24949,16 +24961,17 @@ class IMEService : InputMethodService(), LifecycleOwner, InputConnection,
         return filterNot { it.string.containsHentaigana() }
     }
 
+    private suspend fun getLegacyUserTemplateCandidates(input: String): List<Candidate> {
+        if (isUserTemplateEnable != true) return emptyList()
+        return withContext(Dispatchers.IO) {
+            userTemplateRepository.searchByReading(reading = input, limit = 8)
+                .toUserTemplateCandidates()
+        }
+    }
+
     private suspend fun getUserTemplateCandidates(insertString: String): List<Candidate> {
         return withContext(Dispatchers.IO) {
-            val legacyTemplates = if (isUserTemplateEnable == true) {
-                userTemplateRepository.searchByReading(
-                    reading = insertString,
-                    limit = 8
-                ).toUserTemplateCandidates()
-            } else {
-                emptyList()
-            }
+            val legacyTemplates = getLegacyUserTemplateCandidates(insertString)
             val contextualMacrosAllowed = !isPrivateMode && currentInputType !in passwordTypes
             val macros = if (isTextMacroCandidateEnable) {
                 textMacroRepository.getEnabledByReading(insertString, limit = 8)

--- a/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuRomajiCandidatesTest.kt
+++ b/app/src/test/java/com/kazumaproject/markdownhelperkeyboard/ime_service/BunsetsuRomajiCandidatesTest.kt
@@ -1,11 +1,15 @@
 package com.kazumaproject.markdownhelperkeyboard.ime_service
 
 import com.kazumaproject.markdownhelperkeyboard.converter.candidate.Candidate
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CandidateConversionSegment
+import com.kazumaproject.markdownhelperkeyboard.converter.candidate.CANDIDATE_TYPE_USER_TEMPLATE
 import com.kazumaproject.markdownhelperkeyboard.converter.engine.KanaKanjiEngine
 import com.kazumaproject.markdownhelperkeyboard.converter.session.KanaKanjiConversionSession
 import com.kazumaproject.markdownhelperkeyboard.converter.session.KanaKanjiQueryResult
 import com.kazumaproject.markdownhelperkeyboard.ime_service.romaji_kana.RomajiKanaConverter
 import com.kazumaproject.markdownhelperkeyboard.ng_word.database.NgWord
+import com.kazumaproject.markdownhelperkeyboard.ng_word.database.NgWordMatchMode
+import com.kazumaproject.markdownhelperkeyboard.user_template.database.UserTemplate
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.ExecutorCoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -18,6 +22,7 @@ import org.junit.runner.RunWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.mockito.kotlin.verifyNoInteractions
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.util.ReflectionHelpers
@@ -35,6 +40,7 @@ class BunsetsuRomajiCandidatesTest {
     @Before fun setUp() = runBlocking {
         service.appPreference = mock()
         service.userDictionaryRepository = mock()
+        service.userTemplateRepository = mock()
         ReflectionHelpers.getField<CompletableDeferred<KanaKanjiEngine>>(service, "kanaKanjiEngineReady")
             .complete(mock())
         ReflectionHelpers.setField(service, "kanaKanjiConversionSession", session)
@@ -86,6 +92,93 @@ class BunsetsuRomajiCandidatesTest {
         ReflectionHelpers.setField(service, "conversionCandidatesRomajiEnablePreference", true)
         ReflectionHelpers.setField(service, "romajiConverter", null)
         assertEquals(listOf(school), query().candidates)
+    }
+
+    @Test fun templatesRemainSelectableWithoutReplacingSentenceDisplay() = runBlocking {
+        ReflectionHelpers.setField(service, "isUserTemplateEnable", true)
+        whenever(service.userTemplateRepository.searchByReading("がっこう", 8)).thenReturn(listOf(
+            template("学校への連絡です", 200), template("学校を欠席します", 100),
+        ))
+        val candidates = query().candidates
+        assertEquals(listOf("学校を欠席します", "学校への連絡です", "学校"), candidates.map { it.string })
+        assertTrue(candidates.take(2).all { it.type == CANDIDATE_TYPE_USER_TEMPLATE })
+        val loaded = mergeBunsetsuCandidates(
+            BunsetsuSegmentState("がっこう", "学校", hasConvertedDisplay = true), candidates,
+        )
+        assertEquals(listOf("学校", "学校を欠席します", "学校への連絡です"), loaded.candidates.map { it.string })
+        assertEquals("学校", loaded.displayText)
+    }
+
+    @Test fun disabledTemplatesAreNotQueried() = runBlocking {
+        ReflectionHelpers.setField(service, "isUserTemplateEnable", false)
+        assertEquals(listOf(school), query().candidates)
+        verifyNoInteractions(service.userTemplateRepository)
+    }
+
+    @Test fun templatesAreFilteredAndDeduplicatedWithEngineCandidates() = runBlocking {
+        ReflectionHelpers.setField(service, "isUserTemplateEnable", true)
+        ReflectionHelpers.setField(service, "isNgWordEnable", true)
+        whenever(service.userTemplateRepository.searchByReading("がっこう", 8)).thenReturn(listOf(
+            template("学校を欠席します", 100), template("学校", 200),
+        ))
+        ReflectionHelpers.getField<MutableStateFlow<List<NgWord>>>(service, "_ngWordsList").value =
+            listOf(NgWord(yomi = "がっこう", tango = "学校を欠席します", matchMode = NgWordMatchMode.EXACT))
+        val candidates = query().candidates
+        assertEquals(listOf("学校"), candidates.map { it.string })
+        assertEquals(CANDIDATE_TYPE_USER_TEMPLATE, candidates.single().type)
+    }
+
+    @Test fun exactNgWordInvalidatesUnfocusedProjectedDisplayBeforeCandidateLoading() {
+        ReflectionHelpers.setField(service, "isNgWordEnable", true)
+        ReflectionHelpers.getField<MutableStateFlow<List<NgWord>>>(service, "_ngWordsList").value =
+            listOf(NgWord(yomi = "いく", tango = "行く", matchMode = NgWordMatchMode.EXACT))
+        val segments = projectSchoolSentence()
+        assertEquals("学校に", segments[0].displayText)
+        assertTrue(segments[0].hasConvertedDisplay)
+        assertEquals("いく", segments[1].displayText)
+        assertFalse(segments[1].hasConvertedDisplay)
+        val loaded = mergeBunsetsuCandidates(segments[1], listOf(school.copy(string = "往く", length = 2u)))
+        assertEquals("往く", loaded.displayText)
+        assertFalse(loaded.candidates.any { it.string == "行く" })
+        val fallback = mergeBunsetsuCandidates(segments[1], emptyList())
+        assertEquals("いく", fallback.displayText)
+        assertEquals(listOf("いく"), fallback.candidates.map { it.string })
+        assertEquals("がっこうにいく", segments.joinToString("") { it.reading })
+    }
+
+    @Test fun partialNgWordAlsoInvalidatesProjectedDisplay() {
+        ReflectionHelpers.setField(service, "isNgWordEnable", true)
+        ReflectionHelpers.getField<MutableStateFlow<List<NgWord>>>(service, "_ngWordsList").value =
+            listOf(NgWord(yomi = "", tango = "学校", matchMode = NgWordMatchMode.PARTIAL))
+        val segments = projectSchoolSentence()
+        assertFalse(segments[0].hasConvertedDisplay)
+        assertEquals("がっこうに", segments[0].displayText)
+        assertEquals("行く", segments[1].displayText)
+    }
+
+    @Test fun disabledNgWordsPreserveProjectedDisplay() {
+        ReflectionHelpers.setField(service, "isNgWordEnable", false)
+        ReflectionHelpers.getField<MutableStateFlow<List<NgWord>>>(service, "_ngWordsList").value =
+            listOf(NgWord(yomi = "いく", tango = "行く", matchMode = NgWordMatchMode.EXACT))
+        assertEquals(listOf("学校に", "行く"), projectSchoolSentence().map { it.displayText })
+    }
+
+    private fun template(text: String, score: Int) = UserTemplate(
+        word = text, reading = "がっこう", posIndex = 0, posScore = score,
+    )
+
+    @Suppress("UNCHECKED_CAST")
+    private fun projectSchoolSentence(): List<BunsetsuSegmentState> {
+        val input = "がっこうにいく"
+        val full = school.copy(string = "学校に行く", length = input.length.toUByte())
+        val snapshot = BunsetsuConversionSnapshot(input, listOf(full), mapOf(full.string to listOf(
+            CandidateConversionSegment(0, 4, "学校"),
+            CandidateConversionSegment(4, 5, "に"),
+            CandidateConversionSegment(5, 7, "行く"),
+        )))
+        return IMEService::class.java.getDeclaredMethod(
+            "buildBunsetsuSegments", String::class.java, List::class.java, BunsetsuConversionSnapshot::class.java,
+        ).apply { isAccessible = true }.invoke(service, input, listOf(5), snapshot) as List<BunsetsuSegmentState>
     }
 
     private suspend fun query(): KanaKanjiQueryResult = suspendCoroutineUninterceptedOrReturn { continuation ->


### PR DESCRIPTION
## 変更内容

文節変換で定型文候補が抜ける問題と、全文の変換結果から復元した文節が完全一致NGワードに該当しても残る問題を修正します。#1004 のマージ後レビューで見つかった回帰への対応です。

- 同じ読みに複数の定型文がある場合も、変換開始後の文節候補として選択できます。既存の定型文取得・候補変換処理を共用し、NGフィルタ・重複除去・候補順序設定を適用します。全文から選ばれた現在の表記は保持します。
- 全文から各文節を復元した時点で、その文節の読みと表記を使ってNG判定します。例えば「いく → 行く」が完全一致NGの場合、「学校に行く」から復元した後続の「行く」も初回表示前に代替候補へ置き換えます。代替候補がなければ読みを保持します。
- 初回変換と分割位置変更の両方が同じ判定を通ります。まだフォーカスしていない文節も候補準備の対象になります。

## 検証

修正前の dev に追加テストを適用し、定型文候補・定型文の重複統合・完全一致NG・部分一致NGの4件が失敗することを確認しました。

- 修正後の JVM テスト: 56件成功、失敗・スキップなし。追加した6件に加え、全文表記の復元、ローマ字候補、実辞書での通常・増分バックエンド比較、NG判定、定型文候補型、候補順序を確認しました。
- `:app:assembleFullStandardDebug` 成功。
- `git diff --check` 成功。
- Android 15 / API 35（arm64）エミュレータ上で操作テスト15件成功。物理キーイベントの14件と、通常・フローティング両表示を含む画面タップ1件を、それぞれの構成で実行しました。実機での結果ではありません。
- 今回追加した端末回帰テスト3件は、実際のRoomデータベースに定型文・完全一致NGを登録して確認します。定型文2件の切り替えと前後の文節を保持した確定、先頭文節と未選択の後続文節のNG除外、候補切り替え後もNGが戻らないことを検証しました。
- 既存の端末テストで、文節移動、選択文節だけの候補変更、文節幅変更後の取消、候補順序設定ON、連続移動・変換・取消、部分確定後の追加入力、エディタ再開、通常・フローティング表示でのタップ変換と確定を確認しました。
- テスト用データは終了時に削除し、設定と既定IMEを復元します。データベースへのテスト用入口はdebugビルドのみです。
- 初回の一括実行はキー操作14件成功、画面タップ1件が準備段階で失敗しました。ハードウェアキーボード接続を検出したアプリが物理キーボード用表示になっていたためです。画面タップはAVDの `hw.keyboard=no` 構成で再実行して成功し、終了後にAVD設定を復元しました。
- 本体APK・AndroidTest APKのビルド成功。画面タップ時の通常表示・フローティング表示のスクリーンショットも確認しました。

## 再レビュー

候補取得による全文分割状態への副作用、定型文の有効・無効、候補型の保持、重複除去、NG無効時の表記保持、後続文節の候補準備、候補がない場合の読み保持を確認しました。

今回の変更範囲を再レビューした限り、追加の未解消の問題は見つかりませんでした。

最新 dev (`fa3336436`) を起点とした専用 worktree の変更です。
